### PR TITLE
feat: inline account creation during CSV import (v1.2.1)

### DIFF
--- a/core/accounts.ts
+++ b/core/accounts.ts
@@ -16,6 +16,12 @@ export function updateAccountValue(id: string, value: number): void {
   db.prepare('INSERT OR REPLACE INTO balance_history (account_id, balance, date) VALUES (?, ?, ?)').run(id, value, today);
 }
 
+export function createCsvAccount(name: string, type: string, subtype: string | null): string {
+  const id = `csv-acct-${Date.now()}`;
+  db.prepare('INSERT INTO accounts (id, name, type, subtype) VALUES (?, ?, ?, ?)').run(id, name.trim(), type, subtype);
+  return id;
+}
+
 export function createManualAccount(name: string, value: number): string {
   const id = `manual-${Date.now()}`;
   const today = new Date().toISOString().slice(0, 10);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fungible",
-  "version": "1.1.2",
+  "version": "1.2.1",
   "description": "Terminal UI for personal finance — Plaid sync, CSV import, AI assistant, and MCP server",
   "type": "module",
   "homepage": "https://github.com/tomfunk/fungible",

--- a/tui/Accounts.tsx
+++ b/tui/Accounts.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Box, Text, useInput } from 'ink';
+import { useSetTyping } from './TypingContext.js';
 import { spawn } from 'node:child_process';
 import { syncAll } from '../core/sync.js';
 import { getCsvPlaidDupeCandidates, type DupePair } from '../core/dedup.js';
@@ -121,6 +122,13 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
   // Dupes view state
   const [dupes, setDupes] = useState<DupePair[]>([]);
   const [dupeCursor, setDupeCursor] = useState(0);
+
+  const setTyping = useSetTyping();
+  const TEXT_INPUT_STEPS = new Set<AddStep>(['file', 'manual-name', 'manual-value', 'new-acct-name']);
+  const TEXT_INPUT_MODES = new Set<AcctMode>(['nickname', 'update-value']);
+  useEffect(() => {
+    setTyping(TEXT_INPUT_STEPS.has(addStep) || TEXT_INPUT_MODES.has(acctMode));
+  }, [addStep, acctMode]);
 
   const termW = useTerminalWidth();
   const inner = Math.max(60, termW) - 4;

--- a/tui/Accounts.tsx
+++ b/tui/Accounts.tsx
@@ -7,7 +7,7 @@ import { parseCSV, parseDate } from '../core/csv.js';
 import { getLinkedAccounts, getCsvAccounts, type LinkedAccount, type CsvAccount } from '../core/queries.js';
 import {
   updateAccountTypeSubtype, updateAccountNickname, updateAccountValue,
-  createManualAccount, deleteAccount, importCsvTransactions, deleteDuplicate, deleteAllDuplicates,
+  createManualAccount, createCsvAccount, deleteAccount, importCsvTransactions, deleteDuplicate, deleteAllDuplicates,
 } from '../core/accounts.js';
 import type { Screen, TxFilter } from './App.js';
 import { truncate, Divider } from './fmt.js';
@@ -37,7 +37,9 @@ type AddStep =
   | 'manual-name'
   | 'manual-value'
   | 'manual-confirm'
-  | 'manual-done';
+  | 'manual-done'
+  | 'new-acct-name'
+  | 'new-acct-type';
 
 const ACCOUNT_TYPES = ['depository', 'investment', 'credit', 'loan', 'other'] as const;
 
@@ -103,6 +105,12 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
   const [manualValue, setManualValue] = useState('');
   const [manualValueError, setManualValueError] = useState('');
 
+  // New CSV account state (inline creation during CSV import)
+  const [newAcctName, setNewAcctName] = useState('');
+  const [newAcctType, setNewAcctType] = useState('credit');
+  const [newAcctSubtype, setNewAcctSubtype] = useState('credit card');
+  const [newAcctField, setNewAcctField] = useState<'type' | 'subtype'>('type');
+
   // Update-value mode state
   const [updateValueInput, setUpdateValueInput] = useState('');
   const [updateValueError, setUpdateValueError] = useState('');
@@ -164,6 +172,14 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
       setSyncStatus('done');
       setTimeout(() => { setSyncStatus('idle'); setSyncMsg(''); }, 3000);
     });
