### PR TITLE
fix: start-date step followups (skip, async save error, render cleanup, DB tests)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fungible",
-  "version": "1.3.12",
+  "version": "1.3.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fungible",
-      "version": "1.3.12",
+      "version": "1.3.13",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.98.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fungible",
-  "version": "1.3.12",
+  "version": "1.3.13",
   "description": "Terminal UI for personal finance — Plaid sync, CSV import, AI assistant, and MCP server",
   "type": "module",
   "homepage": "https://github.com/tomfunk/fungible",

--- a/tests/settings-db.test.ts
+++ b/tests/settings-db.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../core/db.js', async () => {
+  const { makeTestDb } = await import('./helpers/makeTestDb.js');
+  return { db: await makeTestDb() };
+});
+
+import {
+  getSetting, setSetting, getDefaultDaysRequested,
+  DEFAULT_START_DATE_KEY, MAX_DAYS_REQUESTED,
+} from '../core/settings.js';
+
+describe('getSetting / setSetting', () => {
+  it('returns null for an unset key', async () => {
+    expect(await getSetting('_missing_key_xyz_')).toBeNull();
+  });
+
+  it('stores and retrieves a value', async () => {
+    await setSetting('_test_roundtrip_', 'hello');
+    expect(await getSetting('_test_roundtrip_')).toBe('hello');
+  });
+
+  it('upserts — second write replaces the first', async () => {
+    await setSetting('_test_upsert_', 'v1');
+    await setSetting('_test_upsert_', 'v2');
+    expect(await getSetting('_test_upsert_')).toBe('v2');
+  });
+});
+
+describe('getDefaultDaysRequested', () => {
+  it('returns MAX_DAYS_REQUESTED when no start date is set', async () => {
+    expect(await getDefaultDaysRequested()).toBe(MAX_DAYS_REQUESTED);
+  });
+
+  it('returns MAX_DAYS_REQUESTED for a date farther back than 730 days', async () => {
+    await setSetting(DEFAULT_START_DATE_KEY, '2020-01-01');
+    expect(await getDefaultDaysRequested()).toBe(MAX_DAYS_REQUESTED);
+  });
+});

--- a/tui/Setup.tsx
+++ b/tui/Setup.tsx
@@ -128,10 +128,14 @@ export function Setup() {
     return null;
   }
 
