### PR TITLE
feat: optional Turso sync for backup and cross-device (v1.3.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,31 @@ npm run dev -- --setup
 
 Data and config are stored at `~/.fungible/`. Plaid access tokens are encrypted at rest using a key file at `~/.fungible/key` — do not delete this file or you will need to re-link your bank accounts. You'll need a free [Plaid](https://plaid.com) developer account to sync bank transactions (sandbox tier works).
 
+## Turso sync (optional)
+
+By default, fungible stores everything in a local SQLite file at `~/.fungible/fungible.db`. It is fully self-contained — no cloud account needed.
+
+If you want **automatic backup and cross-device sync**, you can point fungible at your own [Turso](https://turso.tech) database. Turso is a cloud SQLite service with a generous free tier. fungible stays local-first: all reads and writes go to the local file, and Turso mirrors it silently in the background.
+
+**Setup (one time):**
+
+1. Sign up at [turso.tech](https://turso.tech) and install the CLI: `brew install tursodatabase/tap/turso`
+2. Create a database: `turso db create fungible`
+3. Get the URL: `turso db show fungible --url`
+4. Generate a token: `turso db tokens create fungible`
+5. Add both to `~/.fungible/.env`:
+
+```
+FUNGIBLE_TURSO_URL=libsql://fungible-<your-name>.turso.io
+FUNGIBLE_TURSO_TOKEN=<token>
+```
+
+Or run `fungible --setup` and answer yes when asked about Turso.
+
+**Cross-device:** on a second machine, install fungible, add the same two env vars, and run it. It will pull your full database from Turso on first launch. From then on, both machines stay in sync automatically.
+
+**No lock-in:** removing the env vars reverts to local-only mode. Your local `fungible.db` is always a complete, readable SQLite file.
+
 ## Screens
 
 | Key | Screen |

--- a/api/server.ts
+++ b/api/server.ts
@@ -4,10 +4,11 @@ import { DATA_DIR } from '../core/paths.js';
 config({ path: join(DATA_DIR, '.env') });
 
 import { createServer, IncomingMessage, ServerResponse } from 'node:http';
-import { initDb } from '../core/db.js';
+import { initDb, syncDb } from '../core/db.js';
 import { executeTool, TOOL_DEFS } from '../core/tools.js';
 
 await initDb();
+await syncDb().catch(() => {});
 
 const PORT = parseInt(process.env.FUNGIBLE_API_PORT ?? '3456', 10);
 const API_KEY = process.env.FUNGIBLE_API_KEY;

--- a/core/db.ts
+++ b/core/db.ts
@@ -8,18 +8,25 @@ const DB_PATH = path.join(DATA_DIR, 'fungible.db');
 
 fs.mkdirSync(DATA_DIR, { recursive: true });
 
+export function isTursoConfigured(): boolean {
+  return !!(process.env.FUNGIBLE_TURSO_URL && process.env.FUNGIBLE_TURSO_TOKEN);
+}
+
 function createDb(): Client {
   const syncUrl   = process.env.FUNGIBLE_TURSO_URL;
   const authToken = process.env.FUNGIBLE_TURSO_TOKEN;
   if (syncUrl && authToken) {
-    // Paid tier: embedded replica syncs with Turso
     return createClient({ url: `file:${DB_PATH}`, syncUrl, authToken });
   }
-  // Free tier: local file only
   return createClient({ url: `file:${DB_PATH}` });
 }
 
 export const db: Client = createDb();
+
+/** Pull latest changes from Turso. No-op when Turso is not configured. */
+export async function syncDb(): Promise<void> {
+  if (isTursoConfigured()) await db.sync();
+}
 
 export async function initDb() {
   // Create all tables (idempotent)

--- a/mcp/server.ts
+++ b/mcp/server.ts
@@ -5,10 +5,11 @@ config({ path: join(DATA_DIR, '.env') });
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
-import { initDb } from '../core/db.js';
+import { initDb, syncDb } from '../core/db.js';
 import { executeTool } from '../core/tools.js';
 
 await initDb();
+await syncDb().catch(() => {});
 
 const server = new McpServer({
   name: 'fungible',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fungible",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Terminal UI for personal finance — Plaid sync, CSV import, AI assistant, and MCP server",
   "type": "module",
   "homepage": "https://github.com/tomfunk/fungible",

--- a/tui/Setup.tsx
+++ b/tui/Setup.tsx
@@ -15,6 +15,9 @@ type Step =
   | 'plaid-env'
   | 'link-choice'
   | 'linking'
+  | 'turso-choice'
+  | 'turso-url'
+  | 'turso-token'
   | 'seed-choice'
   | 'done';
 
@@ -59,11 +62,17 @@ export function Setup() {
   const [linkStatus, setLinkStatus] = useState<'idle' | 'running' | 'done' | 'error'>('idle');
   const [linkMsg, setLinkMsg] = useState('');
 
+  // Turso fields
+  const [tursoUrl, setTursoUrl] = useState(existing['FUNGIBLE_TURSO_URL'] ?? '');
+  const [tursoToken, setTursoToken] = useState(existing['FUNGIBLE_TURSO_TOKEN'] ?? '');
+
   // Seed status
   const [seedResult, setSeedResult] = useState<{ rules: number; recategorized: number } | null>(null);
 
   const alreadyConfigured =
     !!existing['PLAID_CLIENT_ID'] && !!existing['PLAID_SECRET'] && !!existing['PLAID_ENV'];
+  const tursoAlreadyConfigured =
+    !!existing['FUNGIBLE_TURSO_URL'] && !!existing['FUNGIBLE_TURSO_TOKEN'];
 
   function savePlaidCreds() {
     writeEnv({
@@ -75,6 +84,15 @@ export function Setup() {
     process.env['PLAID_CLIENT_ID'] = clientId.trim();
     process.env['PLAID_SECRET'] = secret.trim();
     process.env['PLAID_ENV'] = PLAID_ENVS[plaidEnvIdx];
+  }
+
+  function saveTursoCreds() {
+    writeEnv({
+      FUNGIBLE_TURSO_URL: tursoUrl.trim(),
+      FUNGIBLE_TURSO_TOKEN: tursoToken.trim(),
+    });
+    process.env['FUNGIBLE_TURSO_URL'] = tursoUrl.trim();
+    process.env['FUNGIBLE_TURSO_TOKEN'] = tursoToken.trim();
   }
 
   function startLink() {
@@ -116,7 +134,7 @@ export function Setup() {
 
     if (step === 'plaid-choice') {
       if (input === 'y') { setStep('plaid-client-id'); return; }
-      if (input === 'n') { setStep('seed-choice'); return; }
+      if (input === 'n') { setStep('turso-choice'); return; }
       return;
     }
 
@@ -146,14 +164,36 @@ export function Setup() {
 
     if (step === 'link-choice') {
       if (input === 'y') { setStep('linking'); startLink(); return; }
-      if (input === 'n') { setStep('seed-choice'); return; }
+      if (input === 'n') { setStep('turso-choice'); return; }
       return;
     }
 
     if (step === 'linking') {
       if ((linkStatus === 'done' || linkStatus === 'error') && key.return) {
-        setStep('seed-choice');
+        setStep('turso-choice');
       }
+      return;
+    }
+
+    if (step === 'turso-choice') {
+      if (input === 'y') { setStep('turso-url'); return; }
+      if (input === 'n') { setStep('seed-choice'); return; }
+      return;
+    }
+
+    if (step === 'turso-url') {
+      if (key.escape) { setStep('turso-choice'); return; }
+      if (key.return && tursoUrl.trim()) { setStep('turso-token'); return; }
+      if (key.backspace || key.delete) { setTursoUrl((v) => v.slice(0, -1)); return; }
+      if (input && !key.ctrl && !key.meta) { setTursoUrl((v) => v + input); return; }
+      return;
+    }
+
+    if (step === 'turso-token') {
+      if (key.escape) { setStep('turso-url'); return; }
+      if (key.return && tursoToken.trim()) { saveTursoCreds(); setStep('seed-choice'); return; }
+      if (key.backspace || key.delete) { setTursoToken((v) => v.slice(0, -1)); return; }
+      if (input && !key.ctrl && !key.meta) { setTursoToken((v) => v + input); return; }
       return;
     }
 
@@ -186,6 +226,7 @@ export function Setup() {
             <Text dimColor>This wizard will help you:</Text>
             <Text dimColor>  · Configure Plaid credentials (to sync bank accounts)</Text>
             <Text dimColor>  · Link your first bank account</Text>
+            <Text dimColor>  · Set up Turso sync for backup / cross-device (optional)</Text>
             <Text dimColor>  · Seed starter category rules</Text>
           </Box>
           {alreadyConfigured && (
@@ -276,6 +317,55 @@ export function Setup() {
           {(linkStatus === 'done' || linkStatus === 'error') && (
             <Text dimColor>Press Enter to continue.</Text>
           )}
+        </Box>
+      )}
+
+      {step === 'turso-choice' && (
+        <Box flexDirection="column" gap={1}>
+          <Text bold>Turso sync  <Text dimColor>(optional)</Text></Text>
+          <Text dimColor>
+            Turso is a cloud SQLite service that can back up and sync your data across
+            devices. fungible stays fully local — Turso just mirrors the same database.
+          </Text>
+          <Text dimColor>
+            Sign up free at turso.tech, create a database, and paste the URL and token here.
+          </Text>
+          {tursoAlreadyConfigured && (
+            <Box marginTop={1}>
+              <Text color={C_POSITIVE}>Turso already configured in .env</Text>
+            </Box>
+          )}
+          <Box marginTop={1}>
+            <Text>Set up Turso?  </Text>
+            <Text color={C_ACCENT}>[y] Yes  </Text>
+            <Text color={C_ACCENT}>[n] Skip</Text>
+          </Box>
+        </Box>
+      )}
+
+      {step === 'turso-url' && (
+        <Box flexDirection="column" gap={1}>
+          <Text bold>Turso database URL</Text>
+          <Text dimColor>Looks like: libsql://your-db-name.turso.io</Text>
+          <Box marginTop={1}>
+            <Text>URL: </Text>
+            <Text color={C_WARNING}>{tursoUrl}</Text>
+            <Text color={C_ACCENT}>█</Text>
+          </Box>
+          <Text dimColor>Enter to continue · Esc back</Text>
+        </Box>
+      )}
+
+      {step === 'turso-token' && (
+        <Box flexDirection="column" gap={1}>
+          <Text bold>Turso auth token</Text>
+          <Text dimColor>Found in your Turso dashboard under the database → Generate Token</Text>
+          <Box marginTop={1}>
+            <Text>Token: </Text>
+            <Text color={C_WARNING}>{'*'.repeat(Math.min(tursoToken.length, 20))}{tursoToken.length > 20 ? '…' : ''}</Text>
+            <Text color={C_ACCENT}>█</Text>
+          </Box>
+          <Text dimColor>Enter to save · Esc back</Text>
         </Box>
       )}
 

--- a/tui/index.tsx
+++ b/tui/index.tsx
@@ -4,7 +4,7 @@ import { DATA_DIR } from '../core/paths.js';
 config({ path: join(DATA_DIR, '.env'), quiet: true });
 import React from 'react';
 import { render } from 'ink';
-import { initDb } from '../core/db.js';
+import { initDb, syncDb } from '../core/db.js';
 import { syncAll } from '../core/sync.js';
 import { rebuildDisplayNames } from '../core/rename.js';
 import { App } from './App.js';
@@ -13,6 +13,7 @@ import { Setup } from './Setup.js';
 const isDemo = process.argv.includes('--demo');
 
 await initDb();
+await syncDb().catch(() => {}); // pull latest from Turso if configured
 
 if (process.argv.includes('--setup')) {
   render(<Setup />);


### PR DESCRIPTION
## Summary

- Adds optional [Turso](https://turso.tech) sync — set two env vars and fungible keeps a cloud mirror of your local SQLite database, enabling backup and cross-device sync
- fungible stays fully local-first: all reads/writes still hit the local file; Turso is a silent replica
- No Turso account needed — local-only mode is unchanged and the default
- `syncDb()` is called on startup in the TUI, MCP server, and API server to pull the latest before serving
- Setup wizard now includes an optional Turso step (skippable)
- README documents the full setup flow

## Test plan

- [ ] `npm test` passes (282 tests)
- [ ] `npm run typecheck` clean
- [ ] Without Turso env vars: behavior identical to before
- [ ] With `FUNGIBLE_TURSO_URL` + `FUNGIBLE_TURSO_TOKEN` set: startup pulls from Turso, writes propagate to Turso
- [ ] `fungible --setup` shows Turso step and saves credentials to `.env`
- [ ] Second machine with same env vars syncs full database on first launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)