### PR TITLE
docs: clarify backup retention is last N files, not N calendar days

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ A terminal UI for personal finance. Syncs transactions from [Plaid](https://plai
 - **Regex search** — `/` on Dashboard or Transactions filters by name using a regular expression; search is shared when navigating between Dashboard, Transactions, and Trends
 - **MCP server** — Claude can read and manage your finances via the Model Context Protocol
 - **HTTP API** — REST-style API server for scripting and automation
-- **Daily backups** — database is backed up to `~/.fungible/backups/` on startup once per day; defaults to 7 days retention, configurable via `FUNGIBLE_BACKUP_DAYS`
+- **Daily backups** — database is backed up to `~/.fungible/backups/` on startup once per day; keeps the last 7 backups by default, configurable via `FUNGIBLE_BACKUP_DAYS`
 
 ## Try it (no account needed)
 


### PR DESCRIPTION
Follows up on #38 — updates the README to accurately describe the new backup behavior (keeps last N files) rather than the old wording ("N days retention").

🤖 Generated with [Claude Code](https://claude.com/claude-code)