### PR TITLE
fix: await async DB writes before reloading accounts list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fungible",
-  "version": "1.3.8",
+  "version": "1.3.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fungible",
-      "version": "1.3.8",
+      "version": "1.3.11",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.98.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fungible",
-  "version": "1.3.10",
+  "version": "1.3.11",
   "description": "Terminal UI for personal finance — Plaid sync, CSV import, AI assistant, and MCP server",
   "type": "module",
   "homepage": "https://github.com/tomfunk/fungible",

--- a/tests/tui/screens.test.tsx
+++ b/tests/tui/screens.test.tsx
@@ -17,6 +17,7 @@ import { NetWorth } from '../../tui/NetWorth.js';
 import { Tags } from '../../tui/Tags.js';
 import { Rules } from '../../tui/Rules.js';
 import { Accounts } from '../../tui/Accounts.js';
+import * as accountsApi from '../../core/accounts.js';
 import { Health } from '../../tui/Health.js';
 import { RefreshProvider } from '../../tui/RefreshContext.js';
 import { TypingContext } from '../../tui/TypingContext.js';
@@ -600,6 +601,85 @@ describe('Accounts', () => {
     await waitFor(() => expect(frame(r)).toContain('Accounts'));
     r.stdin.write('1');
     expect(onNavigate).toHaveBeenCalledWith('dashboard');
+  });
+
+  // Regression guards for the stale-list bug: the mutation DB calls are async, so
+  // the list must reload only AFTER the write commits. The handlers must await the
+  // write before calling loadAccounts(); otherwise the reload reads pre-mutation
+  // data and the list never reflects the change.
+  //
+  // In-memory libsql applies an un-awaited write before the next read, so the race
+  // can't be observed at face value. We reproduce the real-world DB latency by
+  // delaying the write ~60ms: with the bug, loadAccounts() reads stale data while
+  // the write is still in flight and the list never updates; with the fix, the
+  // reload is chained off the write and shows fresh data.
+  const WRITE_DELAY = 60;
+  function delayWrite<A extends unknown[], R>(fn: (...a: A) => Promise<R>) {
+    return (...args: A): Promise<R> =>
+      new Promise((res) => setTimeout(res, WRITE_DELAY)).then(() => fn(...args));
+  }
+  afterEach(() => vi.restoreAllMocks());
+
+  it('setting a nickname refreshes the list to show the new nickname', async () => {
+    const real = accountsApi.updateAccountNickname;
+    vi.spyOn(accountsApi, 'updateAccountNickname').mockImplementation(delayWrite(real));
+
+    const r = accounts();
+    // Cursor starts on the first account (depository sorts first = Test Checking).
+    await waitFor(() => expect(frame(r)).toContain('Test Checking'));
+    r.stdin.write('n');                 // open nickname editor
+    await waitFor(() => expect(frame(r)).toContain('Leave empty to clear nickname'));
+    r.stdin.write('Vacation Fund');     // type the nickname
+    await waitFor(() => expect(frame(r)).toContain('Vacation Fund'));
+    r.stdin.write('\r');                // save (separate chunk so it isn't merged with the text)
+    // The list row now shows the nickname in place of the account name. Asserting
+    // the original name is gone proves the list reloaded with post-write data (the
+    // status toast that mentions the nickname never contains the original name).
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).toContain('Vacation Fund');
+      expect(f).not.toContain('Test Checking');
+    });
+  });
+
+  it('deleting an account refreshes the list to drop it', async () => {
+    const real = accountsApi.deleteAccount;
+    vi.spyOn(accountsApi, 'deleteAccount').mockImplementation(delayWrite(real));
+
+    const r = accounts();
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).toContain('Test Checking');
+      expect(f).toContain('2 accounts');
+    });
+    r.stdin.write('x');                 // confirm-delete panel
+    await waitFor(() => expect(frame(r)).toContain('this cannot be undone'));
+    r.stdin.write('y');                 // confirm
+    // The account-count line reflects the reloaded list independently of the
+    // "Deleted …" status toast (which still mentions the deleted account name).
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).toContain('1 account');
+      expect(f).toContain('Test Visa');
+    });
+  });
+
+  it('surfaces an error and leaves the list unchanged when a write fails', async () => {
+    vi.spyOn(accountsApi, 'updateAccountNickname').mockRejectedValue(new Error('db down'));
+
+    const r = accounts();
+    await waitFor(() => expect(frame(r)).toContain('Test Checking'));
+    r.stdin.write('n');
+    await waitFor(() => expect(frame(r)).toContain('Leave empty to clear nickname'));
+    r.stdin.write('Vacation Fund');
+    await waitFor(() => expect(frame(r)).toContain('Vacation Fund'));
+    r.stdin.write('\r');                 // save → write rejects
+    // A failed write must show an error rather than a (false) success, and the
+    // account must keep its original name.
+    await waitFor(() => expect(frame(r)).toContain('Failed to save nickname'));
+    const f = frame(r);
+    expect(f).toContain('Test Checking');
+    expect(f).not.toContain('Nickname set to');
   });
 });
 

