### PR TITLE
feat: ink-testing-library TUI tests for all 8 screens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fungible",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fungible",
-      "version": "1.3.6",
+      "version": "1.3.7",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.98.0",
@@ -26,6 +26,7 @@
       "devDependencies": {
         "@types/node": "^25.9.1",
         "@types/react": "^19.2.15",
+        "ink-testing-library": "^4.0.0",
         "typescript": "^6.0.3",
         "vitest": "^3.2.4"
       },
@@ -2328,6 +2329,24 @@
           "optional": true
         },
         "react-devtools-core": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ink-testing-library": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ink-testing-library/-/ink-testing-library-4.0.0.tgz",
+      "integrity": "sha512-yF92kj3pmBvk7oKbSq5vEALO//o7Z9Ck/OaLNlkzXNeYdwfpxMQkSowGTFUCS5MSu9bWfSZMewGpp7bFc66D7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fungible",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "Terminal UI for personal finance — Plaid sync, CSV import, AI assistant, and MCP server",
   "type": "module",
   "homepage": "https://github.com/tomfunk/fungible",
@@ -41,6 +41,7 @@
   "devDependencies": {
     "@types/node": "^25.9.1",
     "@types/react": "^19.2.15",
+    "ink-testing-library": "^4.0.0",
     "typescript": "^6.0.3",
     "vitest": "^3.2.4"
   }

--- a/tests/helpers/seedTuiData.ts
+++ b/tests/helpers/seedTuiData.ts
@@ -1,0 +1,59 @@
+import type { Client } from '@libsql/client';
+
+/**
+ * Seeds a small but representative dataset into the given in-memory DB.
+ * All transactions are in 2026-05 (or 2026-04 for prior-period comparisons)
+ * so tests can target a fixed period via initialFilter anchor.
+ */
+export async function seedTuiData(db: Client) {
+  await db.batch(
+    [
+      // Accounts
+      `INSERT INTO accounts (id, name, type, subtype, institution_name, mask)
+       VALUES ('test-checking', 'Test Checking', 'depository', 'checking', 'Test Bank', '0001')`,
+      `INSERT INTO accounts (id, name, type, subtype, institution_name, mask)
+       VALUES ('test-credit', 'Test Visa', 'credit', 'credit card', 'Test Bank', '0002')`,
+
+      // May 2026 transactions
+      `INSERT INTO transactions (id, account_id, date, name, amount, category, pending, ignored)
+       VALUES ('tx-income',   'test-checking', '2026-05-01', 'Direct Deposit', -3500.00, 'Income', 0, 0)`,
+      `INSERT INTO transactions (id, account_id, date, name, amount, category, pending, ignored)
+       VALUES ('tx-groc-1',   'test-credit',   '2026-05-06', 'Whole Foods',    120.00,   'Grocery', 0, 0)`,
+      `INSERT INTO transactions (id, account_id, date, name, amount, category, pending, ignored)
+       VALUES ('tx-groc-2',   'test-credit',   '2026-05-14', 'Trader Joes',     85.00,   'Grocery', 0, 0)`,
+      `INSERT INTO transactions (id, account_id, date, name, amount, category, pending, ignored)
+       VALUES ('tx-dining-1', 'test-credit',   '2026-05-09', 'Sweetgreen',      45.00,   'Dining', 0, 0)`,
+      `INSERT INTO transactions (id, account_id, date, name, amount, category, pending, ignored)
+       VALUES ('tx-bills-1',  'test-credit',   '2026-05-03', 'Con Edison',      95.00,   'Bills & Utilities', 0, 0)`,
+      `INSERT INTO transactions (id, account_id, date, name, amount, category, pending, ignored)
+       VALUES ('tx-shopping', 'test-credit',   '2026-05-11', 'Amazon',          43.99,   'Shopping', 0, 0)`,
+
+      // April 2026 transactions (for prior-period drift)
+      `INSERT INTO transactions (id, account_id, date, name, amount, category, pending, ignored)
+       VALUES ('tx-income-apr', 'test-checking', '2026-04-01', 'Direct Deposit', -3500.00, 'Income', 0, 0)`,
+      `INSERT INTO transactions (id, account_id, date, name, amount, category, pending, ignored)
+       VALUES ('tx-groc-apr',   'test-credit',   '2026-04-08', 'Whole Foods',    100.00,   'Grocery', 0, 0)`,
+      `INSERT INTO transactions (id, account_id, date, name, amount, category, pending, ignored)
+       VALUES ('tx-dining-apr', 'test-credit',   '2026-04-15', 'Sweetgreen',      40.00,   'Dining', 0, 0)`,
+
+      // Flexibility tiers
+      `INSERT INTO categories (name, flexibility) VALUES ('Grocery', 'flexible')`,
+      `INSERT INTO categories (name, flexibility) VALUES ('Dining', 'discretionary')`,
+      `INSERT INTO categories (name, flexibility) VALUES ('Bills & Utilities', 'fixed')`,
+      `INSERT INTO categories (name, flexibility) VALUES ('Shopping', 'discretionary')`,
+      `INSERT INTO categories (name, flexibility) VALUES ('Income', NULL)`,
+
+      // Category rule
+      `INSERT INTO category_rules (priority, match_type, pattern, category) VALUES (10, 'name', 'Whole Foods', 'Grocery')`,
+
+      // Tags
+      `INSERT INTO tags (id, name) VALUES (1, 'travel')`,
+      `INSERT INTO tags (id, name) VALUES (2, 'work')`,
+
+      // Balance history (required for NetWorth accounts view)
+      `INSERT INTO balance_history (account_id, balance, date) VALUES ('test-checking', 5000.00, '2026-05-20')`,
+      `INSERT INTO balance_history (account_id, balance, date) VALUES ('test-credit', -450.00, '2026-05-20')`,
+    ],
+    'write',
+  );
+}

