### PR TITLE
Add HTTP API server

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A terminal UI for personal finance. Syncs transactions from Plaid, imports CSVs,
 - **Time ranges** — view Dashboard by week, month, quarter, year, or all time
 - **Trends** — month-by-month bar charts for expenses, income, net, or any category; per-range aggregation
 - **MCP server** — Claude can read and manage your finances via the Model Context Protocol
+- **HTTP API** — REST-style API server for scripting and automation
 
 ## Try it (no account needed)
 
@@ -212,6 +213,33 @@ npm run import-csv /path/to/file.csv
 # Seed default category rules
 npm run seed-rules
 ```
+
+## HTTP API
+
+Exposes the same tools as the MCP server over HTTP — useful for scripting and automation.
+
+```bash
+npm run api
+# Listening on http://localhost:3456
+```
+
+**Endpoint:** `POST /tools/:name` with a JSON body.
+
+```bash
+curl -X POST http://localhost:3456/tools/spending_summary \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <key>" \
+  -d '{"year": 2026, "month": 5}'
+```
+
+**Configuration** (in `~/.fungible/.env`):
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `FUNGIBLE_API_KEY` | _(none)_ | Bearer token required on all requests. If unset, auth is skipped (dev only). |
+| `FUNGIBLE_API_PORT` | `3456` | Port to listen on. |
+
+Available tools: same set as the MCP server below.
 
 ## MCP Server
 

--- a/api/server.ts
+++ b/api/server.ts
@@ -1,0 +1,76 @@
+import { config } from 'dotenv';
+import { join } from 'node:path';
+import { DATA_DIR } from '../core/paths.js';
+config({ path: join(DATA_DIR, '.env') });
+
+import { createServer, IncomingMessage, ServerResponse } from 'node:http';
+import { initDb } from '../core/db.js';
+import { executeTool, TOOL_DEFS } from '../core/tools.js';
+
+initDb();
+
+const PORT = parseInt(process.env.FUNGIBLE_API_PORT ?? '3456', 10);
+const API_KEY = process.env.FUNGIBLE_API_KEY;
+const VALID_TOOLS = new Set(TOOL_DEFS.map((t) => t.name));
+
+if (!API_KEY) {
+  console.warn('[fungible-api] Warning: FUNGIBLE_API_KEY not set — all requests accepted');
+}
+
+function send(res: ServerResponse, status: number, body: object) {
+  const json = JSON.stringify(body);
+  res.writeHead(status, { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(json) });
+  res.end(json);
+}
+
+async function readBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    req.on('data', (chunk) => (data += chunk));
+    req.on('end', () => resolve(data));
+    req.on('error', reject);
+  });
+}
+
+const server = createServer(async (req, res) => {
+  // Auth
+  if (API_KEY) {
+    const auth = req.headers['authorization'];
+    if (auth !== `Bearer ${API_KEY}`) {
+      return send(res, 401, { error: 'Unauthorized' });
+    }
+  }
+
+  // Route: POST /tools/:name
+  const match = req.method === 'POST' && req.url?.match(/^\/tools\/([^/?]+)$/);
+  if (!match) {
+    return send(res, 404, { error: 'Not found. Use POST /tools/:name' });
+  }
+
+  const toolName = match[1];
+  if (!VALID_TOOLS.has(toolName)) {
+    return send(res, 404, { error: `unknown tool: ${toolName}` });
+  }
+
+  let input: Record<string, unknown> = {};
+  const raw = await readBody(req);
+  if (raw) {
+    try {
+      input = JSON.parse(raw);
+    } catch {
+      return send(res, 400, { error: 'invalid JSON body' });
+    }
+  }
+
+  try {
+    const result = await executeTool(toolName, input);
+    send(res, 200, { result });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    send(res, 500, { error: message });
+  }
+});
+
+server.listen(PORT, () => {
+  console.log(`[fungible-api] Listening on http://localhost:${PORT}`);
+});

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "import-csv": "node --experimental-sqlite --no-warnings --import tsx/esm scripts/import-csv.ts",
     "seed-rules": "node --experimental-sqlite --no-warnings --import tsx/esm scripts/seed-rules.ts",
     "mcp": "node --experimental-sqlite --no-warnings --import tsx/esm mcp/server.ts",
+    "api": "node --experimental-sqlite --no-warnings --import tsx/esm api/server.ts",
     "typecheck": "tsc --noEmit",
     "test": "~/.nvm/versions/node/v22.22.3/bin/node ./node_modules/.bin/vitest run",
     "test:watch": "~/.nvm/versions/node/v22.22.3/bin/node ./node_modules/.bin/vitest"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,5 +10,5 @@
     "outDir": "dist",
     "types": ["node"]
   },
-  "include": ["core/**/*", "tui/**/*", "mcp/**/*", "scripts/**/*", "tests/**/*", "vitest.config.ts"]
+  "include": ["core/**/*", "tui/**/*", "mcp/**/*", "api/**/*", "scripts/**/*", "tests/**/*", "vitest.config.ts"]
 }


### PR DESCRIPTION
Closes #5

## Summary
- New `api/server.ts`: `node:http` server exposing `POST /tools/:name` — same thin-wrapper pattern as the MCP server
- Optional Bearer auth via `FUNGIBLE_API_KEY` in `.env` (warns and allows all if unset)
- Port configurable via `FUNGIBLE_API_PORT` (default `3456`)
- Added `npm run api` script

## Test plan
- [x] `npm run api` starts server and logs listening message
- [x] `POST /tools/spending_summary` with valid body returns `{ result: "..." }`
- [x] Unknown tool name returns 404 `{ error: "unknown tool: ..." }`
- [x] Bad route returns 404
- [x] With `FUNGIBLE_API_KEY` set, missing/wrong token returns 401
- [x] `npm run typecheck` and `npm test` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)