### PR TITLE
feat: user-definable Plaid transaction history window

### DIFF
--- a/core/db.ts
+++ b/core/db.ts
@@ -106,6 +106,7 @@ export async function initDb() {
     'ALTER TABLE name_rules ADD COLUMN max_amount REAL',
     "ALTER TABLE categories ADD COLUMN flexibility TEXT CHECK(flexibility IN ('fixed','flexible','discretionary'))",
     'ALTER TABLE plaid_items ADD COLUMN last_synced_at INTEGER',
+    'ALTER TABLE plaid_items ADD COLUMN days_requested INTEGER',
     'ALTER TABLE accounts ADD COLUMN nickname TEXT',
   ];
   for (const sql of migrations) {

--- a/core/plaid.ts
+++ b/core/plaid.ts
@@ -23,13 +23,15 @@ export function getPlaidClient(): PlaidApi {
   return new PlaidApi(config);
 }
 
-export async function createLinkToken(userId: string) {
+export async function createLinkToken(userId: string, daysRequested?: number) {
   const response = await getPlaidClient().linkTokenCreate({
     user: { client_user_id: userId },
     client_name: 'Fungible',
     products: [Products.Transactions],
     country_codes: [CountryCode.Us],
     language: 'en',
+    // Omitting transactions lets Plaid apply its 90-day default
+    ...(daysRequested ? { transactions: { days_requested: daysRequested } } : {}),
   });
   return response.data.link_token;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fungible",
-  "version": "1.3.9",
+  "version": "1.3.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fungible",
-      "version": "1.3.10",
+      "version": "1.3.11",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.98.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fungible",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fungible",
-      "version": "1.3.8",
+      "version": "1.3.10",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.98.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fungible",
-  "version": "1.3.10",
+  "version": "1.3.11",
   "description": "Terminal UI for personal finance — Plaid sync, CSV import, AI assistant, and MCP server",
   "type": "module",
   "homepage": "https://github.com/tomfunk/fungible",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fungible",
-  "version": "1.3.9",
+  "version": "1.3.10",
   "description": "Terminal UI for personal finance — Plaid sync, CSV import, AI assistant, and MCP server",
   "type": "module",
   "homepage": "https://github.com/tomfunk/fungible",

--- a/scripts/link.ts
+++ b/scripts/link.ts
@@ -100,10 +100,21 @@ function successPage() {
 </html>`;
 }
 
+// History window (days of transactions Plaid backfills) is set by the TUI via
+// PLAID_DAYS_REQUESTED. It's locked at Item creation and can't be changed later.
+function resolveDaysRequested(): number | undefined {
+  const raw = process.env.PLAID_DAYS_REQUESTED;
+  if (!raw) return undefined;
+  const n = parseInt(raw, 10);
+  if (isNaN(n)) return undefined;
+  return Math.max(30, Math.min(730, n));
+}
+
 async function main() {
   await initDb();
   console.log('Creating Plaid link token...');
-  const linkToken = await createLinkToken('local-user');
+  const daysRequested = resolveDaysRequested();
+  const linkToken = await createLinkToken('local-user', daysRequested);
 
   const server = http.createServer(async (req, res) => {
     if (req.method === 'GET' && req.url === '/') {
@@ -123,10 +134,10 @@ async function main() {
           const institutionName = institution?.name ?? null;
 
           await db.execute({
-            sql: `INSERT INTO plaid_items (item_id, access_token, institution_name)
-                  VALUES (?, ?, ?)
-                  ON CONFLICT(item_id) DO UPDATE SET access_token=excluded.access_token, institution_name=excluded.institution_name`,
-            args: [itemId, encryptToken(accessToken), institutionName],
+            sql: `INSERT INTO plaid_items (item_id, access_token, institution_name, days_requested)
+                  VALUES (?, ?, ?, ?)
+                  ON CONFLICT(item_id) DO UPDATE SET access_token=excluded.access_token, institution_name=excluded.institution_name, days_requested=excluded.days_requested`,
+            args: [itemId, encryptToken(accessToken), institutionName, daysRequested ?? null],
           });
 
           res.writeHead(200, { 'Content-Type': 'text/html' });

--- a/tests/helpers/makeTestDb.ts
+++ b/tests/helpers/makeTestDb.ts
@@ -69,7 +69,8 @@ const SCHEMA = `
     item_id TEXT PRIMARY KEY,
     access_token TEXT NOT NULL,
     institution_name TEXT,
-    last_synced_at INTEGER
+    last_synced_at INTEGER,
+    days_requested INTEGER
   );
 
   CREATE TABLE balance_history (

--- a/tui/Accounts.tsx
+++ b/tui/Accounts.tsx
@@ -86,7 +86,7 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
   const [addStep, setAddStep] = useState<AddStep>('landing');
   const [linkStatus, setLinkStatus] = useState<'idle' | 'running' | 'done' | 'error'>('idle');
   const [linkMsg, setLinkMsg] = useState('');
-  const [daysInput, setDaysInput] = useState('90');
+  const [daysInput, setDaysInput] = useState('730');
   const [daysError, setDaysError] = useState('');
 
   // CSV import state
@@ -239,7 +239,7 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
     loadAccounts();
   }
 
-  function startPlaidLink(days = 90) {
+  function startPlaidLink(days = 730) {
     setLinkStatus('running');
     setLinkMsg('Opening browser…');
     const node = process.execPath;
@@ -407,7 +407,7 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
 
       if (input === 'r' && linkedAccounts[acctCursor]) {
         setMainView('add-data');
-        setDaysInput('90');
+        setDaysInput('730');
         setDaysError('');
         setAddStep('link-days');
         return;
@@ -444,7 +444,7 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
     if (addStep === 'landing') {
       if (key.escape) { setMainView('accounts'); return; }
       if (key.tab) { setMainView('dupes'); return; }
-      if (input === 'l') { setDaysInput('90'); setDaysError(''); setAddStep('link-days'); return; }
+      if (input === 'l') { setDaysInput('730'); setDaysError(''); setAddStep('link-days'); return; }
       if (input === 'c') { setAddStep('file'); return; }
       if (input === 'm') { setManualName(''); setAddStep('manual-name'); return; }
       if (input === 's' && syncStatus === 'idle') { forceSync(); return; }
@@ -794,7 +794,7 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
           {addStep === 'link-days' && (
             <Box flexDirection="column" marginTop={1} gap={1}>
               <Text bold>Transaction History Window</Text>
-              <Text dimColor>How many days of history should Plaid fetch? (30–730, default 90)</Text>
+              <Text dimColor>How many days of history should Plaid fetch? (30–730, default 730)</Text>
               <Text dimColor>This is set when the bank is linked and can only be changed if you recreate the link later.</Text>
               <Box>
                 <Text>Days: </Text>

--- a/tui/Accounts.tsx
+++ b/tui/Accounts.tsx
@@ -24,6 +24,7 @@ type EditField = 'type' | 'subtype';
 
 type AddStep =
   | 'landing'
+  | 'link-days'
   | 'link-plaid'
   | 'file'
   | 'map-date'
@@ -85,6 +86,8 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
   const [addStep, setAddStep] = useState<AddStep>('landing');
   const [linkStatus, setLinkStatus] = useState<'idle' | 'running' | 'done' | 'error'>('idle');
   const [linkMsg, setLinkMsg] = useState('');
+  const [daysInput, setDaysInput] = useState('90');
+  const [daysError, setDaysError] = useState('');
 
   // CSV import state
   const [filePath, setFilePath] = useState('');
@@ -126,7 +129,7 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
   const [dupeCursor, setDupeCursor] = useState(0);
 
   const setTyping = useSetTyping();
-  const TEXT_INPUT_STEPS = new Set<AddStep>(['file', 'manual-name', 'manual-value', 'new-acct-name']);
+  const TEXT_INPUT_STEPS = new Set<AddStep>(['link-days', 'file', 'manual-name', 'manual-value', 'new-acct-name']);
   const TEXT_INPUT_MODES = new Set<AcctMode>(['nickname', 'update-value']);
   useEffect(() => {
     setTyping(TEXT_INPUT_STEPS.has(addStep) || TEXT_INPUT_MODES.has(acctMode));
@@ -236,7 +239,7 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
     loadAccounts();
   }
 
-  function startPlaidLink() {
+  function startPlaidLink(days = 90) {
     setLinkStatus('running');
     setLinkMsg('Opening browser…');
     const node = process.execPath;
@@ -245,7 +248,10 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
       '--no-warnings',
       '--import', 'tsx/esm',
       script,
-    ], { cwd: new URL('..', import.meta.url).pathname });
+    ], {
+      cwd: new URL('..', import.meta.url).pathname,
+      env: { ...process.env, PLAID_DAYS_REQUESTED: String(days) },
+    });
     child.stdout.on('data', (data: Buffer) => {
       const line = data.toString().trim().split('\n').pop() ?? '';
       if (line) setLinkMsg(line);
@@ -401,8 +407,9 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
 
       if (input === 'r' && linkedAccounts[acctCursor]) {
         setMainView('add-data');
-        setAddStep('link-plaid');
-        startPlaidLink();
+        setDaysInput('90');
+        setDaysError('');
+        setAddStep('link-days');
         return;
       }
       if (input === 's' && syncStatus === 'idle') { forceSync(); return; }
@@ -437,10 +444,25 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
     if (addStep === 'landing') {
       if (key.escape) { setMainView('accounts'); return; }
       if (key.tab) { setMainView('dupes'); return; }
-      if (input === 'l') { setAddStep('link-plaid'); startPlaidLink(); return; }
+      if (input === 'l') { setDaysInput('90'); setDaysError(''); setAddStep('link-days'); return; }
       if (input === 'c') { setAddStep('file'); return; }
       if (input === 'm') { setManualName(''); setAddStep('manual-name'); return; }
       if (input === 's' && syncStatus === 'idle') { forceSync(); return; }
+      return;
+    }
+
+    if (addStep === 'link-days') {
+      if (key.escape) { setAddStep('landing'); setDaysError(''); return; }
+      if (key.return) {
+        const n = parseInt(daysInput, 10);
+        if (isNaN(n) || n < 30 || n > 730) { setDaysError('Enter a whole number from 30 to 730'); return; }
+        setDaysError('');
+        setAddStep('link-plaid');
+        startPlaidLink(n);
+        return;
+      }
+      if (key.backspace || key.delete) { setDaysInput((v) => v.slice(0, -1)); setDaysError(''); return; }
+      if (input && /^[0-9]+$/.test(input) && !key.ctrl && !key.meta) { setDaysInput((v) => v + input); setDaysError(''); return; }
       return;
     }
 
@@ -766,6 +788,20 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
               </Box>
               {syncMsg && <Box marginTop={1}><Text color={syncStatus === 'syncing' ? C_WARNING : C_POSITIVE}>{syncMsg}</Text></Box>}
               <Box marginTop={1}><Text dimColor>Tab or Esc to go back</Text></Box>
+            </Box>
+          )}
+
+          {addStep === 'link-days' && (
+            <Box flexDirection="column" marginTop={1} gap={1}>
+              <Text bold>Transaction History Window</Text>
+              <Text dimColor>How many days of history should Plaid fetch? (30–730, default 90)</Text>
+              <Text dimColor>This is set when the bank is linked and can only be changed if you recreate the link later.</Text>
+              <Box>
+                <Text>Days: </Text>
+                <Text>{daysInput}<Text color={C_ACCENT}>{CURSOR}</Text></Text>
+              </Box>
+              {daysError && <Text color={C_NEGATIVE}>{daysError}</Text>}
+              <Text dimColor>Enter to continue · Esc back</Text>
             </Box>
           )}
 

--- a/tui/Accounts.tsx
+++ b/tui/Accounts.tsx
@@ -462,7 +462,7 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
         return;
       }
       if (key.backspace || key.delete) { setDaysInput((v) => v.slice(0, -1)); setDaysError(''); return; }
-      if (input && /^[0-9]+$/.test(input) && !key.ctrl && !key.meta) { setDaysInput((v) => v + input); setDaysError(''); return; }
+      if (input && /^[0-9]+$/.test(input) && !key.ctrl && !key.meta && daysInput.length <= 3) { setDaysInput((v) => v + input); setDaysError(''); return; }
       return;
     }
 


### PR DESCRIPTION
* feat: user-definable Plaid transaction history window

Let users choose how many days of transaction history Plaid backfills (30-730, default 90) when linking or repairing a bank from Accounts -> Add Data. Both the new-link ([l]) and repair-link ([r]) flows now route through a "days" prompt before opening Plaid.

The window is passed to scripts/link.ts via PLAID_DAYS_REQUESTED, sent to Plaid as transactions.days_requested at link-token creation, and persisted in a new plaid_items.days_requested column.

The window is locked at Item creation and can't be changed afterward, so the prompt surfaces that. Omitting the value preserves Plaid's 90-day default, keeping the unchanged Setup-wizard link path identical.