--- a/tests/tui/screens.test.tsx
+++ b/tests/tui/screens.test.tsx
@@ -1,0 +1,642 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import React from 'react';
+import { render, cleanup } from 'ink-testing-library';
+
+vi.mock('../../core/db.js', async () => {
+  const { makeTestDb } = await import('../helpers/makeTestDb.js');
+  return { db: await makeTestDb() };
+});
+
+import { db } from '../../core/db.js';
+import { seedTuiData } from '../helpers/seedTuiData.js';
+import { App } from '../../tui/App.js';
+import { Dashboard } from '../../tui/Dashboard.js';
+import { Transactions } from '../../tui/Transactions.js';
+import { Trends } from '../../tui/Trends.js';
+import { NetWorth } from '../../tui/NetWorth.js';
+import { Tags } from '../../tui/Tags.js';
+import { Rules } from '../../tui/Rules.js';
+import { Accounts } from '../../tui/Accounts.js';
+import { Health } from '../../tui/Health.js';
+import { RefreshProvider } from '../../tui/RefreshContext.js';
+import { TypingContext } from '../../tui/TypingContext.js';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const ANSI_RE = /\x1b\[[0-9;]*[mGKHFABCDJ]/g;
+
+function frame(r: ReturnType<typeof render>): string {
+  return (r.lastFrame() ?? '').replace(ANSI_RE, '');
+}
+
+async function waitFor(assertion: () => void, timeout = 2000): Promise<void> {
+  const deadline = Date.now() + timeout;
+  let lastErr: unknown;
+  while (Date.now() < deadline) {
+    try { assertion(); return; } catch (e) { lastErr = e; }
+    await new Promise((res) => setTimeout(res, 30));
+  }
+  throw lastErr;
+}
+
+function W({ children }: { children: React.ReactNode }) {
+  return (
+    <RefreshProvider>
+      <TypingContext.Provider value={() => {}}>
+        {children}
+      </TypingContext.Provider>
+    </RefreshProvider>
+  );
+}
+
+// Anchor all tests to May 2026 so they hit the seeded data regardless of real date.
+const MAY_FILTER = { range: 'month' as const, anchor: '2026-05-15' };
+const noop = () => {};
+
+// ── Setup ─────────────────────────────────────────────────────────────────────
+
+beforeEach(async () => {
+  for (const tbl of ['transactions', 'accounts', 'categories', 'tags', 'transaction_tags',
+                     'category_rules', 'name_rules', 'hidden_categories', 'balance_history']) {
+    await db.execute(`DELETE FROM ${tbl}`);
+  }
+  await seedTuiData(db);
+});
+
+afterEach(() => cleanup());
+
+// ── Dashboard ─────────────────────────────────────────────────────────────────
+
+describe('Dashboard', () => {
+  function dash(overrides?: Parameters<typeof Dashboard>[0]) {
+    return render(
+      <W>
+        <Dashboard onNavigate={noop} showHints={false} initialFilter={MAY_FILTER} {...overrides} />
+      </W>,
+    );
+  }
+
+  it('renders app title and screen header', () => {
+    const r = dash();
+    expect(frame(r)).toContain('fungible');
+    expect(frame(r)).toContain('Dashboard');
+  });
+
+  it('shows Income / Expenses / Net after data loads', async () => {
+    const r = dash();
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).toContain('Income');
+      expect(f).toContain('Expenses');
+      expect(f).toContain('Net');
+    });
+  });
+
+  it('shows spending amounts from seeded transactions', async () => {
+    const r = dash();
+    await waitFor(() => {
+      const f = frame(r);
+      // Grocery ($205) should be the top category
+      expect(f).toContain('Grocery');
+    });
+  });
+
+  it('shows SPENDING BY CATEGORY heading', async () => {
+    const r = dash();
+    await waitFor(() => expect(frame(r)).toContain('SPENDING BY CATEGORY'));
+  });
+
+  it('Tab cycles to flex view', async () => {
+    const r = dash();
+    await waitFor(() => expect(frame(r)).toContain('Income'));
+    r.stdin.write('\t');
+    await waitFor(() => expect(frame(r)).toContain('SPENDING BY FLEXIBILITY'));
+  });
+
+  it('Tab Tab cycles to account view', async () => {
+    const r = dash();
+    await waitFor(() => expect(frame(r)).toContain('Income'));
+    r.stdin.write('\t');
+    r.stdin.write('\t');
+    await waitFor(() => expect(frame(r)).toContain('account'));
+  });
+
+  it('account view shows linked accounts', async () => {
+    const r = dash();
+    await waitFor(() => expect(frame(r)).toContain('Income'));
+    r.stdin.write('\t');
+    r.stdin.write('\t');
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).toContain('Test Checking');
+    });
+  });
+
+  it('r key cycles the range label', async () => {
+    const r = dash();
+    await waitFor(() => expect(frame(r)).toContain('Month'));
+    r.stdin.write('r');
+    await waitFor(() => {
+      const f = frame(r);
+      // Range label should change away from 'Month' heading being bold/active
+      // The next range after 'month' is 'week' — look for 'Week' in the period area
+      expect(f).toContain('Week');
+    });
+  });
+
+  it('/ key opens search mode', async () => {
+    const r = dash();
+    await waitFor(() => expect(frame(r)).toContain('Income'));
+    r.stdin.write('/');
+    // Search bar should appear with the cursor indicator
+    await waitFor(() => expect(frame(r)).toContain('/'));
+  });
+
+  it('d key toggles delta mode label', async () => {
+    const r = dash();
+    await waitFor(() => expect(frame(r)).toContain('Income'));
+    r.stdin.write('d');
+    await waitFor(() => expect(frame(r)).toContain('delta'));
+  });
+
+  it('pressing a nav number calls onNavigate', async () => {
+    const onNavigate = vi.fn();
+    const r = render(
+      <W>
+        <Dashboard onNavigate={onNavigate} showHints={false} initialFilter={MAY_FILTER} />
+      </W>,
+    );
+    await waitFor(() => expect(frame(r)).toContain('Income'));
+    r.stdin.write('3'); // trends
+    expect(onNavigate).toHaveBeenCalledWith('trends');
+  });
+
+  it('shows period label for the anchored month', async () => {
+    const r = dash();
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).toMatch(/May 2026/);
+    });
+  });
+});
+
+// ── Transactions ──────────────────────────────────────────────────────────────
+
+describe('Transactions', () => {
+  const MAY_DATE_FILTER = { from: '2026-05-01', to: '2026-05-31' };
+
+  function txns(overrides?: Partial<Parameters<typeof Transactions>[0]>) {
+    return render(
+      <W>
+        <Transactions onNavigate={noop} showHints={false} initialFilter={MAY_DATE_FILTER} {...overrides} />
+      </W>,
+    );
+  }
+
+  it('renders Transactions title', () => {
+    const r = txns();
+    expect(frame(r)).toContain('Transactions');
+  });
+
+  it('renders column headers', () => {
+    const r = txns();
+    const f = frame(r);
+    expect(f).toContain('DATE');
+    expect(f).toContain('DESCRIPTION');
+    expect(f).toContain('AMOUNT');
+    expect(f).toContain('CATEGORY');
+  });
+
+  it('shows seeded transactions after load', async () => {
+    const r = txns();
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).toContain('Whole Foods');
+    });
+  });
+
+  it('shows transaction count in footer', async () => {
+    const r = txns();
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).toMatch(/\d+ transactions/);
+    });
+  });
+
+  it('filters to only May transactions when date filter applied', async () => {
+    const r = txns();
+    await waitFor(() => {
+      const f = frame(r);
+      // April-only transaction should not appear
+      expect(f).not.toContain('tx-groc-apr');
+      // May transactions should appear
+      expect(f).toContain('Whole Foods');
+    });
+  });
+
+  it('/ key enters search mode', async () => {
+    const r = txns();
+    await waitFor(() => expect(frame(r)).toContain('Whole Foods'));
+    r.stdin.write('/');
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).toContain('/');
+    });
+  });
+
+  it('s key cycles sort order label', async () => {
+    const r = txns();
+    await waitFor(() => expect(frame(r)).toContain('DATE'));
+    // Initial sort is 'date-desc', header shows '↓'
+    expect(frame(r)).toContain('↓');
+    r.stdin.write('s');
+    // After one press → date-asc, shows '↑'
+    await waitFor(() => expect(frame(r)).toContain('↑'));
+  });
+
+  it('Escape navigates back to dashboard', async () => {
+    const onNavigate = vi.fn();
+    // No date filter so the first Escape goes straight to onNavigate
+    const r = render(
+      <W>
+        <Transactions onNavigate={onNavigate} showHints={false} />
+      </W>,
+    );
+    await waitFor(() => expect(frame(r)).toContain('Transactions'));
+    r.stdin.write('\x1b');
+    await waitFor(() => expect(onNavigate).toHaveBeenCalledWith('dashboard', undefined));
+  });
+
+  it('shows category filter label when category is provided', async () => {
+    const r = txns({ initialFilter: { ...MAY_DATE_FILTER, category: 'Grocery' } });
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).toContain('Grocery');
+    });
+  });
+
+  it('shows a May 2026 date filter label', async () => {
+    const r = txns();
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).toMatch(/May 2026/);
+    });
+  });
+
+  it('pressing nav number calls onNavigate', async () => {
+    const onNavigate = vi.fn();
+    const r = render(
+      <W>
+        <Transactions onNavigate={onNavigate} showHints={false} initialFilter={MAY_DATE_FILTER} />
+      </W>,
+    );
+    await waitFor(() => expect(frame(r)).toContain('Transactions'));
+    r.stdin.write('4'); // networth
+    expect(onNavigate).toHaveBeenCalledWith('networth');
+  });
+});
+
+// ── Trends ────────────────────────────────────────────────────────────────────
+
+describe('Trends', () => {
+  function trends(overrides?: Partial<Parameters<typeof Trends>[0]>) {
+    return render(
+      <W>
+        <Trends onNavigate={noop} showHints={false} {...overrides} />
+      </W>,
+    );
+  }
+
+  it('renders app title and screen header', () => {
+    const r = trends();
+    expect(frame(r)).toContain('fungible');
+    expect(frame(r)).toContain('Trends');
+  });
+
+  it('shows the current view label (Expenses by default)', async () => {
+    const r = trends();
+    // Trends shows only the current view's label in the header, not all tabs at once.
+    // The initial view is 'Expenses'.
+    await waitFor(() => expect(frame(r)).toContain('Expenses'));
+  });
+
+  it('shows range labels', async () => {
+    const r = trends();
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).toContain('Month');
+    });
+  });
+
+  it('r key cycles range label', async () => {
+    const r = trends();
+    await waitFor(() => expect(frame(r)).toContain('Month'));
+    r.stdin.write('r');
+    await waitFor(() => expect(frame(r)).toContain('Quarter'));
+  });
+
+  it('pressing nav number calls onNavigate', async () => {
+    const onNavigate = vi.fn();
+    const r = render(
+      <W><Trends onNavigate={onNavigate} showHints={false} /></W>,
+    );
+    await waitFor(() => expect(frame(r)).toContain('Trends'));
+    r.stdin.write('1');
+    expect(onNavigate).toHaveBeenCalledWith('dashboard');
+  });
+});
+
+// ── Net Worth ─────────────────────────────────────────────────────────────────
+
+describe('NetWorth', () => {
+  function networth(overrides?: Partial<Parameters<typeof NetWorth>[0]>) {
+    return render(
+      <W>
+        <NetWorth onNavigate={noop} showHints={false} {...overrides} />
+      </W>,
+    );
+  }
+
+  it('renders app title and screen header', () => {
+    const r = networth();
+    expect(frame(r)).toContain('fungible');
+    expect(frame(r)).toContain('Net Worth');
+  });
+
+  it('shows seeded accounts after load', async () => {
+    const r = networth();
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).toContain('Test Checking');
+    });
+  });
+
+  it('shows Assets and Liabilities sections', async () => {
+    const r = networth();
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).toContain('Assets');
+      expect(f).toContain('Liabilities');
+    });
+  });
+
+  it('Tab cycles to types view', async () => {
+    const r = networth();
+    await waitFor(() => expect(frame(r)).toContain('Net Worth'));
+    r.stdin.write('\t');
+    await waitFor(() => {
+      const f = frame(r);
+      // types view groups by subtype: checking, savings, credit card, brokerage
+      expect(f).toContain('checking');
+    });
+  });
+
+  it('pressing nav number calls onNavigate', async () => {
+    const onNavigate = vi.fn();
+    const r = render(
+      <W><NetWorth onNavigate={onNavigate} showHints={false} /></W>,
+    );
+    await waitFor(() => expect(frame(r)).toContain('Net Worth'));
+    r.stdin.write('1');
+    expect(onNavigate).toHaveBeenCalledWith('dashboard');
+  });
+});
+
+// ── Tags ──────────────────────────────────────────────────────────────────────
+
+describe('Tags', () => {
+  function tags(overrides?: Partial<Parameters<typeof Tags>[0]>) {
+    return render(
+      <W>
+        <Tags onNavigate={noop} showHints={false} {...overrides} />
+      </W>,
+    );
+  }
+
+  it('renders app title and screen header', () => {
+    const r = tags();
+    expect(frame(r)).toContain('fungible');
+    expect(frame(r)).toContain('Tags');
+  });
+
+  it('shows seeded tags after load', async () => {
+    const r = tags();
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).toContain('travel');
+      expect(f).toContain('work');
+    });
+  });
+
+  it('a key enters new-tag input mode', async () => {
+    const r = tags();
+    await waitFor(() => expect(frame(r)).toContain('travel'));
+    r.stdin.write('a');
+    await waitFor(() => expect(frame(r)).toContain('New Tag'));
+  });
+
+  it('pressing nav number calls onNavigate', async () => {
+    const onNavigate = vi.fn();
+    const r = render(
+      <W><Tags onNavigate={onNavigate} showHints={false} /></W>,
+    );
+    await waitFor(() => expect(frame(r)).toContain('Tags'));
+    r.stdin.write('1');
+    expect(onNavigate).toHaveBeenCalledWith('dashboard');
+  });
+});
+
+// ── Rules ─────────────────────────────────────────────────────────────────────
+
+describe('Rules', () => {
+  function rules(overrides?: Partial<Parameters<typeof Rules>[0]>) {
+    return render(
+      <W>
+        <Rules onNavigate={noop} showHints={false} {...overrides} />
+      </W>,
+    );
+  }
+
+  it('renders app title and section tabs', () => {
+    const r = rules();
+    const f = frame(r);
+    expect(f).toContain('fungible');
+    expect(f).toContain('Category Rules');
+    expect(f).toContain('Name Rules');
+    expect(f).toContain('Categories');
+  });
+
+  it('shows seeded category rule after load', async () => {
+    const r = rules();
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).toContain('Whole Foods');
+    });
+  });
+
+  it('Tab cycles to Name Rules section', async () => {
+    const r = rules();
+    await waitFor(() => expect(frame(r)).toContain('Category Rules'));
+    r.stdin.write('\t');
+    await waitFor(() => {
+      // Name Rules section is now active — its label should be highlighted (non-dimmed)
+      // We can check we're in name rules by pressing Tab again to get to Categories
+      expect(frame(r)).toContain('Name Rules');
+    });
+  });
+
+  it('Tab Tab cycles to Categories section showing seeded categories', async () => {
+    const r = rules();
+    await waitFor(() => expect(frame(r)).toContain('Category Rules'));
+    r.stdin.write('\t');
+    r.stdin.write('\t');
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).toContain('Grocery');
+      expect(f).toContain('Dining');
+    });
+  });
+
+  it('pressing nav number calls onNavigate', async () => {
+    const onNavigate = vi.fn();
+    const r = render(
+      <W><Rules onNavigate={onNavigate} showHints={false} /></W>,
+    );
+    await waitFor(() => expect(frame(r)).toContain('Category Rules'));
+    r.stdin.write('1');
+    expect(onNavigate).toHaveBeenCalledWith('dashboard');
+  });
+});
+
+// ── Accounts ──────────────────────────────────────────────────────────────────
+
+describe('Accounts', () => {
+  function accounts(overrides?: Partial<Parameters<typeof Accounts>[0]>) {
+    return render(
+      <W>
+        <Accounts onNavigate={noop} showHints={false} {...overrides} />
+      </W>,
+    );
+  }
+
+  it('renders app title and Accounts tab', () => {
+    const r = accounts();
+    const f = frame(r);
+    expect(f).toContain('fungible');
+    expect(f).toContain('Accounts');
+  });
+
+  it('shows seeded accounts after load', async () => {
+    const r = accounts();
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).toContain('Test Checking');
+      expect(f).toContain('Test Visa');
+    });
+  });
+
+  it('Tab cycles to Add Data view', async () => {
+    const r = accounts();
+    await waitFor(() => expect(frame(r)).toContain('Test Checking'));
+    r.stdin.write('\t');
+    await waitFor(() => expect(frame(r)).toContain('Add Data'));
+  });
+
+  it('pressing nav number calls onNavigate', async () => {
+    const onNavigate = vi.fn();
+    const r = render(
+      <W><Accounts onNavigate={onNavigate} showHints={false} /></W>,
+    );
+    await waitFor(() => expect(frame(r)).toContain('Accounts'));
+    r.stdin.write('1');
+    expect(onNavigate).toHaveBeenCalledWith('dashboard');
+  });
+});
+
+// ── Health ────────────────────────────────────────────────────────────────────
+
+describe('Health', () => {
+  function health(overrides?: Partial<Parameters<typeof Health>[0]>) {
+    return render(
+      <W>
+        <Health onNavigate={noop} showHints={false} {...overrides} />
+      </W>,
+    );
+  }
+
+  it('renders app title and screen header', () => {
+    const r = health();
+    const f = frame(r);
+    expect(f).toContain('fungible');
+    expect(f).toContain('Financial Health');
+  });
+
+  it('shows SNAPSHOT section', async () => {
+    const r = health();
+    await waitFor(() => expect(frame(r)).toContain('SNAPSHOT'));
+  });
+
+  it('shows RUNWAY section', async () => {
+    const r = health();
+    await waitFor(() => expect(frame(r)).toContain('RUNWAY'));
+  });
+
+  it('shows RETIREMENT section', async () => {
+    const r = health();
+    await waitFor(() => expect(frame(r)).toContain('RETIREMENT'));
+  });
+
+  it('shows ASSUMPTIONS section', async () => {
+    const r = health();
+    await waitFor(() => expect(frame(r)).toContain('ASSUMPTIONS'));
+  });
+
+  it('pressing nav number calls onNavigate', async () => {
+    const onNavigate = vi.fn();
+    const r = render(
+      <W><Health onNavigate={onNavigate} showHints={false} /></W>,
+    );
+    await waitFor(() => expect(frame(r)).toContain('Financial Health'));
+    r.stdin.write('1');
+    expect(onNavigate).toHaveBeenCalledWith('dashboard');
+  });
+});
+
+// ── App smoke test ────────────────────────────────────────────────────────────
+// Renders the full component tree (App → screen + Chat) to catch startup crashes
+// that screen-level tests miss.
+
+describe('App', () => {
+  it('mounts and shows the dashboard without crashing', async () => {
+    const r = render(<App />);
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).toContain('fungible');
+      expect(f).toContain('Dashboard');
+    });
+  });
+
+  it('pressing 2 switches to Transactions screen', async () => {
+    const r = render(<App />);
+    await waitFor(() => expect(frame(r)).toContain('Dashboard'));
+    r.stdin.write('2');
+    await waitFor(() => expect(frame(r)).toContain('Transactions'));
+  });
+
+  it('pressing 1 from Transactions returns to Dashboard', async () => {
+    const r = render(<App />);
+    await waitFor(() => expect(frame(r)).toContain('Dashboard'));
+    r.stdin.write('2');
+    await waitFor(() => expect(frame(r)).toContain('Transactions'));
+    r.stdin.write('1');
+    await waitFor(() => expect(frame(r)).toContain('Dashboard'));
+  });
+
+  it('h key toggles hint text', async () => {
+    const r = render(<App />);
+    await waitFor(() => expect(frame(r)).toContain('fungible'));
+    // hints off by default — pressing h shows them
+    r.stdin.write('h');
+    await waitFor(() => expect(frame(r)).toContain('[h]'));
+  });
+});

