### PR TITLE
fix: color consistency across Dashboard, Rules, and Accounts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fungible",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fungible",
-      "version": "1.3.7",
+      "version": "1.3.8",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.98.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fungible",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "description": "Terminal UI for personal finance — Plaid sync, CSV import, AI assistant, and MCP server",
   "type": "module",
   "homepage": "https://github.com/tomfunk/fungible",

--- a/tui/Accounts.tsx
+++ b/tui/Accounts.tsx
@@ -14,7 +14,7 @@ import {
 import type { Screen, TxFilter } from './App.js';
 import { truncate, Divider } from './fmt.js';
 import { NavHints, handleNavKey } from './nav.js';
-import { useTerminalWidth, CURSOR, MONTHS, SUBTYPE_DISPLAY, C_POSITIVE, C_NEGATIVE, C_WARNING, C_NEUTRAL, C_ACCENT } from './ui.js';
+import { useTerminalWidth, CURSOR, MONTHS, SUBTYPE_DISPLAY, C_POSITIVE, C_NEGATIVE, C_WARNING, C_NEUTRAL, C_ACCENT, C_MANUAL, C_DIM } from './ui.js';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -580,9 +580,9 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
 
       <Box marginTop={1}>
         <Box gap={3}>
-          <Text bold color={mainView === 'accounts' ? C_NEUTRAL : undefined} dimColor={mainView !== 'accounts'}>Accounts</Text>
-          <Text bold color={mainView === 'add-data' ? C_NEUTRAL : undefined} dimColor={mainView !== 'add-data'}>Add Data</Text>
-          <Text bold color={mainView === 'dupes' ? C_NEUTRAL : undefined} dimColor={mainView !== 'dupes'}>
+          <Text bold color={mainView === 'accounts' ? C_ACCENT : undefined} dimColor={mainView !== 'accounts'}>Accounts</Text>
+          <Text bold color={mainView === 'add-data' ? C_ACCENT : undefined} dimColor={mainView !== 'add-data'}>Add Data</Text>
+          <Text bold color={mainView === 'dupes' ? C_ACCENT : undefined} dimColor={mainView !== 'dupes'}>
             Dupes{dupes.length > 0 ? ` (${dupes.length})` : ''}
           </Text>
           {showHints && <Text dimColor>[Tab]</Text>}
@@ -625,7 +625,7 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
                     <Text color={isSelected ? C_ACCENT : undefined} dimColor={!isSelected}>
                       {truncate(acct.nickname ?? acct.name, acctNameW).padEnd(acctNameW)}
                     </Text>
-                    <Text dimColor={!isSelected} color={isSelected && acct.nickname ? C_WARNING : undefined}>{acct.nickname ? '✎' : ' '}</Text>
+                    <Text dimColor={!isSelected} color={isSelected && acct.nickname ? C_MANUAL : undefined}>{acct.nickname ? '✎' : ' '}</Text>
                     <Text dimColor>{acct.mask ? `···${acct.mask}` : '      '}</Text>
                     <Text dimColor>{label}</Text>
                     <Text dimColor>{institution.padEnd(acctInstW)}</Text>
@@ -709,7 +709,7 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
                   <Text color={editField === 'subtype' ? C_ACCENT : C_NEUTRAL}>
                     {editField === 'subtype' ? '▶ ' : '  '}Subtype
                   </Text>
-                  <Text color={editField === 'subtype' ? C_ACCENT : C_WARNING}>
+                  <Text color={editField === 'subtype' ? C_ACCENT : C_DIM}>
                     {'← '}{editSubtype || '—'}{'  →'}
                   </Text>
                 </Box>
@@ -894,7 +894,7 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
                   <Text color={newAcctField === 'subtype' ? C_ACCENT : C_NEUTRAL}>
                     {newAcctField === 'subtype' ? '▶ ' : '  '}Subtype
                   </Text>
-                  <Text color={newAcctField === 'subtype' ? C_ACCENT : C_WARNING}>
+                  <Text color={newAcctField === 'subtype' ? C_ACCENT : C_DIM}>
                     {'← '}{newAcctSubtype || '—'}{'  →'}
                   </Text>
                 </Box>

--- a/tui/Dashboard.tsx
+++ b/tui/Dashboard.tsx
@@ -450,7 +450,7 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
                             {isSelected ? '▶ ' : '  '}
                             {row.category.length > nameW ? row.category.slice(0, nameW - 1) + '…' : row.category.padEnd(nameW)}
                           </Text>
-                          <Text color={C_WARNING}>{fmt(row.current).padStart(10)}</Text>
+                          <Text color={C_NEUTRAL}>{fmt(row.current).padStart(10)}</Text>
                           <Text color={color}>{fmtDelta(row.lastPeriodDelta).padStart(9)}</Text>
                           <Text color={color}>{fmtDelta(row.lastYearDelta).padStart(9)}</Text>
                           <Text color={color}>{fmtDelta(row.avg12mDelta).padStart(9)}</Text>
@@ -472,7 +472,7 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
                             {isSelected ? '▶ ' : '  '}
                             {row.category.length > dashCatNameW ? row.category.slice(0, dashCatNameW - 1) + '…' : row.category.padEnd(dashCatNameW)}
                           </Text>
-                          <Text color={C_WARNING}>{fmt(row.total).padStart(10)}</Text>
+                          <Text color={C_NEUTRAL}>{fmt(row.total).padStart(10)}</Text>
                           <Text color={C_ACCENT} dimColor={!isSelected}>
                             {bar(row.total, maxCategorySpend, dashBarW)}
                           </Text>
@@ -505,7 +505,7 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
                     return (
                       <Box key={key} gap={2}>
                         <Text color={color}>{'  '}{label.padEnd(16)}</Text>
-                        <Text color={C_WARNING}>{fmt(slice.current).padStart(10)}</Text>
+                        <Text color={C_NEUTRAL}>{fmt(slice.current).padStart(10)}</Text>
                         <Text color={color}>{fmtDelta(slice.lastPeriodDelta).padStart(9)}</Text>
                         <Text color={color}>{fmtDelta(slice.lastYearDelta).padStart(9)}</Text>
                         <Text color={color}>{fmtDelta(slice.avg12mDelta).padStart(9)}</Text>
@@ -521,7 +521,7 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
                     return (
                       <Box key={key} gap={2}>
                         <Text color={color}>{'  '}{label.padEnd(16)}</Text>
-                        <Text color={C_WARNING}>{fmt(amount).padStart(10)}</Text>
+                        <Text color={C_NEUTRAL}>{fmt(amount).padStart(10)}</Text>
                         <Text dimColor>{pct(amount, totalExpenses).padStart(4)}</Text>
                         <Text color={color}>{bar(amount, totalExpenses, dashFlexBarW)}</Text>
                       </Box>

--- a/tui/Rules.tsx
+++ b/tui/Rules.tsx
@@ -332,7 +332,7 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
       <Box justifyContent="space-between" marginTop={1}>
         <Box gap={3}>
           {SECTIONS.map((s) => (
-            <Text key={s} bold color={section === s ? C_NEUTRAL : undefined} dimColor={section !== s}>
+            <Text key={s} bold color={section === s ? C_ACCENT : undefined} dimColor={section !== s}>
               {s === 'rules' ? 'Category Rules' : s === 'names' ? 'Name Rules' : 'Categories'}
             </Text>
           ))}


### PR DESCRIPTION
## Summary

- **Dashboard** category, flex, and account spend amounts: `C_WARNING` → `C_NEUTRAL` — yellow is for caution signals; the heatmap color on the row name already carries semantic meaning, the number itself is neutral
- **Rules** section tabs + **Accounts** view tabs: `C_NEUTRAL` → `C_ACCENT` when active — matches Dashboard's existing range-button pattern where the active selection is cyan
- **Accounts** nickname indicator `✎`: `C_WARNING` → `C_MANUAL` — it marks a manual override (magenta is explicitly for that), not a warning condition
- **Accounts** type editor inactive subtype value: `C_WARNING` → `C_DIM` — an inactive field showing yellow incorrectly implies something needs attention

## Test plan

- [x] `npm run typecheck` passes
- [x] All 338 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)