### PR TITLE
fix: keep last N backup files instead of pruning by calendar days

### DIFF
--- a/core/backup.ts
+++ b/core/backup.ts
@@ -20,15 +20,11 @@ export async function backupDb(): Promise<void> {
     await fs.promises.copyFile(DB_PATH, backupPath);
   }
 
-  const cutoffDate = new Date();
-  cutoffDate.setDate(cutoffDate.getDate() - keepDays);
-  const cutoff = cutoffDate.toISOString().slice(0, 10);
+  const files = fs.readdirSync(BACKUP_DIR)
+    .filter(f => /^fungible\.\d{4}-\d{2}-\d{2}\.bak$/.test(f))
+    .sort();
 
-  for (const file of fs.readdirSync(BACKUP_DIR)) {
-    const match = file.match(/^fungible\.(\d{4}-\d{2}-\d{2})\.bak$/);
-    if (!match) continue;
-    if (match[1] < cutoff) {
-      fs.unlinkSync(path.join(BACKUP_DIR, file));
-    }
+  for (const file of files.slice(0, -keepDays)) {
+    fs.unlinkSync(path.join(BACKUP_DIR, file));
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fungible",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "description": "Terminal UI for personal finance — Plaid sync, CSV import, AI assistant, and MCP server",
   "type": "module",
   "homepage": "https://github.com/tomfunk/fungible",


### PR DESCRIPTION
## Summary
- Backup pruning now keeps the most recent N files by count rather than deleting files older than N calendar days
- Fixes a bug where returning after 8+ days of inactivity could wipe all backups (old anchor was today, so any backup from before the window was deleted)
- `FUNGIBLE_BACKUP_DAYS` env var still controls the count, defaulting to 7

## Test plan
- [ ] Verify backups accumulate correctly on repeated runs
- [ ] Verify only the oldest file is removed when count exceeds limit
- [ ] Verify inactive periods no longer cause backup loss

🤖 Generated with [Claude Code](https://claude.com/claude-code)