### PR TITLE
feat: live refresh all TUI screens after any MCP, API, or agent write

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,13 +282,47 @@ Available tools: same set as the MCP server below.
 
 Exposes your financial data to Claude via the [Model Context Protocol](https://modelcontextprotocol.io).
 
-Two modes:
-- **stdio** (`fungible mcp`) — Claude Desktop spawns this as a child process. Use this in your Claude config.
-- **HTTP** — starts automatically on port 3741 whenever the TUI is running. Connect any MCP client to `http://localhost:3741/mcp`.
+**Two connection modes:**
 
-```bash
-fungible mcp
-# or: npm run mcp
+- **stdio** — Claude Desktop spawns `fungible mcp` as a child process. Always works, even when the TUI isn't open. When the TUI is running, writes notify it automatically so the UI refreshes. Use this if you're not sure which to pick.
+
+- **HTTP** — when the TUI is running, it starts an HTTP MCP server on port 3741 (`FUNGIBLE_MCP_PORT` to override). Point Claude at `http://localhost:3741/mcp` instead of using a command — writes are in-process so the TUI updates instantly. Only works while the TUI is open.
+
+Add to your Claude config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+
+**stdio — Homebrew:**
+```json
+{
+  "mcpServers": {
+    "fungible": {
+      "command": "/opt/homebrew/bin/node",
+      "args": ["--no-warnings", "--import", "tsx/esm", "/opt/homebrew/lib/node_modules/fungible/mcp/server.ts"]
+    }
+  }
+}
+```
+
+**stdio — from source:**
+```json
+{
+  "mcpServers": {
+    "fungible": {
+      "command": "node",
+      "args": ["--no-warnings", "--import", "tsx/esm", "/path/to/fungible/mcp/server.ts"]
+    }
+  }
+}
+```
+
+**HTTP (TUI must be running):**
+```json
+{
+  "mcpServers": {
+    "fungible": {
+      "url": "http://localhost:3741/mcp"
+    }
+  }
+}
 ```
 
 Available tools:
@@ -319,29 +353,3 @@ Available tools:
 | `get_drift` | Per-category spending deltas vs prior period, last year, and 12-month avg |
 | `get_trends` | Month-by-month spending trends for the last N months |
 | `get_finance_guide` | Opinionated personal finance guidance by topic |
-
-Add to your Claude config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
-
-**If installed via Homebrew:**
-```json
-{
-  "mcpServers": {
-    "fungible": {
-      "command": "/opt/homebrew/bin/node",
-      "args": ["--no-warnings", "--import", "tsx/esm", "/opt/homebrew/lib/node_modules/fungible/mcp/server.ts"]
-    }
-  }
-}
-```
-
-**If running from source:**
-```json
-{
-  "mcpServers": {
-    "fungible": {
-      "command": "node",
-      "args": ["--no-warnings", "--import", "tsx/esm", "/path/to/fungible/mcp/server.ts"]
-    }
-  }
-}
-```

--- a/api/server.ts
+++ b/api/server.ts
@@ -8,6 +8,7 @@ import { createServer, IncomingMessage, ServerResponse } from 'node:http';
 import { initDb } from '../core/db.js';
 import { backupDb } from '../core/backup.js';
 import { executeTool, TOOL_DEFS } from '../core/tools.js';
+import { notifyChange } from '../core/refresh.js';
 
 const DEFAULT_PORT = parseInt(process.env.FUNGIBLE_API_PORT ?? '3456', 10);
 const API_KEY = process.env.FUNGIBLE_API_KEY;
@@ -37,6 +38,11 @@ export function startApiServer(port = DEFAULT_PORT, opts: { quiet?: boolean } = 
     if (API_KEY) {
       const auth = req.headers['authorization'];
       if (auth !== `Bearer ${API_KEY}`) return send(res, 401, { error: 'Unauthorized' });
+    }
+
+    if (req.method === 'POST' && req.url === '/notify') {
+      notifyChange();
+      return send(res, 200, { ok: true });
     }
 
     const match = req.method === 'POST' && req.url?.match(/^\/tools\/([^/?]+)$/);

--- a/core/refresh.ts
+++ b/core/refresh.ts
@@ -1,0 +1,12 @@
+import { EventEmitter } from 'node:events';
+
+const emitter = new EventEmitter();
+
+export function notifyChange(): void {
+  emitter.emit('change');
+}
+
+export function onRefresh(fn: () => void): () => void {
+  emitter.on('change', fn);
+  return () => { emitter.off('change', fn); };
+}

--- a/core/tools.ts
+++ b/core/tools.ts
@@ -25,6 +25,8 @@ import type { ToolDef } from './llm-provider.js';
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
+// Keep in sync with executeTool — any tool that mutates data must be listed here
+// or TUI refresh and afterWrite callbacks will be silently skipped for that tool.
 export const WRITE_TOOLS = new Set([
   'edit_transaction', 'clear_edit', 'ignore_transaction',
   'add_rule', 'delete_rule', 'add_name_rule', 'delete_name_rule',

--- a/core/tools.ts
+++ b/core/tools.ts
@@ -7,6 +7,7 @@
  * embedded agent handles those before calling executeTool.
  */
 
+import { notifyChange } from './refresh.js';
 import { getRangeSummary, getMonthlySummary, getTagSummary, getCategoryDriftData, getNetWorthHistory, type NetWorthGranularity } from './queries.js';
 import { solveTVM } from './calculator.js';
 import { getDriftWindows } from './dateUtils.js';
@@ -341,7 +342,7 @@ export function describeToolCall(name: string, input: Record<string, unknown>): 
  * Execute a tool by name and return a plain-text result string.
  * Does not handle `show` (agent-only), confirmation, or MCP wrapping.
  */
-export async function executeTool(
+async function executeToolImpl(
   name: string,
   input: Record<string, unknown>,
 ): Promise<string> {
@@ -742,4 +743,10 @@ export async function executeTool(
     default:
       return `Unknown tool: ${name}`;
   }
+}
+
+export async function executeTool(name: string, input: Record<string, unknown>): Promise<string> {
+  const result = await executeToolImpl(name, input);
+  if (WRITE_TOOLS.has(name)) notifyChange();
+  return result;
 }

--- a/mcp/create-server.ts
+++ b/mcp/create-server.ts
@@ -1,13 +1,13 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import { executeTool } from '../core/tools.js';
+import { executeTool, WRITE_TOOLS } from '../core/tools.js';
 
-async function run(name: string, input: Record<string, unknown>) {
-  const text = await executeTool(name, input);
-  return { content: [{ type: 'text' as const, text }] };
-}
-
-export function createMcpServer(): McpServer {
+export function createMcpServer(opts: { afterWrite?: () => void } = {}): McpServer {
+  async function run(name: string, input: Record<string, unknown>) {
+    const text = await executeTool(name, input);
+    if (opts.afterWrite && WRITE_TOOLS.has(name)) opts.afterWrite();
+    return { content: [{ type: 'text' as const, text }] };
+  }
   const server = new McpServer({ name: 'fungible', version: '1.0.0' });
 
   // ── spending_summary ────────────────────────────────────────────────────────

--- a/mcp/server.ts
+++ b/mcp/server.ts
@@ -9,6 +9,11 @@ import { createMcpServer } from './create-server.js';
 
 await initDb();
 backupDb().catch(() => {});
-const server = createMcpServer();
+const apiPort = parseInt(process.env.FUNGIBLE_API_PORT ?? '3456', 10);
+const server = createMcpServer({
+  afterWrite: () => {
+    fetch(`http://localhost:${apiPort}/notify`, { method: 'POST' }).catch(() => {});
+  },
+});
 const transport = new StdioServerTransport();
 await server.connect(transport);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fungible",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "Terminal UI for personal finance — Plaid sync, CSV import, AI assistant, and MCP server",
   "type": "module",
   "homepage": "https://github.com/tomfunk/fungible",

--- a/tui/Accounts.tsx
+++ b/tui/Accounts.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Box, Text, useInput } from 'ink';
 import { useSetTyping } from './TypingContext.js';
+import { useRefreshKey } from './RefreshContext.js';
 import { spawn } from 'node:child_process';
 import { syncAll } from '../core/sync.js';
 import { getCsvPlaidDupeCandidates, type DupePair } from '../core/dedup.js';
@@ -63,6 +64,7 @@ function fmtDate(d: string | null): string {
 // ─── Component ────────────────────────────────────────────────────────────────
 
 export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: Screen, f?: TxFilter) => void; isActive?: boolean; showHints: boolean }) {
+  const refreshKey = useRefreshKey();
   // Main view toggle
   const [mainView, setMainView] = useState<MainView>('accounts');
 
@@ -142,7 +144,7 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
     void getLinkedAccounts().then(setLinkedAccounts);
     void getCsvPlaidDupeCandidates().then(setDupes);
   }
-  useEffect(() => { loadAccounts(); }, []);
+  useEffect(() => { loadAccounts(); }, [refreshKey]);
 
   function openEdit(acct: LinkedAccount) {
     const type = acct.type;

--- a/tui/App.tsx
+++ b/tui/App.tsx
@@ -60,19 +60,19 @@ export function App() {
 
   return (
     <RefreshProvider>
-    <TypingContext.Provider value={setScreenTyping}>
-    <Box flexDirection="column" height="100%">
-      <Box flexGrow={1}>
-        {currentScreen}
-      </Box>
-      <Chat
-        isActive={chatFocused}
-        onActivate={() => setChatFocused(true)}
-        onDeactivate={() => setChatFocused(false)}
-        onNavigate={navigate}
-      />
-    </Box>
-    </TypingContext.Provider>
+      <TypingContext.Provider value={setScreenTyping}>
+        <Box flexDirection="column" height="100%">
+          <Box flexGrow={1}>
+            {currentScreen}
+          </Box>
+          <Chat
+            isActive={chatFocused}
+            onActivate={() => setChatFocused(true)}
+            onDeactivate={() => setChatFocused(false)}
+            onNavigate={navigate}
+          />
+        </Box>
+      </TypingContext.Provider>
     </RefreshProvider>
   );
 }

--- a/tui/App.tsx
+++ b/tui/App.tsx
@@ -10,6 +10,7 @@ import { Rules } from './Rules.js';
 import { Accounts } from './Accounts.js';
 import { Health } from './Health.js';
 import { Chat } from './Chat.js';
+import { RefreshProvider } from './RefreshContext.js';
 
 export type Screen = 'dashboard' | 'transactions' | 'trends' | 'networth' | 'tags' | 'rules' | 'accounts' | 'health';
 
@@ -58,6 +59,7 @@ export function App() {
   })();
 
   return (
+    <RefreshProvider>
     <TypingContext.Provider value={setScreenTyping}>
     <Box flexDirection="column" height="100%">
       <Box flexGrow={1}>
@@ -71,5 +73,6 @@ export function App() {
       />
     </Box>
     </TypingContext.Provider>
+    </RefreshProvider>
   );
 }

--- a/tui/Dashboard.tsx
+++ b/tui/Dashboard.tsx
@@ -16,6 +16,7 @@ import { fmt, fmtSigned, bar, Divider, truncate } from './fmt.js';
 import { NavHints, handleNavKey } from './nav.js';
 import { useTerminalWidth, CURSOR, FLEX_COLORS, C_POSITIVE, C_NEGATIVE, C_WARNING, C_NEUTRAL, C_MANUAL, C_ACCENT } from './ui.js';
 import { useSetTyping } from './TypingContext.js';
+import { useRefreshKey } from './RefreshContext.js';
 
 const BAR_WIDTH = 20;
 
@@ -51,6 +52,7 @@ const FLEX_TIERS: Array<{ key: keyof FlexSummary; label: string; color: string }
 ];
 
 export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { onNavigate: (s: Screen, filter?: TxFilter) => void; isActive?: boolean; initialFilter?: TxFilter; showHints: boolean }) {
+  const refreshKey = useRefreshKey();
   const now = new Date();
   const [range, setRange] = useState<Range>('month');
   const [anchor, setAnchor] = useState<Date>(() => getPeriodStart('month', now));
@@ -97,7 +99,7 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
   useEffect(() => {
     load(range, anchor, selectedAccount);
     setCatCursor(0);
-  }, [range, anchor.toISOString().slice(0, 10), selectedAccount?.id ?? null]);
+  }, [range, anchor.toISOString().slice(0, 10), selectedAccount?.id ?? null, refreshKey]);
 
   useEffect(() => {
     if (!driftMode) { setCatDrift(null); setFlexDrift(null); setAcctDrift(null); return; }

--- a/tui/Health.tsx
+++ b/tui/Health.tsx
@@ -5,6 +5,7 @@ import { Divider } from './fmt.js';
 import { NavHints, handleNavKey } from './nav.js';
 import { loadHealthData, yearsToFire, coastYears, type HealthData } from '../core/health.js';
 import { C_POSITIVE, C_NEGATIVE, C_WARNING, C_NEUTRAL, C_ACCENT } from './ui.js';
+import { useRefreshKey } from './RefreshContext.js';
 
 function savingsRateColor(rate: number): string {
   if (rate < 0)  return C_NEGATIVE;
@@ -42,6 +43,7 @@ function progressBar(ratio: number, width = PROGRESS_BAR_WIDTH) {
 const DEFAULT_HEALTH: HealthData = { avgMonthlyExpenses: 0, monthlyIncome: 0, monthlySavings: 0, cash: 0, liquid: 0, totalDebt: 0, netWorth: 0 };
 
 export function Health({ onNavigate, isActive, showHints }: { onNavigate: (s: Screen) => void; isActive?: boolean; showHints: boolean }) {
+  const refreshKey = useRefreshKey();
   const [data, setData] = useState<HealthData>(DEFAULT_HEALTH);
 
   const [dialIdx, setDialIdx]           = useState(0);
@@ -54,7 +56,7 @@ export function Health({ onNavigate, isActive, showHints }: { onNavigate: (s: Sc
       setMonthlySpend(Math.max(SPEND_STEP, Math.round(d.avgMonthlyExpenses / SPEND_STEP) * SPEND_STEP));
       setMonthlySavings(Math.round(d.monthlySavings / SPEND_STEP) * SPEND_STEP);
     });
-  }, []);
+  }, [refreshKey]);
   const [withdrawal, setWithdrawal]     = useState(DEFAULT_WITHDRAWAL);
   const [growth, setGrowth]             = useState(DEFAULT_GROWTH);
 

--- a/tui/NetWorth.tsx
+++ b/tui/NetWorth.tsx
@@ -5,6 +5,7 @@ import type { Screen } from './App.js';
 import { fmt, fmtSigned, bar, truncate, Divider } from './fmt.js';
 import { NavHints, handleNavKey } from './nav.js';
 import { useTerminalWidth, MONTHS, SUBTYPE_DISPLAY, C_POSITIVE, C_NEGATIVE, C_ACCENT } from './ui.js';
+import { useRefreshKey } from './RefreshContext.js';
 
 const BAR_WIDTH = 32;
 const PAGE = 20;
@@ -44,6 +45,7 @@ function periodLabel(period: string, range: NWRange): string {
 }
 
 export function NetWorth({ onNavigate, isActive, showHints }: { onNavigate: (s: Screen) => void; isActive?: boolean; showHints: boolean }) {
+  const refreshKey = useRefreshKey();
   const [accounts, setAccounts] = useState<AccountBalance[]>([]);
   const [rows,     setRows]     = useState<NetWorthPeriod[]>([]);
   const [view,   setView]   = useState<ViewMode>('accounts');
@@ -52,14 +54,14 @@ export function NetWorth({ onNavigate, isActive, showHints }: { onNavigate: (s: 
 
   useEffect(() => {
     void getAccountsWithBalances().then(({ accounts: a }) => setAccounts(a));
-  }, []);
+  }, [refreshKey]);
 
   useEffect(() => {
     void getNetWorthHistory(range).then((r) => {
       setRows(r);
       setCursor(Math.max(0, r.length - 1));
     });
-  }, [range]);
+  }, [range, refreshKey]);
 
   useInput((input, key) => {
     if (key.tab)      { setView((v) => v === 'accounts' ? 'types' : 'accounts'); return; }

--- a/tui/RefreshContext.tsx
+++ b/tui/RefreshContext.tsx
@@ -1,0 +1,14 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import { onRefresh } from '../core/refresh.js';
+
+const Ctx = createContext(0);
+
+export function RefreshProvider({ children }: { children: React.ReactNode }) {
+  const [key, setKey] = useState(0);
+  useEffect(() => onRefresh(() => setKey((k) => k + 1)), []);
+  return <Ctx.Provider value={key}>{children}</Ctx.Provider>;
+}
+
+export function useRefreshKey(): number {
+  return useContext(Ctx);
+}

--- a/tui/RefreshContext.tsx
+++ b/tui/RefreshContext.tsx
@@ -1,14 +1,14 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
 import { onRefresh } from '../core/refresh.js';
 
-const Ctx = createContext(0);
+const RefreshCtx = createContext(0);
 
 export function RefreshProvider({ children }: { children: React.ReactNode }) {
   const [key, setKey] = useState(0);
   useEffect(() => onRefresh(() => setKey((k) => k + 1)), []);
-  return <Ctx.Provider value={key}>{children}</Ctx.Provider>;
+  return <RefreshCtx.Provider value={key}>{children}</RefreshCtx.Provider>;
 }
 
 export function useRefreshKey(): number {
-  return useContext(Ctx);
+  return useContext(RefreshCtx);
 }

--- a/tui/Rules.tsx
+++ b/tui/Rules.tsx
@@ -10,6 +10,7 @@ import type { Screen, TxFilter } from './App.js';
 import { truncate, Divider } from './fmt.js';
 import { NavHints, handleNavKey } from './nav.js';
 import { useTerminalWidth, CURSOR, FLEX_COLORS, C_ACCENT, C_MANUAL, C_NEUTRAL, C_POSITIVE, C_WARNING } from './ui.js';
+import { useRefreshKey } from './RefreshContext.js';
 import { useSetTyping } from './TypingContext.js';
 
 type Flexibility = 'fixed' | 'flexible' | 'discretionary' | null;
@@ -20,6 +21,7 @@ type Section = 'rules' | 'names' | 'categories';
 const SECTIONS: Section[] = ['rules', 'names', 'categories'];
 
 export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Screen, f?: TxFilter) => void; isActive?: boolean; showHints: boolean }) {
+  const refreshKey = useRefreshKey();
   const [rules, setRules] = useState<Rule[]>([]);
   const [nameRules, setNameRules] = useState<NameRule[]>([]);
   const [cursor, setCursor] = useState(0);
@@ -83,7 +85,7 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
     void getCategoryDetails().then(setCatDetails);
   }
 
-  useEffect(() => { load(); }, []);
+  useEffect(() => { load(); }, [refreshKey]);
 
   function handleDeleteRule(id: number) {
     deleteCategoryRule(id);

--- a/tui/Tags.tsx
+++ b/tui/Tags.tsx
@@ -7,10 +7,12 @@ import { fmt, bar, truncate, Divider } from './fmt.js';
 import { NavHints, handleNavKey } from './nav.js';
 import { useTerminalWidth, CURSOR, C_POSITIVE, C_NEGATIVE, C_WARNING, C_ACCENT } from './ui.js';
 import { useSetTyping } from './TypingContext.js';
+import { useRefreshKey } from './RefreshContext.js';
 
 type Mode = 'list' | 'search' | 'add' | 'detail' | 'rename';
 
 export function Tags({ onNavigate, isActive, showHints }: { onNavigate: (s: Screen, f?: TxFilter) => void; isActive?: boolean; showHints: boolean }) {
+  const refreshKey = useRefreshKey();
   const [tags, setTags] = useState<Tag[]>([]);
   const [cursor, setCursor] = useState(0);
   const [mode, setMode] = useState<Mode>('list');
@@ -21,7 +23,7 @@ export function Tags({ onNavigate, isActive, showHints }: { onNavigate: (s: Scre
   const [catCursor, setCatCursor] = useState(0);
 
   function load() { void getAllTags().then(setTags); }
-  useEffect(() => { load(); }, []);
+  useEffect(() => { load(); }, [refreshKey]);
 
   const setTyping = useSetTyping();
   useEffect(() => { setTyping(mode === 'search' || mode === 'add' || mode === 'rename'); }, [mode]);

--- a/tui/Transactions.tsx
+++ b/tui/Transactions.tsx
@@ -18,6 +18,7 @@ import type { Screen, TxFilter } from './App.js';
 import { NavHints, handleNavKey } from './nav.js';
 import { Divider } from './fmt.js';
 import { useTerminalWidth, CURSOR, MONTHS, C_POSITIVE, C_NEGATIVE, C_WARNING, C_NEUTRAL, C_MANUAL, C_ACCENT, C_DIM } from './ui.js';
+import { useRefreshKey } from './RefreshContext.js';
 import { useSetTyping } from './TypingContext.js';
 
 type Tx = TxRow;
@@ -46,6 +47,7 @@ function truncate(s: string, n: number) {
 
 
 export function Transactions({ onNavigate, initialFilter, isActive, showHints }: { onNavigate: (s: Screen, f?: TxFilter) => void; initialFilter?: TxFilter; isActive?: boolean; showHints: boolean }) {
+  const refreshKey = useRefreshKey();
   const [category, setCategory] = useState<string | null>(initialFilter?.category ?? null);
   const [from, setFrom] = useState<string | null>(initialFilter?.from ?? null);
   const [to, setTo] = useState<string | null>(initialFilter?.to ?? null);
@@ -84,7 +86,7 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
   }
 
   useEffect(() => { void getDataBounds().then(setBounds); void getAllCategories().then(setCategories); }, []);
-  useEffect(() => { load(); }, [category, from, to, search, tag, account, sort]);
+  useEffect(() => { load(); }, [category, from, to, search, tag, account, sort, refreshKey]);
 
   const setTyping = useSetTyping();
   useEffect(() => {

--- a/tui/Trends.tsx
+++ b/tui/Trends.tsx
@@ -6,6 +6,7 @@ import type { Screen, TxFilter } from './App.js';
 import { fmt, fmtSigned, bar, Divider } from './fmt.js';
 import { NavHints, handleNavKey } from './nav.js';
 import { useTerminalWidth, FLEX_COLORS, C_POSITIVE, C_NEGATIVE, C_NEUTRAL, C_ACCENT } from './ui.js';
+import { useRefreshKey } from './RefreshContext.js';
 
 const TRENDS_RANGES: TrendsRange[] = ['week', 'month', 'quarter', 'year'];
 const RANGE_LABELS: Record<TrendsRange, string> = { week: 'Week', month: 'Month', quarter: 'Quarter', year: 'Year' };
@@ -29,6 +30,7 @@ export function Trends({
   isActive?: boolean;
   showHints: boolean;
 }) {
+  const refreshKey = useRefreshKey();
   const [views, setViews] = useState<View[]>([
     { mode: 'expenses',      category: null, flex: null,            label: 'Expenses'      },
     { mode: 'income',        category: null, flex: null,            label: 'Income'        },
@@ -59,7 +61,7 @@ export function Trends({
       setRows(data);
       setCursor(Math.max(0, data.length - 1));
     });
-  }, [viewIdx, range, views]);
+  }, [viewIdx, range, views, refreshKey]);
 
   useInput((input, key) => {
     if (key.escape) { onNavigate('dashboard'); return; }


### PR DESCRIPTION
## Summary

- Adds a lightweight EventEmitter singleton (`core/refresh.ts`) with `notifyChange()` / `onRefresh()`
- `executeTool` calls `notifyChange()` after any write operation — covers MCP, REST API, and the embedded chat agent since they all share the same function
- New `tui/RefreshContext.tsx` exposes a `useRefreshKey()` hook that increments on every change signal
- All 8 TUI screens call `useRefreshKey()` and include the key in their primary data-load `useEffect` dep array — one line each, no per-screen logic

## Result

Any write via the MCP server, REST API, or the in-app agent chat immediately refreshes the currently visible screen — no navigation required.

## Test plan

- [ ] Add a rule via MCP/API while on the Rules screen — rule appears without navigating away
- [ ] Run `sync` while on Dashboard — totals update automatically
- [ ] Edit a transaction category while on Transactions — row updates live
- [ ] Tag a transaction while on Tags — tag counts update

🤖 Generated with [Claude Code](https://claude.com/claude-code)