--- a/tui/Accounts.tsx
+++ b/tui/Accounts.tsx
@@ -78,6 +78,7 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
   const [editType, setEditType] = useState('');
   const [editSubtype, setEditSubtype] = useState('');
   const [acctMsg, setAcctMsg] = useState('');
+  const [acctErr, setAcctErr] = useState('');
 
   // Sync state (shared)
   const [syncStatus, setSyncStatus] = useState<'idle' | 'syncing' | 'done'>('idle');
@@ -167,15 +168,25 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
     setAcctMode('edit');
   }
 
-  function saveEdit() {
+  // Surface a write failure in red; clears itself after a few seconds (mirrors syncMsg).
+  function showAcctErr(msg: string) {
+    setAcctErr(msg);
+    setTimeout(() => setAcctErr(''), 3000);
+  }
+
+  async function saveEdit() {
     const acct = linkedAccounts[acctCursor];
     if (!acct) return;
-    void updateAccountTypeSubtype(acct.id, editType, editSubtype.trim() || null).then(() => {
+    try {
+      await updateAccountTypeSubtype(acct.id, editType, editSubtype.trim() || null);
       setAcctMode('list');
+      setAcctErr('');
       setAcctMsg(`Updated ${acct.name}`);
       setTimeout(() => setAcctMsg(''), 2500);
       loadAccounts();
-    });
+    } catch {
+      showAcctErr(`Failed to update ${acct.name}`);
+    }
   }
 
   function forceSync() {
@@ -204,50 +215,66 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
     });
   }
 