--- a/tests/tui/screens.test.tsx
+++ b/tests/tui/screens.test.tsx
@@ -29,7 +29,7 @@ function frame(r: ReturnType<typeof render>): string {
   return (r.lastFrame() ?? '').replace(ANSI_RE, '');
 }
 
-async function waitFor(assertion: () => void, timeout = 2000): Promise<void> {
+async function waitFor(assertion: () => void, timeout = 1000): Promise<void> {
   const deadline = Date.now() + timeout;
   let lastErr: unknown;
   while (Date.now() < deadline) {
@@ -148,8 +148,7 @@ describe('Dashboard', () => {
     const r = dash();
     await waitFor(() => expect(frame(r)).toContain('Income'));
     r.stdin.write('/');
-    // Search bar should appear with the cursor indicator
-    await waitFor(() => expect(frame(r)).toContain('/'));
+    await waitFor(() => expect(frame(r)).toContain('▊'));
   });
 
   it('d key toggles delta mode label', async () => {
@@ -238,10 +237,7 @@ describe('Transactions', () => {
     const r = txns();
     await waitFor(() => expect(frame(r)).toContain('Whole Foods'));
     r.stdin.write('/');
-    await waitFor(() => {
-      const f = frame(r);
-      expect(f).toContain('/');
-    });
+    await waitFor(() => expect(frame(r)).toContain('Esc cancel'));
   });
 
   it('s key cycles sort order label', async () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,6 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    include: ['tests/**/*.test.ts'],
+    include: ['tests/**/*.test.ts', 'tests/**/*.test.tsx'],
   },
 });


### PR DESCRIPTION
## Summary

- Adds `ink-testing-library` and 56 TUI tests covering all 8 screens (Dashboard, Transactions, Trends, NetWorth, Tags, Rules, Accounts, Health) plus a full-app smoke test
- Tests cover initial render, async data loading, keyboard interactions (Tab, `r`, `/`, `s`, `d`, `a`, `h`, Escape, nav numbers), and `onNavigate` call assertions
- Seed data and `MAY_FILTER` anchor fix tests to May 2026 so they never depend on the real date
- Also includes the agent `show` tool navigation enhancements (`search`, `range`, `anchor` params) that enable `initialFilter` support in Tags and Trends

## Test plan

- [x] All 338 tests pass (`npm test`)
- [x] Search-mode assertions use unambiguous markers (`▊` cursor in Dashboard, `Esc cancel` in Transactions)
- [x] `waitFor` timeout halved from 2 s to 1 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)