### PR TITLE
feat: daily database backups with configurable retention

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ A terminal UI for personal finance. Syncs transactions from [Plaid](https://plai
 - **Regex search** — `/` on Dashboard or Transactions filters by name using a regular expression; search is shared when navigating between Dashboard, Transactions, and Trends
 - **MCP server** — Claude can read and manage your finances via the Model Context Protocol
 - **HTTP API** — REST-style API server for scripting and automation
+- **Daily backups** — database is backed up to `~/.fungible/backups/` on startup once per day; defaults to 7 days retention, configurable via `FUNGIBLE_BACKUP_DAYS`
 
 ## Try it (no account needed)
 

--- a/api/server.ts
+++ b/api/server.ts
@@ -5,9 +5,11 @@ config({ path: join(DATA_DIR, '.env') });
 
 import { createServer, IncomingMessage, ServerResponse } from 'node:http';
 import { initDb } from '../core/db.js';
+import { backupDb } from '../core/backup.js';
 import { executeTool, TOOL_DEFS } from '../core/tools.js';
 
 await initDb();
+backupDb().catch(() => {});
 
 const PORT = parseInt(process.env.FUNGIBLE_API_PORT ?? '3456', 10);
 const API_KEY = process.env.FUNGIBLE_API_KEY;

--- a/core/backup.ts
+++ b/core/backup.ts
@@ -1,0 +1,34 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { DATA_DIR } from './paths.js';
+
+const DB_PATH = path.join(DATA_DIR, 'fungible.db');
+const BACKUP_DIR = path.join(DATA_DIR, 'backups');
+
+export async function backupDb(): Promise<void> {
+  const keepDays = parseInt(process.env.FUNGIBLE_BACKUP_DAYS ?? '7', 10);
+  if (isNaN(keepDays) || keepDays <= 0) return;
+
+  if (!fs.existsSync(DB_PATH)) return;
+
+  fs.mkdirSync(BACKUP_DIR, { recursive: true });
+
+  const today = new Date().toISOString().slice(0, 10);
+  const backupPath = path.join(BACKUP_DIR, `fungible.${today}.bak`);
+
+  if (!fs.existsSync(backupPath)) {
+    await fs.promises.copyFile(DB_PATH, backupPath);
+  }
+
+  const cutoffDate = new Date();
+  cutoffDate.setDate(cutoffDate.getDate() - keepDays);
+  const cutoff = cutoffDate.toISOString().slice(0, 10);
+
+  for (const file of fs.readdirSync(BACKUP_DIR)) {
+    const match = file.match(/^fungible\.(\d{4}-\d{2}-\d{2})\.bak$/);
+    if (!match) continue;
+    if (match[1] < cutoff) {
+      fs.unlinkSync(path.join(BACKUP_DIR, file));
+    }
+  }
+}

--- a/mcp/server.ts
+++ b/mcp/server.ts
@@ -6,9 +6,11 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
 import { initDb } from '../core/db.js';
+import { backupDb } from '../core/backup.js';
 import { executeTool } from '../core/tools.js';
 
 await initDb();
+backupDb().catch(() => {});
 
 const server = new McpServer({
   name: 'fungible',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fungible",
-  "version": "1.3.1",
+  "version": "1.3.3",
   "description": "Terminal UI for personal finance — Plaid sync, CSV import, AI assistant, and MCP server",
   "type": "module",
   "homepage": "https://github.com/tomfunk/fungible",

--- a/tui/index.tsx
+++ b/tui/index.tsx
@@ -5,6 +5,7 @@ config({ path: join(DATA_DIR, '.env'), quiet: true });
 import React from 'react';
 import { render } from 'ink';
 import { initDb } from '../core/db.js';
+import { backupDb } from '../core/backup.js';
 import { syncAll } from '../core/sync.js';
 import { rebuildDisplayNames } from '../core/rename.js';
 import { App } from './App.js';
@@ -13,6 +14,7 @@ import { Setup } from './Setup.js';
 const isDemo = process.argv.includes('--demo');
 
 await initDb();
+if (!isDemo) backupDb().catch(() => {});
 
 if (process.argv.includes('--setup')) {
   render(<Setup />);


### PR DESCRIPTION
## Summary

- Adds `core/backup.ts` which copies `fungible.db` to `~/.fungible/backups/fungible.YYYY-MM-DD.bak` once per day on startup
- Defaults to 7 days retention; set `FUNGIBLE_BACKUP_DAYS` in `~/.fungible/.env` to override (set to `0` to disable)
- Backup runs fire-and-forget after `initDb()` in all three entry points (TUI, MCP server, API server); errors are swallowed so a backup failure never crashes the app
- Demo mode skips backup
- Bumps version to 1.3.3

## Test plan

- [ ] Launch app and confirm `~/.fungible/backups/fungible.<today>.bak` is created
- [ ] Launch again same day and confirm no duplicate backup is written
- [ ] Set `FUNGIBLE_BACKUP_DAYS=1` and confirm backups older than 1 day are pruned
- [ ] Set `FUNGIBLE_BACKUP_DAYS=0` and confirm no backup is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)