-  function saveManualAsset() {
+  async function saveManualAsset() {
     const value = parseFloat(manualValue.replace(/[$,]/g, ''));
     if (isNaN(value) || value < 0) { setManualValueError('Enter a valid positive number'); return; }
-    void createManualAccount(manualName, value).then(() => {
+    try {
+      await createManualAccount(manualName, value);
       setAddStep('manual-done');
       loadAccounts();
-    });
+    } catch {
+      setManualValueError('Failed to save asset — please try again');
+    }
   }
 
-  function handleDeleteAccount() {
+  async function handleDeleteAccount() {
     const acct = linkedAccounts[acctCursor];
     if (!acct) return;
-    void deleteAccount(acct.id).then(() => {
+    try {
+      await deleteAccount(acct.id);
       setAcctMode('list');
       setAcctCursor((c) => Math.max(0, c - 1));
+      setAcctErr('');
       setAcctMsg(`Deleted ${acct.nickname ?? acct.name}`);
       setTimeout(() => setAcctMsg(''), 2500);
       loadAccounts();
-    });
+    } catch {
+      setAcctMode('list');
+      showAcctErr(`Failed to delete ${acct.nickname ?? acct.name}`);
+    }
   }
 
-  function saveNickname() {
+  async function saveNickname() {
     const acct = linkedAccounts[acctCursor];
     if (!acct) return;
     const nickname = nicknameInput.trim() || null;
-    void updateAccountNickname(acct.id, nickname).then(() => {
+    try {
+      await updateAccountNickname(acct.id, nickname);
       setAcctMode('list');
+      setAcctErr('');
       setAcctMsg(nickname ? `Nickname set to "${nickname}"` : 'Nickname cleared');
       setTimeout(() => setAcctMsg(''), 2500);
       loadAccounts();
-    });
+    } catch {
+      showAcctErr('Failed to save nickname');
+    }
   }
 
-  function saveUpdatedValue() {
+  async function saveUpdatedValue() {
     const acct = linkedAccounts[acctCursor];
     if (!acct) return;
     const value = parseFloat(updateValueInput.replace(/[$,]/g, ''));
     if (isNaN(value) || value < 0) { setUpdateValueError('Enter a valid positive number'); return; }
-    void updateAccountValue(acct.id, value).then(() => {
+    try {
+      await updateAccountValue(acct.id, value);
       setAcctMode('list');
+      setAcctErr('');
       setAcctMsg(`Updated value for ${acct.name}`);
       setTimeout(() => setAcctMsg(''), 2500);
       loadAccounts();
-    });
+    } catch {
+      setUpdateValueError('Failed to update value — please try again');
+    }
   }
 
   function startPlaidLink(days = 730) {
@@ -343,7 +370,7 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
     if (mainView === 'accounts') {
       if (acctMode === 'edit') {
         if (key.escape) { setAcctMode('list'); return; }
-        if (key.return) { saveEdit(); return; }
+        if (key.return) { void saveEdit(); return; }
         if (key.tab) {
           setEditField((f) => f === 'type' ? 'subtype' : 'type');
           return;
@@ -374,7 +401,7 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
 
       if (acctMode === 'update-value') {
         if (key.escape) { setAcctMode('list'); setUpdateValueInput(''); setUpdateValueError(''); return; }
-        if (key.return) { saveUpdatedValue(); return; }
+        if (key.return) { void saveUpdatedValue(); return; }
         if (key.backspace || key.delete) { setUpdateValueInput((v) => v.slice(0, -1)); setUpdateValueError(''); return; }
         if (input && !key.ctrl && !key.meta) { setUpdateValueInput((v) => v + input); setUpdateValueError(''); return; }
         return;
@@ -382,7 +409,7 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
 
       if (acctMode === 'nickname') {
         if (key.escape) { setAcctMode('list'); setNicknameInput(''); return; }
-        if (key.return) { saveNickname(); return; }
+        if (key.return) { void saveNickname(); return; }
         if (key.backspace || key.delete) { setNicknameInput((v) => v.slice(0, -1)); return; }
         if (input && !key.ctrl && !key.meta) { setNicknameInput((v) => v + input); return; }
         return;
@@ -390,7 +417,7 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
 
       if (acctMode === 'confirm-delete') {
         if (key.escape || input === 'n') { setAcctMode('list'); return; }
-        if (input === 'y') { handleDeleteAccount(); return; }
+        if (input === 'y') { void handleDeleteAccount(); return; }
         return;
       }
 
@@ -587,7 +614,7 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
 
     if (addStep === 'manual-value') {
       if (key.escape) { setAddStep('manual-name'); return; }
-      if (key.return) { saveManualAsset(); return; }
+      if (key.return) { void saveManualAsset(); return; }
       if (key.backspace || key.delete) { setManualValue((v) => v.slice(0, -1)); setManualValueError(''); return; }
       if (input && !key.ctrl && !key.meta) { setManualValue((v) => v + input); setManualValueError(''); return; }
       return;
@@ -678,6 +705,7 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
           <Text dimColor>{linkedAccounts.length} account{linkedAccounts.length !== 1 ? 's' : ''}</Text>
           {syncMsg && <Text color={syncStatus === 'syncing' ? C_WARNING : C_POSITIVE}>{syncMsg}</Text>}
           {acctMsg && <Text color={C_POSITIVE}>{acctMsg}</Text>}
+          {acctErr && <Text color={C_NEGATIVE}>{acctErr}</Text>}
 
           {/* Confirm-delete panel */}
           {acctMode === 'confirm-delete' && selectedAcct && (

--- a/tui/Accounts.tsx
+++ b/tui/Accounts.tsx
@@ -161,11 +161,12 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
   function saveEdit() {
     const acct = linkedAccounts[acctCursor];
     if (!acct) return;
-    updateAccountTypeSubtype(acct.id, editType, editSubtype.trim() || null);
-    setAcctMode('list');
-    setAcctMsg(`Updated ${acct.name}`);
-    setTimeout(() => setAcctMsg(''), 2500);
-    loadAccounts();
+    void updateAccountTypeSubtype(acct.id, editType, editSubtype.trim() || null).then(() => {
+      setAcctMode('list');
+      setAcctMsg(`Updated ${acct.name}`);
+      setTimeout(() => setAcctMsg(''), 2500);
+      loadAccounts();
+    });
   }
 
   function forceSync() {
@@ -197,31 +198,34 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
   function saveManualAsset() {
     const value = parseFloat(manualValue.replace(/[$,]/g, ''));
     if (isNaN(value) || value < 0) { setManualValueError('Enter a valid positive number'); return; }
-    createManualAccount(manualName, value);
-    setAddStep('manual-done');
-    loadAccounts();
+    void createManualAccount(manualName, value).then(() => {
+      setAddStep('manual-done');
+      loadAccounts();
+    });
   }
 
   function handleDeleteAccount() {
     const acct = linkedAccounts[acctCursor];
     if (!acct) return;
-    deleteAccount(acct.id);
-    setAcctMode('list');
-    setAcctCursor((c) => Math.max(0, c - 1));
-    setAcctMsg(`Deleted ${acct.nickname ?? acct.name}`);
-    setTimeout(() => setAcctMsg(''), 2500);
-    loadAccounts();
+    void deleteAccount(acct.id).then(() => {
+      setAcctMode('list');
+      setAcctCursor((c) => Math.max(0, c - 1));
+      setAcctMsg(`Deleted ${acct.nickname ?? acct.name}`);
+      setTimeout(() => setAcctMsg(''), 2500);
+      loadAccounts();
+    });
   }
 
   function saveNickname() {
     const acct = linkedAccounts[acctCursor];
     if (!acct) return;
     const nickname = nicknameInput.trim() || null;
-    updateAccountNickname(acct.id, nickname);
-    setAcctMode('list');
-    setAcctMsg(nickname ? `Nickname set to "${nickname}"` : 'Nickname cleared');
-    setTimeout(() => setAcctMsg(''), 2500);
-    loadAccounts();
+    void updateAccountNickname(acct.id, nickname).then(() => {
+      setAcctMode('list');
+      setAcctMsg(nickname ? `Nickname set to "${nickname}"` : 'Nickname cleared');
+      setTimeout(() => setAcctMsg(''), 2500);
+      loadAccounts();
+    });
   }
 
   function saveUpdatedValue() {
@@ -229,11 +233,12 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
     if (!acct) return;
     const value = parseFloat(updateValueInput.replace(/[$,]/g, ''));
     if (isNaN(value) || value < 0) { setUpdateValueError('Enter a valid positive number'); return; }
-    updateAccountValue(acct.id, value);
-    setAcctMode('list');
-    setAcctMsg(`Updated value for ${acct.name}`);
-    setTimeout(() => setAcctMsg(''), 2500);
-    loadAccounts();
+    void updateAccountValue(acct.id, value).then(() => {
+      setAcctMode('list');
+      setAcctMsg(`Updated value for ${acct.name}`);
+      setTimeout(() => setAcctMsg(''), 2500);
+      loadAccounts();
+    });
   }
 
   function startPlaidLink() {


### PR DESCRIPTION
loadAccounts() was firing before the DB mutation completed, causing the refreshed list to show stale data. Fixed for deleteAccount, updateAccountTypeSubtype, updateAccountNickname, updateAccountValue, and createManualAccount.

Closes #46 