+  }
+
+  function saveNewAcct() {
+    createCsvAccount(newAcctName, newAcctType, newAcctSubtype.trim() || null);
+    const accts = getCsvAccounts();
+    setCsvAccounts(accts);
+    setCsvAccountCursor(accts.length - 1);
+    setAddStep('account');
   }
 
   function saveManualAsset() {
@@ -466,7 +482,38 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
       if (key.escape) { setAddStep('landing'); return; }
       if (key.upArrow)   setCsvAccountCursor((c) => Math.max(0, c - 1));
       if (key.downArrow) setCsvAccountCursor((c) => Math.min(csvAccounts.length - 1, c + 1));
+      if (input === 'n') { setNewAcctName(''); setNewAcctType('credit'); setNewAcctSubtype('credit card'); setNewAcctField('type'); setAddStep('new-acct-name'); return; }
       if (key.return) setAddStep('confirm');
+      return;
+    }
+
+    if (addStep === 'new-acct-name') {
+      if (key.escape) { setAddStep('account'); return; }
+      if (key.return && newAcctName.trim()) { setNewAcctField('type'); setAddStep('new-acct-type'); return; }
+      if (key.backspace || key.delete) { setNewAcctName((v) => v.slice(0, -1)); return; }
+      if (input && !key.ctrl && !key.meta) { setNewAcctName((v) => v + input); return; }
+      return;
+    }
+
+    if (addStep === 'new-acct-type') {
+      if (key.escape) { setAddStep('new-acct-name'); return; }
+      if (key.return) { saveNewAcct(); return; }
+      if (key.tab) { setNewAcctField((f) => f === 'type' ? 'subtype' : 'type'); return; }
+      if (newAcctField === 'type' && (key.leftArrow || key.rightArrow)) {
+        const idx = ACCOUNT_TYPES.indexOf(newAcctType as typeof ACCOUNT_TYPES[number]);
+        const next = ACCOUNT_TYPES[(idx + (key.leftArrow ? -1 : 1) + ACCOUNT_TYPES.length) % ACCOUNT_TYPES.length];
+        setNewAcctType(next);
+        setNewAcctSubtype(SUBTYPES[next]?.[0] ?? '');
+        return;
+      }
+      if (newAcctField === 'subtype') {
+        const subtypes = SUBTYPES[newAcctType] ?? [];
+        if (subtypes.length > 0 && (key.leftArrow || key.rightArrow)) {
+          const idx = subtypes.indexOf(newAcctSubtype);
+          setNewAcctSubtype(subtypes[(idx + (key.leftArrow ? -1 : 1) + subtypes.length) % subtypes.length]);
+        }
+        return;
+      }
       return;
     }
 
@@ -787,7 +834,7 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
           {addStep === 'account' && (
             <Box flexDirection="column" marginTop={1}>
               <Text bold>Which account do these transactions belong to?</Text>
-              <Text dimColor>↑↓ select · Enter confirm</Text>
+              <Text dimColor>↑↓ select · Enter confirm · [n] new account</Text>
               <Box flexDirection="column" marginTop={1}>
                 {csvAccounts.map((acct, i) => (
                   <Box key={acct.id} gap={2}>
@@ -798,6 +845,46 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
                   </Box>
                 ))}
               </Box>
+              {csvAccounts.length === 0 && <Text dimColor>No accounts yet — press [n] to create one.</Text>}
+            </Box>
+          )}
+
+          {addStep === 'new-acct-name' && (
+            <Box flexDirection="column" marginTop={1} gap={1}>
+              <Text bold>New Account — Name</Text>
+              <Text dimColor>Type a name for this account (e.g. "Venture X", "Freedom Unlimited")</Text>
+              <Box marginTop={1}>
+                <Text>Name: </Text>
+                <Text color={C_WARNING}>{newAcctName}</Text>
+                <Text color={C_ACCENT}>█</Text>
+              </Box>
+              <Text dimColor>Enter to continue · Esc back</Text>
+            </Box>
+          )}
+
+          {addStep === 'new-acct-type' && (
+            <Box flexDirection="column" marginTop={1} gap={1}>
+              <Text bold>New Account — Type</Text>
+              <Text dimColor>Account: <Text color={C_ACCENT}>{newAcctName}</Text></Text>
+              <Box flexDirection="column" marginTop={1} gap={1}>
+                <Box gap={2}>
+                  <Text color={newAcctField === 'type' ? C_ACCENT : C_NEUTRAL}>
+                    {newAcctField === 'type' ? '▶ ' : '  '}Type
+                  </Text>
+                  <Text color={newAcctField === 'type' ? C_ACCENT : undefined}>
+                    {'← '}{newAcctType}{'  →'}
+                  </Text>
+                </Box>
+                <Box gap={2}>
+                  <Text color={newAcctField === 'subtype' ? C_ACCENT : C_NEUTRAL}>
+                    {newAcctField === 'subtype' ? '▶ ' : '  '}Subtype
+                  </Text>
+                  <Text color={newAcctField === 'subtype' ? C_ACCENT : C_WARNING}>
+                    {'← '}{newAcctSubtype || '—'}{'  →'}
+                  </Text>
+                </Box>
+              </Box>
+              <Text dimColor>Tab switch field · ← → change · Enter save · Esc back</Text>
             </Box>
           )}
 