-  function saveStartDate() {
+  async function saveStartDate() {
     const value = startDateInput.trim();
-    void setSetting(DEFAULT_START_DATE_KEY, value);
-    setStep('link-choice');
+    try {
+      await setSetting(DEFAULT_START_DATE_KEY, value);
+      setStep('link-choice');
+    } catch {
+      setStartDateError('Failed to save — please try again');
+    }
   }
 
   useInput((input, key) => {
@@ -175,10 +179,11 @@ export function Setup() {
     if (step === 'start-date') {
       if (key.escape) { setStep(alreadyConfigured ? 'welcome' : 'plaid-env'); setStartDateError(''); return; }
       if (key.return) {
+        if (!startDateInput.trim()) { setStep('link-choice'); return; }
         const err = validateStartDate(startDateInput);
         if (err) { setStartDateError(err); return; }
         setStartDateError('');
-        saveStartDate();
+        void saveStartDate();
         return;
       }
       if (key.backspace || key.delete) { setStartDateInput((v) => v.slice(0, -1)); setStartDateError(''); return; }
@@ -215,6 +220,10 @@ export function Setup() {
       return;
     }
   });
+
+  const startDateIsValid = step === 'start-date' && validateStartDate(startDateInput) === null;
+  const startDateRequestedDays = startDateIsValid ? daysFromStartDate(startDateInput.trim()) : null;
+  const startDateCapped = startDateRequestedDays === MAX_DAYS_REQUESTED;
 
   return (
     <Box flexDirection="column" paddingX={3} paddingY={2}>
@@ -297,42 +306,33 @@ export function Setup() {
         </Box>
       )}
 
-      {step === 'start-date' && (() => {
-        const valid = validateStartDate(startDateInput) === null;
-        // Final days_requested for this start date (calendar days + buffer, clamped).
-        const requestedDays = valid ? daysFromStartDate(startDateInput.trim()) : null;
-        const calendarDays = valid
-          ? Math.round((Date.now() - new Date(startDateInput.trim() + 'T12:00:00').getTime()) / 86_400_000)
-          : 0;
-        const capped = calendarDays + START_DATE_BUFFER_DAYS > MAX_DAYS_REQUESTED;
-        return (
-          <Box flexDirection="column" gap={1}>
-            <Text bold>Default history start date</Text>
-            <Text dimColor>
-              How far back should fungible pull transactions when you link a bank?
-              We&apos;ll use this to pre-fill the number of days requested, so you don&apos;t
-              have to do the math.
-            </Text>
-            <Text dimColor>
-              Plaid doesn&apos;t document the timezone it uses for the history window, so we add a
-              {' '}{START_DATE_BUFFER_DAYS}-day buffer to make sure your start date isn&apos;t missed.
-            </Text>
-            <Box marginTop={1}>
-              <Text>Start date (YYYY-MM-DD): </Text>
-              <Text color={C_WARNING}>{startDateInput}</Text>
-              <Text color={C_ACCENT}>█</Text>
-            </Box>
-            {requestedDays != null && (
-              <Text dimColor>= {requestedDays} days of history requested (incl. {START_DATE_BUFFER_DAYS}-day buffer)</Text>
-            )}
-            {capped && (
-              <Text color={C_WARNING}>Plaid limits history to {MAX_DAYS_REQUESTED} days, so it&apos;ll be capped there.</Text>
-            )}
-            {startDateError && <Text color={C_NEGATIVE}>{startDateError}</Text>}
-            <Text dimColor>Enter to save · Esc back</Text>
+      {step === 'start-date' && (
+        <Box flexDirection="column" gap={1}>
+          <Text bold>Default history start date</Text>
+          <Text dimColor>
+            How far back should fungible pull transactions when you link a bank?
+            We&apos;ll use this to pre-fill the number of days requested, so you don&apos;t
+            have to do the math.
+          </Text>
+          <Text dimColor>
+            Plaid doesn&apos;t document the timezone it uses for the history window, so we add a
+            {' '}{START_DATE_BUFFER_DAYS}-day buffer to make sure your start date isn&apos;t missed.
+          </Text>
+          <Box marginTop={1}>
+            <Text>Start date (YYYY-MM-DD): </Text>
+            <Text color={C_WARNING}>{startDateInput}</Text>
+            <Text color={C_ACCENT}>█</Text>
           </Box>
-        );
-      })()}
+          {startDateRequestedDays != null && (
+            <Text dimColor>= {startDateRequestedDays} days of history requested (incl. {START_DATE_BUFFER_DAYS}-day buffer)</Text>
+          )}
+          {startDateCapped && (
+            <Text color={C_WARNING}>Plaid limits history to {MAX_DAYS_REQUESTED} days, so it&apos;ll be capped there.</Text>
+          )}
+          {startDateError && <Text color={C_NEGATIVE}>{startDateError}</Text>}
+          <Text dimColor>Enter to save · Leave blank to skip · Esc back</Text>
+        </Box>
+      )}
 
       {step === 'link-choice' && (
         <Box flexDirection="column" gap={1}>


### PR DESCRIPTION
Follow-up to #45. Addresses the issues flagged in review.

## Changes

- **Skip option** — pressing Enter with a blank start-date field now advances to `link-choice` without saving, so re-running setup to link a new account doesn't force you to re-enter the date
- **Async save error handling** — `saveStartDate` is now `async` and `await`s `setSetting`; a DB write failure surfaces as an inline error message instead of silently advancing
- **Render cleanup** — removed the JSX IIFE; `startDateRequestedDays` and `startDateCapped` are now plain `const` declarations before the `return`. `capped` is derived directly from `daysFromStartDate`'s return value, eliminating the duplicate calendar-day calculation
- **DB integration tests** — new `tests/settings-db.test.ts` covering `getSetting`/`setSetting` (null miss, round-trip, upsert) and `getDefaultDaysRequested` (no key → MAX, old date → MAX)

🤖 Generated with [Claude Code](https://claude.com/claude-code)