### PR TITLE
ci: skip version bump check for dependabot PRs

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v4
         with:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fungible",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Terminal UI for personal finance — Plaid sync, CSV import, AI assistant, and MCP server",
   "type": "module",
   "homepage": "https://github.com/tomfunk/fungible",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fungible",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Terminal UI for personal finance — Plaid sync, CSV import, AI assistant, and MCP server",
   "type": "module",
   "homepage": "https://github.com/tomfunk/fungible",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "fungible",
   "version": "1.2.3",
-  "version": "1.2.2",
   "description": "Terminal UI for personal finance — Plaid sync, CSV import, AI assistant, and MCP server",
   "type": "module",
   "homepage": "https://github.com/tomfunk/fungible",


### PR DESCRIPTION
## Summary
- Adds `if: github.actor != 'dependabot[bot]'` to the version-bump workflow so dependabot PRs aren't blocked by the check

## Test plan
- [ ] Dependabot PRs no longer fail the version-bump job