--- a/tui/App.tsx
+++ b/tui/App.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Box, useInput, useApp } from 'ink';
+import { TypingContext } from './TypingContext.js';
 import { Dashboard } from './Dashboard.js';
 import { Transactions } from './Transactions.js';
 import { Trends } from './Trends.js';
@@ -26,6 +27,7 @@ export function App() {
   const [screen, setScreen]         = useState<Screen>('dashboard');
   const [txFilter, setTxFilter]     = useState<TxFilter>({});
   const [chatFocused, setChatFocused] = useState(false);
+  const [screenTyping, setScreenTyping] = useState(false);
   const [showHints, setShowHints]   = useState(false);
   const { exit } = useApp();
 
@@ -35,7 +37,7 @@ export function App() {
   }
 
   useInput((input) => {
-    if (chatFocused) return; // chat handles its own input
+    if (chatFocused || screenTyping) return;
     if (input === 'q') exit();
     if (input === 'h') setShowHints((v) => !v);
   });
@@ -56,6 +58,7 @@ export function App() {
   })();
 
   return (
+    <TypingContext.Provider value={setScreenTyping}>
     <Box flexDirection="column" height="100%">
       <Box flexGrow={1}>
         {currentScreen}
@@ -67,5 +70,6 @@ export function App() {
         onNavigate={navigate}
       />
     </Box>
+    </TypingContext.Provider>
   );
 }

--- a/tui/Dashboard.tsx
+++ b/tui/Dashboard.tsx
@@ -15,6 +15,7 @@ import type { Screen, TxFilter } from './App.js';
 import { fmt, fmtSigned, bar, Divider, truncate } from './fmt.js';
 import { NavHints, handleNavKey } from './nav.js';
 import { useTerminalWidth, CURSOR, FLEX_COLORS, C_POSITIVE, C_NEGATIVE, C_WARNING, C_NEUTRAL, C_MANUAL, C_ACCENT } from './ui.js';
+import { useSetTyping } from './TypingContext.js';
 
 const BAR_WIDTH = 20;
 
@@ -110,6 +111,9 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
     setFlexDrift(getFlexDriftData(current, lastPeriod, lastYear, rolling12, acctId));
     setAcctDrift(getAccountDriftData(current, lastPeriod, lastYear, rolling12));
   }, [driftMode, range, anchor.toISOString().slice(0, 10), selectedAccount?.id ?? null]);
+
+  const setTyping = useSetTyping();
+  useEffect(() => { setTyping(searchMode); }, [searchMode]);
 
   useEffect(() => {
     const term = searchMode ? searchInput : search;

--- a/tui/Rules.tsx
+++ b/tui/Rules.tsx
@@ -10,6 +10,7 @@ import type { Screen, TxFilter } from './App.js';
 import { truncate, Divider } from './fmt.js';
 import { NavHints, handleNavKey } from './nav.js';
 import { useTerminalWidth, CURSOR, FLEX_COLORS, C_ACCENT, C_MANUAL, C_NEUTRAL, C_POSITIVE, C_WARNING } from './ui.js';
+import { useSetTyping } from './TypingContext.js';
 
 type Flexibility = 'fixed' | 'flexible' | 'discretionary' | null;
 const FLEX_CYCLE: Flexibility[] = [null, 'fixed', 'flexible', 'discretionary'];
@@ -54,6 +55,10 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
 
   // Search
   const [search, setSearch] = useState('');
+
+  const setTyping = useSetTyping();
+  const TEXT_INPUT_MODES_RULES = new Set<Mode>(['search', 'add-pattern', 'add-min-amount', 'add-max-amount', 'add-name-pattern', 'add-name-min-amount', 'add-name-max-amount', 'add-name-replacement', 'add-category-name', 'rename-category']);
+  useEffect(() => { setTyping(TEXT_INPUT_MODES_RULES.has(mode)); }, [mode]);
 
   const termW = useTerminalWidth();
   const inner = Math.max(60, termW) - 4;

--- a/tui/Tags.tsx
+++ b/tui/Tags.tsx
@@ -6,6 +6,7 @@ import type { Screen, TxFilter } from './App.js';
 import { fmt, bar, truncate, Divider } from './fmt.js';
 import { NavHints, handleNavKey } from './nav.js';
 import { useTerminalWidth, CURSOR, C_POSITIVE, C_NEGATIVE, C_WARNING, C_ACCENT } from './ui.js';
+import { useSetTyping } from './TypingContext.js';
 
 type Mode = 'list' | 'search' | 'add' | 'detail' | 'rename';
 
@@ -21,6 +22,9 @@ export function Tags({ onNavigate, isActive, showHints }: { onNavigate: (s: Scre
 
   function load() { setTags(getAllTags()); }
   useEffect(() => { load(); }, []);
+
+  const setTyping = useSetTyping();
+  useEffect(() => { setTyping(mode === 'search' || mode === 'add' || mode === 'rename'); }, [mode]);
 
   function openDetail(tag: Tag) {
     setTagSummary(getTagSummary(tag.name));

--- a/tui/Transactions.tsx
+++ b/tui/Transactions.tsx
@@ -18,6 +18,7 @@ import type { Screen, TxFilter } from './App.js';
 import { NavHints, handleNavKey } from './nav.js';
 import { Divider } from './fmt.js';
 import { useTerminalWidth, CURSOR, MONTHS, C_POSITIVE, C_NEGATIVE, C_WARNING, C_NEUTRAL, C_MANUAL, C_ACCENT, C_DIM } from './ui.js';
+import { useSetTyping } from './TypingContext.js';
 
 type Tx = TxRow;
 
@@ -82,6 +83,13 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
   }
 
   useEffect(() => { load(); }, [category, from, to, search, tag, account, sort]);
+
+  const setTyping = useSetTyping();
+  useEffect(() => {
+    const isTextInput = mode === 'search' || mode === 'edit-rule' || mode === 'tag' || mode === 'tag-all'
+      || (mode === 'edit' && editField === 'name');
+    setTyping(isTextInput);
+  }, [mode, editField]);
 
   const selected = txs[cursor];
 

--- a/tui/TypingContext.tsx
+++ b/tui/TypingContext.tsx
@@ -1,0 +1,4 @@
+import { createContext, useContext } from 'react';
+
+export const TypingContext = createContext<(v: boolean) => void>(() => {});
+export const useSetTyping = () => useContext(TypingContext);


### PR DESCRIPTION
## Summary

- Adds `[n] New account` to the CSV import account-picker step, so users with Plaid-unsupported cards can create an account without leaving the import flow
- Extracts `createCsvAccount()` into `core/accounts.ts` to match the existing pattern for DB writes
- Auto-selects the newly created account so the user can immediately confirm the import
- Shows a hint when the account list is empty ("No accounts yet — press [n] to create one")
- Fixes global key bindings (`h`, `q`) firing during free-text input across all screens — adds a `TypingContext` that screens signal when accepting typed input, gating the App-level handlers

This is an alternative to tomfunk/fungible#11 — same problem, but creation happens inline at the point of need rather than as a separate pre-flight step. Uses semantic color constants consistent with the feature/1.2.0 refactor.

Closes #10

## Test plan

- [ ] Import a CSV with at least one existing account — flow unchanged
- [ ] Import a CSV with no accounts — empty list shows hint, `[n]` starts creation
- [ ] Create an account mid-import, verify it auto-selects and import completes normally
- [ ] Esc from `new-acct-name` returns to account picker
- [ ] Esc from `new-acct-type` returns to `new-acct-name`
- [ ] Tab / ← → cycle type and subtype correctly
- [ ] Type `h` in any text field — hints should not toggle
- [ ] Type `q` in any text field — app should not quit

🤖 Generated with [Claude Code](https://claude.com/claude-code)