### PR TITLE
feat: TUI component library + Health screen polish

### DIFF
--- a/core/fmt.ts
+++ b/core/fmt.ts
@@ -14,3 +14,10 @@ export function fmtMonths(n: number): string {
   if (!isFinite(n) || n > 999) return '∞';
   return `${n.toFixed(1)} mo`;
 }
+
+export function fmtCompact(n: number): string {
+  const abs = Math.abs(n);
+  if (abs >= 1_000_000) return `$${(abs / 1_000_000).toFixed(2)}M`;
+  if (abs >= 10_000)    return `$${(abs / 1_000).toFixed(1)}K`;
+  return fmt(n);
+}

--- a/tests/fmt.test.ts
+++ b/tests/fmt.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { fmt, fmtSigned, fmtPct, fmtMonths } from '../core/fmt.js';
+import { fmt, fmtSigned, fmtPct, fmtMonths, fmtCompact } from '../core/fmt.js';
 import { bar, truncate } from '../tui/charUtils.js';
 
 describe('fmt', () => {
@@ -64,6 +64,28 @@ describe('fmtMonths', () => {
 
   it('returns ∞ for NaN', () => {
     expect(fmtMonths(NaN)).toBe('∞');
+  });
+});
+
+describe('fmtCompact', () => {
+  it('abbreviates millions', () => {
+    expect(fmtCompact(1_838_641.96)).toBe('$1.84M');
+    expect(fmtCompact(3_870_000)).toBe('$3.87M');
+  });
+
+  it('abbreviates ten-thousands and above as K', () => {
+    expect(fmtCompact(68_619.40)).toBe('$68.6K');
+    expect(fmtCompact(21_493.79)).toBe('$21.5K');
+  });
+
+  it('falls through to full fmt below 10K', () => {
+    expect(fmtCompact(5_000)).toBe('$5,000.00');
+    expect(fmtCompact(999)).toBe('$999.00');
+  });
+
+  it('strips sign like fmt does', () => {
+    expect(fmtCompact(-2_000_000)).toBe('$2.00M');
+    expect(fmtCompact(-50_000)).toBe('$50.0K');
   });
 });
 

--- a/tests/navigation.test.ts
+++ b/tests/navigation.test.ts
@@ -46,8 +46,8 @@ const SCREENS = [
  *  1. Inline: lines containing multiple [N] shortcut labels
  *  2. Component: <NavHints current="screenname" /> implies all other screens */
 function extractNavBarKeys(src: string): string[] {
-  // NavHints component: infer all keys except the current screen's
-  const navHintsMatch = src.match(/<NavHints\s+current="([a-z]+)"/);
+  // NavHints or PageHeader component: infer all keys except the current screen's
+  const navHintsMatch = src.match(/<(?:NavHints|PageHeader)\s+current="([a-z]+)"/);
   if (navHintsMatch) {
     const current = navHintsMatch[1];
     return Object.entries(KEY_TO_SCREEN)

--- a/tests/tui/screens.test.tsx
+++ b/tests/tui/screens.test.tsx
@@ -395,6 +395,64 @@ describe('Trends', () => {
     r.stdin.write('1');
     expect(onNavigate).toHaveBeenCalledWith('dashboard');
   });
+
+  it('Tab cycles through the base views in order', async () => {
+    const r = trends();
+    const viewLabels = ['Expenses', 'Income', 'Net', 'Flexibility', 'Fixed', 'Flexible', 'Discretionary'];
+    await waitFor(() => expect(frame(r)).toContain('Expenses'));
+    for (let i = 1; i < viewLabels.length; i++) {
+      r.stdin.write('\t');
+      await waitFor(() => expect(frame(r)).toContain(viewLabels[i]));
+    }
+  });
+
+  it('Net view shows expense/income direction headers', async () => {
+    const r = trends();
+    await waitFor(() => expect(frame(r)).toContain('Expenses'));
+    r.stdin.write('\t'); // Income
+    await waitFor(() => expect(frame(r)).toContain('Income'));
+    r.stdin.write('\t'); // Net
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).toContain('Net');
+      expect(f).toContain('expenses');
+      expect(f).toContain('income');
+    });
+  });
+
+  it('Flexibility view shows fixed/flexible/discr column headers', async () => {
+    const r = trends();
+    await waitFor(() => expect(frame(r)).toContain('Expenses'));
+    for (let i = 0; i < 3; i++) r.stdin.write('\t'); // Expenses→Income→Net→Flexibility
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).toContain('Flexibility');
+      expect(f).toContain('fixed');
+      expect(f).toContain('flexible');
+    });
+  });
+
+  it('shows both seeded periods and Enter navigates to the selected period', async () => {
+    const onNavigate = vi.fn();
+    const r = render(<W><Trends onNavigate={onNavigate} showHints={false} /></W>);
+    // Both Apr and May periods must appear
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).toContain('Apr 2026');
+      expect(f).toContain('May 2026');
+    });
+    // Cursor starts on the last period (May); Enter navigates to its transactions
+    r.stdin.write('\r');
+    await waitFor(() => {
+      expect(onNavigate).toHaveBeenCalledWith('transactions', expect.objectContaining({ from: '2026-05-01' }));
+    });
+  });
+
+
+
+
+
+
 });
 
 // ── Net Worth ─────────────────────────────────────────────────────────────────

--- a/tests/tui/snapshot.test.tsx
+++ b/tests/tui/snapshot.test.tsx
@@ -1,0 +1,128 @@
+/**
+ * Snapshot capture test — renders every screen with seeded data and prints
+ * lastFrame() to a deterministic output file for cross-branch diffing.
+ *
+ * Usage:
+ *   npx vitest run tests/tui/snapshot.test.tsx 2>/dev/null | tee /tmp/snapshot-feat.txt
+ * Then on main:
+ *   npx vitest run tests/tui/snapshot.test.tsx 2>/dev/null | tee /tmp/snapshot-main.txt
+ * Then:
+ *   diff /tmp/snapshot-main.txt /tmp/snapshot-feat.txt
+ */
+import { describe, it, beforeEach, afterEach } from 'vitest';
+import React from 'react';
+import { render, cleanup } from 'ink-testing-library';
+import { vi } from 'vitest';
+
+vi.mock('../../core/db.js', async () => {
+  const { makeTestDb } = await import('../helpers/makeTestDb.js');
+  return { db: await makeTestDb() };
+});
+
+import { db } from '../../core/db.js';
+import { seedTuiData } from '../helpers/seedTuiData.js';
+import { Dashboard } from '../../tui/Dashboard.js';
+import { Transactions } from '../../tui/Transactions.js';
+import { Trends } from '../../tui/Trends.js';
+import { NetWorth } from '../../tui/NetWorth.js';
+import { Tags } from '../../tui/Tags.js';
+import { Rules } from '../../tui/Rules.js';
+import { Accounts } from '../../tui/Accounts.js';
+import { Health } from '../../tui/Health.js';
+import { RefreshProvider } from '../../tui/RefreshContext.js';
+import { TypingContext } from '../../tui/TypingContext.js';
+
+const ANSI_RE = /\x1b\[[0-9;]*[mGKHFABCDJ]/g;
+function frame(r: ReturnType<typeof render>): string {
+  return (r.lastFrame() ?? '').replace(ANSI_RE, '');
+}
+async function waitFor(assertion: () => void, timeout = 1000): Promise<void> {
+  const deadline = Date.now() + timeout;
+  let lastErr: unknown;
+  while (Date.now() < deadline) {
+    try { assertion(); return; } catch (e) { lastErr = e; }
+    await new Promise((res) => setTimeout(res, 30));
+  }
+  throw lastErr;
+}
+function W({ children }: { children: React.ReactNode }) {
+  return (
+    <RefreshProvider>
+      <TypingContext.Provider value={() => {}}>
+        {children}
+      </TypingContext.Provider>
+    </RefreshProvider>
+  );
+}
+const MAY_FILTER = { range: 'month' as const, anchor: '2026-05-15' };
+const noop = () => {};
+
+beforeEach(async () => {
+  for (const tbl of ['transactions', 'accounts', 'categories', 'tags', 'transaction_tags',
+                     'category_rules', 'name_rules', 'hidden_categories', 'balance_history']) {
+    await db.execute(`DELETE FROM ${tbl}`);
+  }
+  await seedTuiData(db);
+});
+afterEach(() => cleanup());
+
+function dump(name: string, output: string) {
+  const lines = output.split('\n');
+  console.log(`\n${'='.repeat(60)}`);
+  console.log(`SCREEN: ${name}`);
+  console.log('='.repeat(60));
+  for (const line of lines) console.log(line);
+}
+
+describe('snapshots', () => {
+  it('dashboard', async () => {
+    const r = render(<W><Dashboard onNavigate={noop} showHints isActive initialFilter={MAY_FILTER} /></W>);
+    await waitFor(() => { if (!r.lastFrame()?.includes('fungible')) throw new Error(); });
+    await waitFor(() => { if (!r.lastFrame()?.includes('Income')) throw new Error(); });
+    dump('dashboard', frame(r));
+  });
+
+  it('transactions', async () => {
+    const r = render(<W><Transactions onNavigate={noop} showHints isActive initialFilter={MAY_FILTER} /></W>);
+    await waitFor(() => { if (!r.lastFrame()?.includes('Transactions')) throw new Error(); });
+    await waitFor(() => { if (!r.lastFrame()?.includes('DATE')) throw new Error(); });
+    dump('transactions', frame(r));
+  });
+
+  it('trends', async () => {
+    const r = render(<W><Trends onNavigate={noop} showHints isActive /></W>);
+    await waitFor(() => { if (!r.lastFrame()?.includes('Trends')) throw new Error(); });
+    await waitFor(() => { if (!r.lastFrame()?.includes('Month')) throw new Error(); });
+    dump('trends', frame(r));
+  });
+
+  it('networth', async () => {
+    const r = render(<W><NetWorth onNavigate={noop} showHints isActive /></W>);
+    await waitFor(() => { if (!r.lastFrame()?.includes('Net Worth')) throw new Error(); });
+    dump('networth', frame(r));
+  });
+
+  it('tags', async () => {
+    const r = render(<W><Tags onNavigate={noop} showHints isActive /></W>);
+    await waitFor(() => { if (!r.lastFrame()?.includes('Tags')) throw new Error(); });
+    dump('tags', frame(r));
+  });
+
+  it('health', async () => {
+    const r = render(<W><Health onNavigate={noop} showHints isActive /></W>);
+    await waitFor(() => { if (!r.lastFrame()?.includes('Financial Health')) throw new Error(); });
+    dump('health', frame(r));
+  });
+
+  it('rules', async () => {
+    const r = render(<W><Rules onNavigate={noop} showHints isActive /></W>);
+    await waitFor(() => { if (!r.lastFrame()?.includes('rules')) throw new Error(); });
+    dump('rules', frame(r));
+  });
+
+  it('accounts', async () => {
+    const r = render(<W><Accounts onNavigate={noop} showHints isActive /></W>);
+    await waitFor(() => { if (!r.lastFrame()?.includes('Accounts')) throw new Error(); });
+    dump('accounts', frame(r));
+  });
+});

--- a/tui/Accounts.tsx
+++ b/tui/Accounts.tsx
@@ -14,9 +14,9 @@ import {
 } from '../core/accounts.js';
 import type { Screen, TxFilter } from './App.js';
 import { truncate, Divider } from './fmt.js';
-import { NavHints, handleNavKey } from './nav.js';
+import { handleNavKey } from './nav.js';
 import { useTerminalWidth, MONTHS, SUBTYPE_DISPLAY, C_POSITIVE, C_NEGATIVE, C_WARNING, C_NEUTRAL, C_ACCENT, C_MANUAL, C_DIM } from './ui.js';
-import { ModalPanel, TextInput, SelectableRow, useStatusMessage } from './components/index.js';
+import { ModalPanel, TextInput, SelectableRow, useStatusMessage, PageHeader } from './components/index.js';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -619,11 +619,7 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
 
   return (
     <Box flexDirection="column" paddingX={2} paddingY={1}>
-      {/* Header */}
-      <Box justifyContent="space-between">
-        <Text bold color={C_ACCENT}>fungible</Text>
-        <NavHints current="accounts" showHints={showHints} />
-      </Box>
+      <PageHeader current="accounts" showHints={showHints} />
 
       <Box marginTop={1}>
         <Box gap={3}>

--- a/tui/Accounts.tsx
+++ b/tui/Accounts.tsx
@@ -15,7 +15,8 @@ import {
 import type { Screen, TxFilter } from './App.js';
 import { truncate, Divider } from './fmt.js';
 import { NavHints, handleNavKey } from './nav.js';
-import { useTerminalWidth, CURSOR, MONTHS, SUBTYPE_DISPLAY, C_POSITIVE, C_NEGATIVE, C_WARNING, C_NEUTRAL, C_ACCENT, C_MANUAL, C_DIM } from './ui.js';
+import { useTerminalWidth, MONTHS, SUBTYPE_DISPLAY, C_POSITIVE, C_NEGATIVE, C_WARNING, C_NEUTRAL, C_ACCENT, C_MANUAL, C_DIM } from './ui.js';
+import { ModalPanel, TextInput, SelectableRow, useStatusMessage } from './components/index.js';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -77,8 +78,8 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
   const [editField, setEditField] = useState<EditField>('type');
   const [editType, setEditType] = useState('');
   const [editSubtype, setEditSubtype] = useState('');
-  const [acctMsg, setAcctMsg] = useState('');
-  const [acctErr, setAcctErr] = useState('');
+  const { statusMsg: acctMsg, showStatus: showAcctMsg } = useStatusMessage(2500);
+  const { statusMsg: acctErr, showStatus: showAcctErr } = useStatusMessage(3000);
 
   // Sync state (shared)
   const [syncStatus, setSyncStatus] = useState<'idle' | 'syncing' | 'done'>('idle');
@@ -168,21 +169,13 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
     setAcctMode('edit');
   }
 
-  // Surface a write failure in red; clears itself after a few seconds (mirrors syncMsg).
-  function showAcctErr(msg: string) {
-    setAcctErr(msg);
-    setTimeout(() => setAcctErr(''), 3000);
-  }
-
   async function saveEdit() {
     const acct = linkedAccounts[acctCursor];
     if (!acct) return;
     try {
       await updateAccountTypeSubtype(acct.id, editType, editSubtype.trim() || null);
       setAcctMode('list');
-      setAcctErr('');
-      setAcctMsg(`Updated ${acct.name}`);
-      setTimeout(() => setAcctMsg(''), 2500);
+      showAcctMsg(`Updated ${acct.name}`);
       loadAccounts();
     } catch {
       showAcctErr(`Failed to update ${acct.name}`);
@@ -234,9 +227,7 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
       await deleteAccount(acct.id);
       setAcctMode('list');
       setAcctCursor((c) => Math.max(0, c - 1));
-      setAcctErr('');
-      setAcctMsg(`Deleted ${acct.nickname ?? acct.name}`);
-      setTimeout(() => setAcctMsg(''), 2500);
+      showAcctMsg(`Deleted ${acct.nickname ?? acct.name}`);
       loadAccounts();
     } catch {
       setAcctMode('list');
@@ -251,9 +242,7 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
     try {
       await updateAccountNickname(acct.id, nickname);
       setAcctMode('list');
-      setAcctErr('');
-      setAcctMsg(nickname ? `Nickname set to "${nickname}"` : 'Nickname cleared');
-      setTimeout(() => setAcctMsg(''), 2500);
+      showAcctMsg(nickname ? `Nickname set to "${nickname}"` : 'Nickname cleared');
       loadAccounts();
     } catch {
       showAcctErr('Failed to save nickname');
@@ -268,9 +257,7 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
     try {
       await updateAccountValue(acct.id, value);
       setAcctMode('list');
-      setAcctErr('');
-      setAcctMsg(`Updated value for ${acct.name}`);
-      setTimeout(() => setAcctMsg(''), 2500);
+      showAcctMsg(`Updated value for ${acct.name}`);
       loadAccounts();
     } catch {
       setUpdateValueError('Failed to update value — please try again');
@@ -678,10 +665,7 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
                 const label = (SUBTYPE_DISPLAY[raw] ?? raw).padEnd(14);
                 const institution = acct.institution_name ? truncate(acct.institution_name, acctInstW) : '';
                 return (
-                  <Box key={acct.id} gap={2}>
-                    <Text color={isSelected ? C_ACCENT : undefined}>
-                      {isSelected ? '▶ ' : '  '}
-                    </Text>
+                  <SelectableRow key={acct.id} selected={isSelected}>
                     <Text color={isSelected ? C_ACCENT : undefined} dimColor={!isSelected}>
                       {truncate(acct.nickname ?? acct.name, acctNameW).padEnd(acctNameW)}
                     </Text>
@@ -695,7 +679,7 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
                         : <Text color={C_WARNING}>not synced</Text>
                       }
                     </Text>
-                  </Box>
+                  </SelectableRow>
                 );
               })}
             </Box>
@@ -709,7 +693,7 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
 
           {/* Confirm-delete panel */}
           {acctMode === 'confirm-delete' && selectedAcct && (
-            <Box flexDirection="column" marginTop={1} borderStyle="round" borderColor={C_NEGATIVE} paddingX={2} paddingY={1}>
+            <ModalPanel borderColor={C_NEGATIVE}>
               <Text bold color={C_NEGATIVE}>Delete account — this cannot be undone</Text>
               <Box marginTop={1} flexDirection="column">
                 <Text><Text color={C_ACCENT}>{selectedAcct.nickname ?? selectedAcct.name}</Text>  {selectedAcct.mask ? `···${selectedAcct.mask}` : ''}</Text>
@@ -722,41 +706,30 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
                 <Text color={C_NEGATIVE}>[y] Yes, delete</Text>
                 <Text color={C_POSITIVE}>[n] / Esc cancel</Text>
               </Box>
-            </Box>
+            </ModalPanel>
           )}
 
           {/* Nickname panel */}
           {acctMode === 'nickname' && selectedAcct && (
-            <Box flexDirection="column" marginTop={1} borderStyle="round" borderColor={C_WARNING} paddingX={2} paddingY={1}>
-              <Text bold>Nickname: {selectedAcct.name}</Text>
+            <ModalPanel title={`Nickname: ${selectedAcct.name}`} borderColor={C_WARNING}>
               <Text dimColor>Leave empty to clear nickname</Text>
-              <Box marginTop={1}>
-                <Text>Nickname: </Text>
-                <Text color={C_WARNING}>{nicknameInput}</Text>
-                <Text color={C_ACCENT}>{CURSOR}</Text>
-              </Box>
+              <Box marginTop={1} gap={1}><Text>Nickname: </Text><TextInput value={nicknameInput} color={C_WARNING} /></Box>
               <Box marginTop={1}><Text dimColor>Enter save · Esc cancel</Text></Box>
-            </Box>
+            </ModalPanel>
           )}
 
           {/* Update-value panel */}
           {acctMode === 'update-value' && selectedAcct && (
-            <Box flexDirection="column" marginTop={1} borderStyle="round" borderColor={C_WARNING} paddingX={2} paddingY={1}>
-              <Text bold>Update value: {selectedAcct.name}</Text>
-              <Box marginTop={1}>
-                <Text>New value: $</Text>
-                <Text color={C_WARNING}>{updateValueInput}</Text>
-                <Text color={C_ACCENT}>█</Text>
-              </Box>
+            <ModalPanel title={`Update value: ${selectedAcct.name}`} borderColor={C_WARNING}>
+              <Box marginTop={1} gap={1}><Text>New value: $</Text><TextInput value={updateValueInput} color={C_WARNING} /></Box>
               {updateValueError && <Text color={C_NEGATIVE}>{updateValueError}</Text>}
               <Box marginTop={1}><Text dimColor>Enter save · Esc cancel</Text></Box>
-            </Box>
+            </ModalPanel>
           )}
 
           {/* Edit panel */}
           {acctMode === 'edit' && selectedAcct && (
-            <Box flexDirection="column" marginTop={1} borderStyle="round" borderColor={C_ACCENT} paddingX={2} paddingY={1}>
-              <Text bold>Edit: {selectedAcct.name}{selectedAcct.mask ? ` ···${selectedAcct.mask}` : ''}</Text>
+            <ModalPanel title={`Edit: ${selectedAcct.name}${selectedAcct.mask ? ` ···${selectedAcct.mask}` : ''}`}>
               <Box marginTop={1} flexDirection="column" gap={1}>
                 <Box gap={2}>
                   <Text color={editField === 'type' ? C_ACCENT : C_NEUTRAL}>
@@ -775,7 +748,7 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
                   </Text>
                 </Box>
               </Box>
-            </Box>
+            </ModalPanel>
           )}
         </>
       )}
@@ -835,10 +808,7 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
               <Text bold>Transaction History Window</Text>
               <Text dimColor>How many days of history should Plaid fetch? (30–{MAX_DAYS_REQUESTED}, default {defaultDays})</Text>
               <Text dimColor>Default comes from the start date set during setup (plus a small buffer for timezone safety). This is locked in when the bank is linked and can only be changed if you recreate the link later.</Text>
-              <Box>
-                <Text>Days: </Text>
-                <Text>{daysInput}<Text color={C_ACCENT}>{CURSOR}</Text></Text>
-              </Box>
+              <Box gap={1}><Text>Days: </Text><TextInput value={daysInput} /></Box>
               {daysError && <Text color={C_NEGATIVE}>{daysError}</Text>}
               <Text dimColor>Enter to continue · Esc back</Text>
             </Box>
@@ -862,10 +832,7 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
           {addStep === 'file' && (
             <Box flexDirection="column" marginTop={1} gap={1}>
               <Text dimColor>Enter the path to your CSV file:</Text>
-              <Box>
-                <Text>Path: </Text>
-                <Text color={C_WARNING}>{filePath}<Text color={C_ACCENT}>█</Text></Text>
-              </Box>
+              <Box gap={1}><Text>Path: </Text><TextInput value={filePath} color={C_WARNING} /></Box>
               {fileError && <Text color={C_NEGATIVE}>{fileError}</Text>}
               <Text dimColor>Press Enter to load · Esc back</Text>
             </Box>
@@ -885,13 +852,12 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
                 {headers.map((h, i) => {
                   const sample = csvRows.slice(0, 3).map((r) => r[i] ?? '').filter(Boolean).join(', ');
                   return (
-                    <Box key={i} gap={2}>
+                    <SelectableRow key={i} selected={i === colCursor}>
                       <Text color={i === colCursor ? C_ACCENT : C_NEUTRAL} dimColor={i !== colCursor}>
-                        {i === colCursor ? '▶ ' : '  '}
                         {h.padEnd(24)}
                         <Text dimColor>  {truncate(sample, 36)}</Text>
                       </Text>
-                    </Box>
+                    </SelectableRow>
                   );
                 })}
               </Box>
@@ -927,12 +893,12 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
               <Text dimColor>↑↓ select · Enter confirm · [n] new account</Text>
               <Box flexDirection="column" marginTop={1}>
                 {csvAccounts.map((acct, i) => (
-                  <Box key={acct.id} gap={2}>
+                  <SelectableRow key={acct.id} selected={i === csvAccountCursor}>
                     <Text color={i === csvAccountCursor ? C_ACCENT : C_NEUTRAL} dimColor={i !== csvAccountCursor}>
-                      {i === csvAccountCursor ? '▶ ' : '  '}{acct.name}
+                      {acct.name}
                       <Text dimColor>  {acct.mask ? `···${acct.mask}` : ''}</Text>
                     </Text>
-                  </Box>
+                  </SelectableRow>
                 ))}
               </Box>
               {csvAccounts.length === 0 && <Text dimColor>No accounts yet — press [n] to create one.</Text>}
@@ -943,11 +909,7 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
             <Box flexDirection="column" marginTop={1} gap={1}>
               <Text bold>New Account — Name</Text>
               <Text dimColor>Type a name for this account (e.g. "Venture X", "Freedom Unlimited")</Text>
-              <Box marginTop={1}>
-                <Text>Name: </Text>
-                <Text color={C_WARNING}>{newAcctName}</Text>
-                <Text color={C_ACCENT}>█</Text>
-              </Box>
+              <Box marginTop={1} gap={1}><Text>Name: </Text><TextInput value={newAcctName} color={C_WARNING} /></Box>
               <Text dimColor>Enter to continue · Esc back</Text>
             </Box>
           )}
@@ -1021,11 +983,7 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
             <Box flexDirection="column" marginTop={1} gap={1}>
               <Text bold>Manual Asset — Name</Text>
               <Text dimColor>Type a name for this asset (e.g. "House", "Car")</Text>
-              <Box marginTop={1}>
-                <Text>Name: </Text>
-                <Text color={C_WARNING}>{manualName}</Text>
-                <Text color={C_ACCENT}>█</Text>
-              </Box>
+              <Box marginTop={1} gap={1}><Text>Name: </Text><TextInput value={manualName} color={C_WARNING} /></Box>
               <Text dimColor>Enter to continue · Esc cancel</Text>
             </Box>
           )}
@@ -1034,11 +992,7 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
             <Box flexDirection="column" marginTop={1} gap={1}>
               <Text bold>Manual Asset — Current Value</Text>
               <Text dimColor>Asset: <Text color={C_ACCENT}>{manualName}</Text></Text>
-              <Box marginTop={1}>
-                <Text>Value: $</Text>
-                <Text color={C_WARNING}>{manualValue}</Text>
-                <Text color={C_ACCENT}>█</Text>
-              </Box>
+              <Box marginTop={1} gap={1}><Text>Value: $</Text><TextInput value={manualValue} color={C_WARNING} /></Box>
               {manualValueError && <Text color={C_NEGATIVE}>{manualValueError}</Text>}
               <Text dimColor>Enter to save · Esc back</Text>
             </Box>

--- a/tui/Chat.tsx
+++ b/tui/Chat.tsx
@@ -5,6 +5,7 @@ import type { Message } from '../core/llm-provider.js';
 import { detectProvider, getProviderModel } from '../core/llm-provider.js';
 import { truncate } from './fmt.js';
 import { CURSOR, C_POSITIVE, C_NEGATIVE, C_WARNING, C_ACCENT, C_DIM } from './ui.js';
+import { TextInput } from './components/index.js';
 import type { Screen, TxFilter } from './App.js';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -260,8 +261,7 @@ export function Chat({
       {isActive && !confirm && (
         <Box>
           <Text color={C_ACCENT}>› </Text>
-          <Text>{input}</Text>
-          {!isStreaming && <Text color={C_ACCENT}>{CURSOR}</Text>}
+          <TextInput value={input} showCursor={!isStreaming} />
         </Box>
       )}
     </Box>

--- a/tui/Dashboard.tsx
+++ b/tui/Dashboard.tsx
@@ -14,7 +14,8 @@ import {
 import type { Screen, TxFilter } from './App.js';
 import { fmt, fmtSigned, bar, Divider, truncate } from './fmt.js';
 import { NavHints, handleNavKey } from './nav.js';
-import { useTerminalWidth, CURSOR, FLEX_COLORS, C_POSITIVE, C_NEGATIVE, C_WARNING, C_NEUTRAL, C_MANUAL, C_ACCENT } from './ui.js';
+import { useTerminalWidth, FLEX_COLORS, C_POSITIVE, C_NEGATIVE, C_WARNING, C_NEUTRAL, C_MANUAL, C_ACCENT } from './ui.js';
+import { StatCard, SectionHeader, SelectableRow, TextInput } from './components/index.js';
 import { useSetTyping } from './TypingContext.js';
 import { useRefreshKey } from './RefreshContext.js';
 
@@ -397,7 +398,7 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
         <Box gap={2} marginTop={1}>
           <Text color={C_ACCENT}>/</Text>
           {searchMode ? (
-            <Text>{searchInput}<Text color={C_ACCENT}>{CURSOR}</Text></Text>
+            <TextInput value={searchInput} />
           ) : (
             <Text color={C_ACCENT}>{search}</Text>
           )}
@@ -424,13 +425,15 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
             <Text dimColor>Delta not available for All Time range.</Text>
           ) : (
             <>
-              <Box gap={2} marginBottom={0}>
-                <Text dimColor>{''.padEnd(2)}</Text>
-                <Text dimColor>{'Account'.padEnd(dashAcctNameW)}</Text>
-                {driftMode
-                  ? <Text dimColor>{'vs prev'.padStart(10)}</Text>
-                  : <Text dimColor>{'Income'.padStart(10)}</Text>}
-                <Text dimColor>{'Expenses'.padStart(10)}</Text>
+              <Box marginBottom={0}>
+                <Text dimColor>{'  '}</Text>
+                <Box gap={2}>
+                  <Text dimColor>{'Account'.padEnd(dashAcctNameW)}</Text>
+                  {driftMode
+                    ? <Text dimColor>{'vs prev'.padStart(10)}</Text>
+                    : <Text dimColor>{'Income'.padStart(10)}</Text>}
+                  <Text dimColor>{'Expenses'.padStart(10)}</Text>
+                </Box>
               </Box>
               {accountRows.map((acct, i) => {
                 const isSelected = i === acctCursor;
@@ -438,8 +441,7 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
                 const drift = driftMode ? acctDrift?.find((d) => d.id === acct.id) : undefined;
                 const spendColor = drift ? driftColor(drift.current, drift.avg12m) : C_NEGATIVE;
                 return (
-                  <Box key={acct.id} gap={2}>
-                    <Text color={isSelected ? C_ACCENT : undefined}>{isSelected ? '▶' : ' '}</Text>
+                  <SelectableRow key={acct.id} selected={isSelected}>
                     <Text color={isFiltered ? C_WARNING : isSelected ? C_ACCENT : undefined} dimColor={!isSelected && !isFiltered}>
                       {(acct.name.length > dashAcctNameW ? acct.name.slice(0, dashAcctNameW - 1) + '…' : acct.name).padEnd(dashAcctNameW)}
                     </Text>
@@ -452,7 +454,7 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
                       {(acct.spending > 0 ? fmt(acct.spending) : '—').padStart(10)}
                     </Text>
                     {isFiltered && <Text color={C_WARNING}>  ●</Text>}
-                  </Box>
+                  </SelectableRow>
                 );
               })}
             </>
@@ -464,25 +466,11 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
       ) : displaySummary ? (
         <>
           <Box gap={6} marginY={1}>
-            <Box flexDirection="column">
-              <Text dimColor>Income</Text>
-              <Text color={C_POSITIVE} bold>{fmt(displaySummary.income)}</Text>
-            </Box>
-            <Box flexDirection="column">
-              <Text dimColor>Expenses</Text>
-              <Text color={C_NEGATIVE} bold>{fmt(displaySummary.expenses)}</Text>
-            </Box>
-            <Box flexDirection="column">
-              <Text dimColor>Net</Text>
-              <Text color={displaySummary.net >= 0 ? C_POSITIVE : C_NEGATIVE} bold>
-                {displaySummary.net >= 0 ? '+' : '-'}{fmt(displaySummary.net)}
-              </Text>
-            </Box>
+            <StatCard label="Income" value={fmt(displaySummary.income)} color={C_POSITIVE} />
+            <StatCard label="Expenses" value={fmt(displaySummary.expenses)} color={C_NEGATIVE} />
+            <StatCard label="Net" value={(displaySummary.net >= 0 ? '+' : '-') + fmt(displaySummary.net)} color={displaySummary.net >= 0 ? C_POSITIVE : C_NEGATIVE} />
             {!search && uncategorized > 0 && (
-              <Box flexDirection="column">
-                <Text dimColor>Uncategorized</Text>
-                <Text color={C_WARNING} bold>{uncategorized} txns</Text>
-              </Box>
+              <StatCard label="Uncategorized" value={`${uncategorized} txns`} color={C_WARNING} />
             )}
           </Box>
 
@@ -490,7 +478,7 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
 
           {view === 'categories' ? (
             <Box flexDirection="column" marginTop={1}>
-              <Text bold dimColor>{merchantDrill ? `TOP MERCHANTS · ${merchantDrill.category}` : 'SPENDING BY CATEGORY'}</Text>
+              <SectionHeader>{merchantDrill ? `TOP MERCHANTS · ${merchantDrill.category}` : 'SPENDING BY CATEGORY'}</SectionHeader>
               {merchantDrill ? (
                 <Box flexDirection="column" marginTop={1}>
                   {merchantRows.length === 0 ? (
@@ -499,15 +487,14 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
                     merchantRows.map((row, i) => {
                       const isSelected = merchantCursor === i;
                       return (
-                        <Box key={`${row.merchant}-${i}`} gap={2}>
+                        <SelectableRow key={`${row.merchant}-${i}`} selected={isSelected}>
                           <Text color={isSelected ? C_ACCENT : undefined}>
-                            {isSelected ? '▶ ' : '  '}
                             {truncate(row.merchant, merchantNameW).padEnd(merchantNameW)}
                           </Text>
                           <Text color={C_WARNING}>{fmt(row.total).padStart(10)}</Text>
                           <Text dimColor>{`${row.count}x`.padStart(6)}</Text>
                           <Text dimColor>{`${Math.round(row.pct * 100)}%`.padStart(6)}</Text>
-                        </Box>
+                        </SelectableRow>
                       );
                     })
                   )}
@@ -518,12 +505,15 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
               ) : driftMode ? (
                 <Box flexDirection="column" marginTop={1}>
                   {/* column headers */}
-                  <Box gap={2}>
-                    <Text dimColor>{''.padEnd(2 + driftCatNameW)}</Text>
-                    <Text dimColor>{'amount'.padStart(10)}</Text>
-                    <Text dimColor>{'vs prev'.padStart(9)}</Text>
-                    <Text dimColor>{'yr ago'.padStart(9)}</Text>
-                    <Text dimColor>{'12m avg'.padStart(9)}</Text>
+                  <Box>
+                    <Text dimColor>{'  '}</Text>
+                    <Box gap={2}>
+                      <Text dimColor>{''.padEnd(driftCatNameW)}</Text>
+                      <Text dimColor>{'amount'.padStart(10)}</Text>
+                      <Text dimColor>{'vs prev'.padStart(9)}</Text>
+                      <Text dimColor>{'yr ago'.padStart(9)}</Text>
+                      <Text dimColor>{'12m avg'.padStart(9)}</Text>
+                    </Box>
                   </Box>
                   {(catDrift ?? []).length === 0 ? (
                     <Text dimColor>No expense data for this period.</Text>
@@ -533,16 +523,15 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
                       const color = driftColor(row.current, row.avg12m);
                       const nameW = driftCatNameW;
                       return (
-                        <Box key={`${row.category}-${i}`} gap={2}>
+                        <SelectableRow key={`${row.category}-${i}`} selected={isSelected}>
                           <Text color={isSelected ? C_ACCENT : color}>
-                            {isSelected ? '▶ ' : '  '}
                             {row.category.length > nameW ? row.category.slice(0, nameW - 1) + '…' : row.category.padEnd(nameW)}
                           </Text>
                           <Text color={C_NEUTRAL}>{fmt(row.current).padStart(10)}</Text>
                           <Text color={color}>{fmtDelta(row.lastPeriodDelta).padStart(9)}</Text>
                           <Text color={color}>{fmtDelta(row.lastYearDelta).padStart(9)}</Text>
                           <Text color={color}>{fmtDelta(row.avg12mDelta).padStart(9)}</Text>
-                        </Box>
+                        </SelectableRow>
                       );
                     })
                   )}
@@ -555,16 +544,15 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
                     (displaySummary?.byCategory ?? []).map((row, i) => {
                       const isSelected = catCursor === i;
                       return (
-                        <Box key={`${row.category}-${i}`} gap={2}>
+                        <SelectableRow key={`${row.category}-${i}`} selected={isSelected}>
                           <Text color={isSelected ? C_ACCENT : undefined}>
-                            {isSelected ? '▶ ' : '  '}
                             {row.category.length > dashCatNameW ? row.category.slice(0, dashCatNameW - 1) + '…' : row.category.padEnd(dashCatNameW)}
                           </Text>
                           <Text color={C_NEUTRAL}>{fmt(row.total).padStart(10)}</Text>
                           <Text color={C_ACCENT} dimColor={!isSelected}>
                             {bar(row.total, maxCategorySpend, dashBarW)}
                           </Text>
-                        </Box>
+                        </SelectableRow>
                       );
                     })
                   )}
@@ -573,7 +561,7 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
             </Box>
           ) : (
             <Box flexDirection="column" marginTop={1}>
-              <Text bold dimColor>SPENDING BY FLEXIBILITY</Text>
+              <SectionHeader>SPENDING BY FLEXIBILITY</SectionHeader>
               {driftMode && range === 'alltime' ? (
                 <Box marginTop={1}><Text dimColor>Delta not available for All Time range.</Text></Box>
               ) : driftMode ? (

--- a/tui/Dashboard.tsx
+++ b/tui/Dashboard.tsx
@@ -362,10 +362,10 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
         : <Text dimColor>
             {showHints
               ? (view === 'account'
-                  ? `← → period  ·  ↑↓ select  ·  Enter txns  ·  Space ${selectedAccount ? 'unfilter' : 'filter'}  ·  [c] clear  ·  [Tab] view  ·  [d] delta  ·  [/] search`
+                  ? `[/] search  ·  ← → period  ·  ↑↓ select  ·  Enter txns  ·  Space ${selectedAccount ? 'unfilter' : 'filter'}  ·  [c] clear  ·  [Tab] view  ·  [d] delta`
                   : view === 'categories'
-                    ? `← → period  ·  ↑↓ select  ·  Enter txns${driftMode ? '' : '  ·  [m] merchants'}  ·  [Tab] view  ·  [d] delta  ·  [/] search`
-                    : '← → period  ·  Enter txns  ·  [Tab] view  ·  [d] delta  ·  [/] search')
+                    ? `[/] search  ·  ← → period  ·  ↑↓ select  ·  Enter txns${driftMode ? '' : '  ·  [m] merchants'}  ·  [Tab] view  ·  [d] delta`
+                    : '[/] search  ·  ← → period  ·  Enter txns  ·  [Tab] view  ·  [d] delta')
               : '[/] search'}
           </Text>
       }

--- a/tui/Dashboard.tsx
+++ b/tui/Dashboard.tsx
@@ -13,9 +13,9 @@ import {
 } from '../core/dateUtils.js';
 import type { Screen, TxFilter } from './App.js';
 import { fmt, fmtSigned, bar, Divider, truncate } from './fmt.js';
-import { NavHints, handleNavKey } from './nav.js';
+import { handleNavKey } from './nav.js';
 import { useTerminalWidth, FLEX_COLORS, C_POSITIVE, C_NEGATIVE, C_WARNING, C_NEUTRAL, C_MANUAL, C_ACCENT } from './ui.js';
-import { StatCard, SectionHeader, SelectableRow, TextInput } from './components/index.js';
+import { StatCard, SectionHeader, SelectableRow, TextInput, PageHeader } from './components/index.js';
 import { useSetTyping } from './TypingContext.js';
 import { useRefreshKey } from './RefreshContext.js';
 
@@ -354,10 +354,7 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
 
   return (
     <Box flexDirection="column" paddingX={2} paddingY={1}>
-      <Box justifyContent="space-between">
-        <Text bold color={C_ACCENT}>fungible</Text>
-        <NavHints current="dashboard" showHints={showHints} />
-      </Box>
+      <PageHeader current="dashboard" showHints={showHints} />
 
       <Box justifyContent="space-between" marginTop={1}>
         <Text bold>Dashboard</Text>

--- a/tui/Dashboard.tsx
+++ b/tui/Dashboard.tsx
@@ -356,18 +356,19 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
     <Box flexDirection="column" paddingX={2} paddingY={1}>
       <PageHeader current="dashboard" showHints={showHints} />
 
-      <Box justifyContent="space-between" marginTop={1}>
-        <Text bold>Dashboard</Text>
-        {showHints && <Text dimColor>
-          {merchantDrill
-            ? '← → period  ·  [r] range  ·  ↑↓ merchant  ·  Enter txns  ·  Esc back'
-            : view === 'account'
-            ? `← → period  ·  ↑↓ select  ·  Enter txns  ·  Space ${selectedAccount ? 'unfilter' : 'filter'}  ·  [c] clear  ·  [Tab] view  ·  [d] delta  ·  [/] search`
-            : view === 'categories'
-            ? `← → period  ·  ↑↓ select  ·  Enter txns${driftMode ? '' : '  ·  [m] merchants'}  ·  [Tab] view  ·  [d] delta  ·  [/] search`
-            : '← → period  ·  Enter txns  ·  [Tab] view  ·  [d] delta  ·  [/] search'}
-        </Text>}
-      </Box>
+      <Box marginTop={1}><Text bold>Dashboard</Text></Box>
+      {merchantDrill
+        ? showHints && <Text dimColor>← → period  ·  [r] range  ·  ↑↓ merchant  ·  Enter txns  ·  Esc back</Text>
+        : <Text dimColor>
+            {showHints
+              ? (view === 'account'
+                  ? `← → period  ·  ↑↓ select  ·  Enter txns  ·  Space ${selectedAccount ? 'unfilter' : 'filter'}  ·  [c] clear  ·  [Tab] view  ·  [d] delta  ·  [/] search`
+                  : view === 'categories'
+                    ? `← → period  ·  ↑↓ select  ·  Enter txns${driftMode ? '' : '  ·  [m] merchants'}  ·  [Tab] view  ·  [d] delta  ·  [/] search`
+                    : '← → period  ·  Enter txns  ·  [Tab] view  ·  [d] delta  ·  [/] search')
+              : '[/] search'}
+          </Text>
+      }
 
       <Box justifyContent="space-between" marginTop={1}>
         <Box gap={2}>

--- a/tui/Health.tsx
+++ b/tui/Health.tsx
@@ -1,10 +1,11 @@
 import React, { useState, useEffect } from 'react';
 import { Box, Text, useInput } from 'ink';
 import type { Screen } from './App.js';
-import { Divider } from './fmt.js';
-import { NavHints, handleNavKey } from './nav.js';
+import { fmt, fmtPct, fmtMonths, Divider } from './fmt.js';
+import { handleNavKey } from './nav.js';
 import { loadHealthData, yearsToFire, coastYears, type HealthData } from '../core/health.js';
 import { C_POSITIVE, C_NEGATIVE, C_WARNING, C_NEUTRAL, C_ACCENT } from './ui.js';
+import { SectionHeader, SelectableRow, PageHeader } from './components/index.js';
 import { useRefreshKey } from './RefreshContext.js';
 
 function savingsRateColor(rate: number): string {
@@ -19,8 +20,6 @@ function runwayColor(months: number, green: number, yellow: number): string {
   if (months >= yellow) return C_WARNING;
   return C_NEGATIVE;
 }
-import { fmt, fmtPct, fmtMonths } from './fmt.js';
-import { SectionHeader, SelectableRow } from './components/index.js';
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -122,11 +121,7 @@ export function Health({ onNavigate, isActive, showHints }: { onNavigate: (s: Sc
 
   return (
     <Box flexDirection="column" paddingX={2} paddingY={1}>
-      {/* Nav */}
-      <Box justifyContent="space-between">
-        <Text bold color={C_ACCENT}>fungible</Text>
-        <NavHints current="health" showHints={showHints} />
-      </Box>
+      <PageHeader current="health" showHints={showHints} />
 
       <Box marginTop={1} justifyContent="space-between">
         <Text bold>Financial Health</Text>

--- a/tui/Health.tsx
+++ b/tui/Health.tsx
@@ -20,6 +20,7 @@ function runwayColor(months: number, green: number, yellow: number): string {
   return C_NEGATIVE;
 }
 import { fmt, fmtPct, fmtMonths } from './fmt.js';
+import { SectionHeader, SelectableRow } from './components/index.js';
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -135,7 +136,7 @@ export function Health({ onNavigate, isActive, showHints }: { onNavigate: (s: Sc
 
       {/* ── Snapshot ───────────────────────────────────────────────────────── */}
       <Box flexDirection="column" marginTop={1}>
-        <Text bold dimColor>SNAPSHOT</Text>
+        <SectionHeader>SNAPSHOT</SectionHeader>
         <Box gap={3} marginTop={1}>
           <Text dimColor>{'Savings rate'.padEnd(L)}</Text>
           {savingsRate === null ? (
@@ -168,7 +169,7 @@ export function Health({ onNavigate, isActive, showHints }: { onNavigate: (s: Sc
 
       {/* ── Runway ─────────────────────────────────────────────────────────── */}
       <Box flexDirection="column" marginTop={1}>
-        <Text bold dimColor>RUNWAY</Text>
+        <SectionHeader>RUNWAY</SectionHeader>
         <Box gap={3} marginTop={1}>
           <Text dimColor>{'Cash'.padEnd(L)}</Text>
           <Text bold color={runwayColor(cashMonths, 6, 3)}>
@@ -188,7 +189,7 @@ export function Health({ onNavigate, isActive, showHints }: { onNavigate: (s: Sc
       {/* ── Debt (only shown if there is debt) ─────────────────────────────── */}
       {data.totalDebt > 0 && (
         <Box flexDirection="column" marginTop={1}>
-          <Text bold dimColor>DEBT</Text>
+          <SectionHeader>DEBT</SectionHeader>
           <Box gap={3} marginTop={1}>
             <Text dimColor>{'Net cash'.padEnd(L)}</Text>
             <Text bold color={netCash >= 0 ? C_POSITIVE : C_NEGATIVE}>
@@ -220,7 +221,7 @@ export function Health({ onNavigate, isActive, showHints }: { onNavigate: (s: Sc
 
       {/* ── Retirement ─────────────────────────────────────────────────────── */}
       <Box flexDirection="column" marginTop={1}>
-        <Text bold dimColor>RETIREMENT</Text>
+        <SectionHeader>RETIREMENT</SectionHeader>
         <Box gap={3} marginTop={1}>
           <Text dimColor>{'Net worth'.padEnd(L)}</Text>
           <Text bold color={data.netWorth >= 0 ? C_POSITIVE : C_NEGATIVE}>
@@ -264,65 +265,48 @@ export function Health({ onNavigate, isActive, showHints }: { onNavigate: (s: Sc
 
       {/* ── Assumptions ────────────────────────────────────────────────────── */}
       <Box marginTop={1}><Divider /></Box>
-      <Text bold dimColor>ASSUMPTIONS</Text>
+      <SectionHeader>ASSUMPTIONS</SectionHeader>
 
       <Box flexDirection="column" marginTop={1}>
-        <Box gap={2}>
-          <Text color={currentDial === 'spend' ? C_ACCENT : undefined}>
-            {currentDial === 'spend' ? '▶' : ' '} {'Monthly spending'.padEnd(16)}
-          </Text>
-          <Text color={currentDial === 'spend' ? C_ACCENT : C_NEUTRAL}>
-            {'[ '}{fmt(monthlySpend).padStart(8)}{' ]'}
-          </Text>
+        <SelectableRow selected={currentDial === 'spend'} gap={2}>
+          <Text color={currentDial === 'spend' ? C_ACCENT : undefined}>{'Monthly spending'.padEnd(16)}</Text>
+          <Text color={currentDial === 'spend' ? C_ACCENT : C_NEUTRAL}>{'[ '}{fmt(monthlySpend).padStart(8)}{' ]'}</Text>
           <Text dimColor>
             {currentDial === 'spend'
               ? (spendChanged ? `default ${fmt(defaultSpend)} · [r] reset` : `avg past 12 months  ← → ±${fmt(SPEND_STEP)}`)
               : `avg past 12 months${spendChanged ? ' (modified)' : ''}`}
           </Text>
-        </Box>
+        </SelectableRow>
 
-        <Box gap={2}>
-          <Text color={currentDial === 'savings' ? C_ACCENT : undefined}>
-            {currentDial === 'savings' ? '▶' : ' '} {'Monthly savings'.padEnd(16)}
-          </Text>
-          <Text color={currentDial === 'savings' ? C_ACCENT : C_NEUTRAL}>
-            {'[ '}{fmt(monthlySavings).padStart(8)}{' ]'}
-          </Text>
+        <SelectableRow selected={currentDial === 'savings'} gap={2}>
+          <Text color={currentDial === 'savings' ? C_ACCENT : undefined}>{'Monthly savings'.padEnd(16)}</Text>
+          <Text color={currentDial === 'savings' ? C_ACCENT : C_NEUTRAL}>{'[ '}{fmt(monthlySavings).padStart(8)}{' ]'}</Text>
           <Text dimColor>
             {currentDial === 'savings'
               ? (savingsChanged ? `default ${fmt(defaultSavings)} · [r] reset` : `avg surplus past 12 mo  ← → ±${fmt(SPEND_STEP)}`)
               : `avg surplus past 12 mo${savingsChanged ? ' (modified)' : ''}`}
           </Text>
-        </Box>
+        </SelectableRow>
 
-        <Box gap={2}>
-          <Text color={currentDial === 'withdrawal' ? C_ACCENT : undefined}>
-            {currentDial === 'withdrawal' ? '▶' : ' '} {'Withdrawal rate'.padEnd(16)}
-          </Text>
-          <Text color={currentDial === 'withdrawal' ? C_ACCENT : C_NEUTRAL}>
-            {'[ '}{fmtPct(withdrawal).padStart(8)}{' ]'}
-          </Text>
+        <SelectableRow selected={currentDial === 'withdrawal'} gap={2}>
+          <Text color={currentDial === 'withdrawal' ? C_ACCENT : undefined}>{'Withdrawal rate'.padEnd(16)}</Text>
+          <Text color={currentDial === 'withdrawal' ? C_ACCENT : C_NEUTRAL}>{'[ '}{fmtPct(withdrawal).padStart(8)}{' ]'}</Text>
           <Text dimColor>
             {currentDial === 'withdrawal'
               ? `↑↓ ±${fmtPct(WITHDRAW_STEP)}${withdrawChanged ? ' · [r] reset' : ''}`
               : `safe withdrawal rate${withdrawChanged ? ' (modified)' : ''}`}
           </Text>
-        </Box>
+        </SelectableRow>
 
-        <Box gap={2}>
-          <Text color={currentDial === 'growth' ? C_ACCENT : undefined}>
-            {currentDial === 'growth' ? '▶' : ' '} {'Growth rate'.padEnd(16)}
-          </Text>
-          <Text color={currentDial === 'growth' ? C_ACCENT : C_NEUTRAL}>
-            {'[ '}{fmtPct(growth).padStart(8)}{' ]'}
-          </Text>
+        <SelectableRow selected={currentDial === 'growth'} gap={2}>
+          <Text color={currentDial === 'growth' ? C_ACCENT : undefined}>{'Growth rate'.padEnd(16)}</Text>
+          <Text color={currentDial === 'growth' ? C_ACCENT : C_NEUTRAL}>{'[ '}{fmtPct(growth).padStart(8)}{' ]'}</Text>
           <Text dimColor>
             {currentDial === 'growth'
               ? `↑↓ ±${fmtPct(GROWTH_STEP)}${growthChanged ? ' · [r] reset' : ''}`
               : `real annual return${growthChanged ? ' (modified)' : ''}`}
           </Text>
-        </Box>
-
+        </SelectableRow>
       </Box>
     </Box>
   );

--- a/tui/Health.tsx
+++ b/tui/Health.tsx
@@ -124,10 +124,8 @@ export function Health({ onNavigate, isActive, showHints }: { onNavigate: (s: Sc
     <Box flexDirection="column" paddingX={2} paddingY={1}>
       <PageHeader current="health" showHints={showHints} />
 
-      <Box marginTop={1} justifyContent="space-between">
-        <Text bold>Financial Health</Text>
-        {showHints && <Text dimColor>↑↓ select  ·  ← → adjust  ·  [r] reset</Text>}
-      </Box>
+      <Box marginTop={1}><Text bold>Financial Health</Text></Box>
+      {showHints && <Text dimColor>↑↓ select  ·  ← → adjust  ·  [r] reset</Text>}
       <Divider />
 
       {/* ── Snapshot ───────────────────────────────────────────────────────── */}

--- a/tui/Health.tsx
+++ b/tui/Health.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Box, Text, useInput } from 'ink';
 import type { Screen } from './App.js';
-import { fmt, fmtPct, fmtMonths, Divider } from './fmt.js';
+import { fmt, fmtPct, fmtMonths, fmtCompact, Divider } from './fmt.js';
 import { handleNavKey } from './nav.js';
 import { loadHealthData, yearsToFire, coastYears, type HealthData } from '../core/health.js';
 import { C_POSITIVE, C_NEGATIVE, C_WARNING, C_NEUTRAL, C_ACCENT } from './ui.js';
@@ -118,6 +118,7 @@ export function Health({ onNavigate, isActive, showHints }: { onNavigate: (s: Sc
   const growthChanged   = growth !== DEFAULT_GROWTH;
 
   const L = 18;
+  const V = 12;
 
   return (
     <Box flexDirection="column" paddingX={2} paddingY={1}>
@@ -135,10 +136,10 @@ export function Health({ onNavigate, isActive, showHints }: { onNavigate: (s: Sc
         <Box gap={3} marginTop={1}>
           <Text dimColor>{'Savings rate'.padEnd(L)}</Text>
           {savingsRate === null ? (
-            <Text dimColor>{'—'.padStart(8)}</Text>
+            <Text dimColor>{'—'.padStart(V)}</Text>
           ) : (
             <Text bold color={savingsRateColor(savingsRate)}>
-              {fmtPct(savingsRate).padStart(8)}
+              {fmtPct(savingsRate).padStart(V)}
             </Text>
           )}
           <Text dimColor>
@@ -157,7 +158,7 @@ export function Health({ onNavigate, isActive, showHints }: { onNavigate: (s: Sc
         </Box>
         <Box gap={3}>
           <Text dimColor>{'Monthly income'.padEnd(L)}</Text>
-          <Text bold>{fmt(data.monthlyIncome).padStart(8)}</Text>
+          <Text bold>{fmt(data.monthlyIncome).padStart(V)}</Text>
           <Text dimColor>avg past 12 months</Text>
         </Box>
       </Box>
@@ -168,14 +169,14 @@ export function Health({ onNavigate, isActive, showHints }: { onNavigate: (s: Sc
         <Box gap={3} marginTop={1}>
           <Text dimColor>{'Cash'.padEnd(L)}</Text>
           <Text bold color={runwayColor(cashMonths, 6, 3)}>
-            {fmtMonths(cashMonths).padStart(8)}
+            {fmtMonths(cashMonths).padStart(V)}
           </Text>
           <Text dimColor>{fmt(data.cash)} in checking/savings</Text>
         </Box>
         <Box gap={3}>
           <Text dimColor>{'Liquid'.padEnd(L)}</Text>
           <Text bold color={runwayColor(liquidMonths, 12, 6)}>
-            {fmtMonths(liquidMonths).padStart(8)}
+            {fmtMonths(liquidMonths).padStart(V)}
           </Text>
           <Text dimColor>{fmt(data.liquid)} incl. brokerage</Text>
         </Box>
@@ -188,26 +189,26 @@ export function Health({ onNavigate, isActive, showHints }: { onNavigate: (s: Sc
           <Box gap={3} marginTop={1}>
             <Text dimColor>{'Net cash'.padEnd(L)}</Text>
             <Text bold color={netCash >= 0 ? C_POSITIVE : C_NEGATIVE}>
-              {(netCash < 0 ? '-' : '') + fmt(netCash).padStart(8)}
+              {(netCash < 0 ? '-' : '') + fmt(netCash).padStart(V)}
             </Text>
             <Text dimColor>
               {netCash >= 0
-                ? `${fmt(data.cash)} cash · ${fmt(data.totalDebt)} debt — could pay off now`
-                : `${fmt(data.cash)} cash · ${fmt(data.totalDebt)} debt`}
+                ? 'could pay off now'
+                : `${fmtCompact(data.cash)} cash · ${fmtCompact(data.totalDebt)} debt`}
             </Text>
           </Box>
           {netCash < 0 && (
             <Box gap={3}>
               <Text dimColor>{'Debt-free in'.padEnd(L)}</Text>
               {debtMonths === null ? (
-                <Text color={C_NEGATIVE}>{'no surplus'.padStart(8)}</Text>
+                <Text color={C_NEGATIVE}>{'no surplus'.padStart(V)}</Text>
               ) : (
                 <Text bold color={debtMonths <= 6 ? C_POSITIVE : debtMonths <= 24 ? C_WARNING : C_NEUTRAL}>
-                  {fmtMonths(debtMonths).padStart(8)}
+                  {fmtMonths(debtMonths).padStart(V)}
                 </Text>
               )}
               <Text dimColor>
-                {debtMonths !== null ? `${fmt(remainingDebt)} remaining after cash` : 'increase savings to pay off debt'}
+                {debtMonths !== null ? `${fmtCompact(remainingDebt)} remaining after cash` : 'increase savings to pay off debt'}
               </Text>
             </Box>
           )}
@@ -220,13 +221,13 @@ export function Health({ onNavigate, isActive, showHints }: { onNavigate: (s: Sc
         <Box gap={3} marginTop={1}>
           <Text dimColor>{'Net worth'.padEnd(L)}</Text>
           <Text bold color={data.netWorth >= 0 ? C_POSITIVE : C_NEGATIVE}>
-            {fmt(data.netWorth).padStart(12)}
+            {((data.netWorth < 0 ? '-' : '') + fmtCompact(data.netWorth)).padStart(12)}
           </Text>
         </Box>
         <Box gap={3}>
           <Text dimColor>{'FIRE number'.padEnd(L)}</Text>
-          <Text bold>{fmt(fireNumber).padStart(12)}</Text>
-          <Text dimColor>  {fmtPct(fireProgress * 100)}</Text>
+          <Text bold>{fmtCompact(fireNumber).padStart(12)}</Text>
+          <Text dimColor>{fmtPct(fireProgress * 100)}</Text>
           <Text color={C_ACCENT} dimColor>{progressBar(fireProgress)}</Text>
         </Box>
         <Box gap={3}>
@@ -265,7 +266,7 @@ export function Health({ onNavigate, isActive, showHints }: { onNavigate: (s: Sc
       <Box flexDirection="column" marginTop={1}>
         <SelectableRow selected={currentDial === 'spend'} gap={2}>
           <Text color={currentDial === 'spend' ? C_ACCENT : undefined}>{'Monthly spending'.padEnd(16)}</Text>
-          <Text color={currentDial === 'spend' ? C_ACCENT : C_NEUTRAL}>{'[ '}{fmt(monthlySpend).padStart(8)}{' ]'}</Text>
+          <Text color={currentDial === 'spend' ? C_ACCENT : C_NEUTRAL}>{'[ '}{fmt(monthlySpend).padStart(V)}{' ]'}</Text>
           <Text dimColor>
             {currentDial === 'spend'
               ? (spendChanged ? `default ${fmt(defaultSpend)} · [r] reset` : `avg past 12 months  ← → ±${fmt(SPEND_STEP)}`)
@@ -275,7 +276,7 @@ export function Health({ onNavigate, isActive, showHints }: { onNavigate: (s: Sc
 
         <SelectableRow selected={currentDial === 'savings'} gap={2}>
           <Text color={currentDial === 'savings' ? C_ACCENT : undefined}>{'Monthly savings'.padEnd(16)}</Text>
-          <Text color={currentDial === 'savings' ? C_ACCENT : C_NEUTRAL}>{'[ '}{fmt(monthlySavings).padStart(8)}{' ]'}</Text>
+          <Text color={currentDial === 'savings' ? C_ACCENT : C_NEUTRAL}>{'[ '}{fmt(monthlySavings).padStart(V)}{' ]'}</Text>
           <Text dimColor>
             {currentDial === 'savings'
               ? (savingsChanged ? `default ${fmt(defaultSavings)} · [r] reset` : `avg surplus past 12 mo  ← → ±${fmt(SPEND_STEP)}`)
@@ -285,7 +286,7 @@ export function Health({ onNavigate, isActive, showHints }: { onNavigate: (s: Sc
 
         <SelectableRow selected={currentDial === 'withdrawal'} gap={2}>
           <Text color={currentDial === 'withdrawal' ? C_ACCENT : undefined}>{'Withdrawal rate'.padEnd(16)}</Text>
-          <Text color={currentDial === 'withdrawal' ? C_ACCENT : C_NEUTRAL}>{'[ '}{fmtPct(withdrawal).padStart(8)}{' ]'}</Text>
+          <Text color={currentDial === 'withdrawal' ? C_ACCENT : C_NEUTRAL}>{'[ '}{fmtPct(withdrawal).padStart(V)}{' ]'}</Text>
           <Text dimColor>
             {currentDial === 'withdrawal'
               ? `↑↓ ±${fmtPct(WITHDRAW_STEP)}${withdrawChanged ? ' · [r] reset' : ''}`
@@ -295,7 +296,7 @@ export function Health({ onNavigate, isActive, showHints }: { onNavigate: (s: Sc
 
         <SelectableRow selected={currentDial === 'growth'} gap={2}>
           <Text color={currentDial === 'growth' ? C_ACCENT : undefined}>{'Growth rate'.padEnd(16)}</Text>
-          <Text color={currentDial === 'growth' ? C_ACCENT : C_NEUTRAL}>{'[ '}{fmtPct(growth).padStart(8)}{' ]'}</Text>
+          <Text color={currentDial === 'growth' ? C_ACCENT : C_NEUTRAL}>{'[ '}{fmtPct(growth).padStart(V)}{' ]'}</Text>
           <Text dimColor>
             {currentDial === 'growth'
               ? `↑↓ ±${fmtPct(GROWTH_STEP)}${growthChanged ? ' · [r] reset' : ''}`

--- a/tui/NetWorth.tsx
+++ b/tui/NetWorth.tsx
@@ -5,6 +5,7 @@ import type { Screen } from './App.js';
 import { fmt, fmtSigned, bar, truncate, Divider } from './fmt.js';
 import { NavHints, handleNavKey } from './nav.js';
 import { useTerminalWidth, MONTHS, SUBTYPE_DISPLAY, C_POSITIVE, C_NEGATIVE, C_ACCENT } from './ui.js';
+import { usePagination } from './components/index.js';
 import { useRefreshKey } from './RefreshContext.js';
 
 const BAR_WIDTH = 32;
@@ -93,8 +94,7 @@ export function NetWorth({ onNavigate, isActive, showHints }: { onNavigate: (s: 
   const AMT_W  = 14;
   const NAME_W = Math.max(14, inner - AMT_W - 16);
 
-  const pageStart = Math.max(0, Math.min(cursor - Math.floor(PAGE / 2), rows.length - PAGE));
-  const visible   = rows.slice(pageStart, pageStart + PAGE);
+  const { visible, pageStart } = usePagination(rows, cursor, PAGE);
   const labelW    = range === 'year' ? 4 : range === 'quarter' ? 7 : range === 'month' ? 8 : 12;
 
   return (

--- a/tui/NetWorth.tsx
+++ b/tui/NetWorth.tsx
@@ -101,10 +101,8 @@ export function NetWorth({ onNavigate, isActive, showHints }: { onNavigate: (s: 
     <Box flexDirection="column" paddingX={2} paddingY={1}>
       <PageHeader current="networth" showHints={showHints} />
 
-      <Box marginTop={1} justifyContent="space-between">
-        <Text bold>Net Worth</Text>
-        {showHints && <Text dimColor>[Tab] {view === 'accounts' ? 'by type' : 'by account'}  ·  [r] range  ·  ↑↓ scroll</Text>}
-      </Box>
+      <Box marginTop={1}><Text bold>Net Worth</Text></Box>
+      {showHints && <Text dimColor>[Tab] {view === 'accounts' ? 'by type' : 'by account'}  ·  [r] range  ·  ↑↓ scroll</Text>}
       <Divider />
 
       {accounts.length === 0 ? (

--- a/tui/NetWorth.tsx
+++ b/tui/NetWorth.tsx
@@ -3,9 +3,9 @@ import { Box, Text, useInput } from 'ink';
 import { getAccountsWithBalances, getNetWorthHistory, type AccountBalance, type NetWorthPeriod } from '../core/queries.js';
 import type { Screen } from './App.js';
 import { fmt, fmtSigned, bar, truncate, Divider } from './fmt.js';
-import { NavHints, handleNavKey } from './nav.js';
+import { handleNavKey } from './nav.js';
 import { useTerminalWidth, MONTHS, SUBTYPE_DISPLAY, C_POSITIVE, C_NEGATIVE, C_ACCENT } from './ui.js';
-import { usePagination } from './components/index.js';
+import { usePagination, PageHeader } from './components/index.js';
 import { useRefreshKey } from './RefreshContext.js';
 
 const BAR_WIDTH = 32;
@@ -99,10 +99,7 @@ export function NetWorth({ onNavigate, isActive, showHints }: { onNavigate: (s: 
 
   return (
     <Box flexDirection="column" paddingX={2} paddingY={1}>
-      <Box justifyContent="space-between">
-        <Text bold color={C_ACCENT}>fungible</Text>
-        <NavHints current="networth" showHints={showHints} />
-      </Box>
+      <PageHeader current="networth" showHints={showHints} />
 
       <Box marginTop={1} justifyContent="space-between">
         <Text bold>Net Worth</Text>

--- a/tui/Rules.tsx
+++ b/tui/Rules.tsx
@@ -8,11 +8,11 @@ import {
 } from '../core/rules.js';
 import type { Screen, TxFilter } from './App.js';
 import { truncate, Divider } from './fmt.js';
-import { NavHints, handleNavKey } from './nav.js';
+import { handleNavKey } from './nav.js';
 import { useTerminalWidth, FLEX_COLORS, C_ACCENT, C_MANUAL, C_NEUTRAL, C_POSITIVE, C_WARNING } from './ui.js';
 import { useRefreshKey } from './RefreshContext.js';
 import { useSetTyping } from './TypingContext.js';
-import { ModalPanel, TextInput, SelectableRow, usePagination, useStatusMessage, ColumnHeader } from './components/index.js';
+import { ModalPanel, TextInput, SelectableRow, usePagination, useStatusMessage, ColumnHeader, PageHeader, SearchBar } from './components/index.js';
 
 type Flexibility = 'fixed' | 'flexible' | 'discretionary' | null;
 const FLEX_CYCLE: Flexibility[] = [null, 'fixed', 'flexible', 'discretionary'];
@@ -316,11 +316,7 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
 
   return (
     <Box flexDirection="column" paddingX={2} paddingY={1}>
-      {/* Header */}
-      <Box justifyContent="space-between">
-        <Text bold color={C_ACCENT}>fungible</Text>
-        <NavHints current="rules" showHints={showHints} />
-      </Box>
+      <PageHeader current="rules" showHints={showHints} />
       <Box justifyContent="space-between" marginTop={1}>
         <Box gap={3}>
           {SECTIONS.map((s) => (
@@ -337,11 +333,7 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
       </Box>
 
       {mode === 'search' ? (
-        <Box marginTop={1} gap={1}>
-          <Text color={C_ACCENT}>/</Text>
-          <TextInput value={search} />
-          <Text dimColor>  Esc clear</Text>
-        </Box>
+        <SearchBar value={search} hint="Esc clear" />
       ) : search ? (
         <Box marginTop={1} gap={1}>
           <Text color={C_WARNING}>"{search}"</Text>

--- a/tui/Rules.tsx
+++ b/tui/Rules.tsx
@@ -317,7 +317,7 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
   return (
     <Box flexDirection="column" paddingX={2} paddingY={1}>
       <PageHeader current="rules" showHints={showHints} />
-      <Box justifyContent="space-between" marginTop={1}>
+      <Box marginTop={1}>
         <Box gap={3}>
           {SECTIONS.map((s) => (
             <Text key={s} bold color={section === s ? C_ACCENT : undefined} dimColor={section !== s}>
@@ -325,12 +325,12 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
             </Text>
           ))}
         </Box>
-        {showHints && <Text dimColor>
-          {section === 'categories'
-            ? '[a] add  [n] rename  [x] delete  [v] hidden  [f] flexibility  ·  [Tab] switch'
-            : '[/] search  [a] add  [e] edit  [x] delete  ·  [Tab] switch'}
-        </Text>}
       </Box>
+      <Text dimColor>
+        {section === 'categories'
+          ? (showHints ? '[a] add  [n] rename  [x] delete  [v] hidden  [f] flexibility  ·  [Tab] switch' : '')
+          : (showHints ? '[/] search  [a] add  [e] edit  [x] delete  ·  [Tab] switch' : '[/] search')}
+      </Text>
 
       {mode === 'search' ? (
         <SearchBar value={search} hint="Esc clear" />

--- a/tui/Rules.tsx
+++ b/tui/Rules.tsx
@@ -9,9 +9,10 @@ import {
 import type { Screen, TxFilter } from './App.js';
 import { truncate, Divider } from './fmt.js';
 import { NavHints, handleNavKey } from './nav.js';
-import { useTerminalWidth, CURSOR, FLEX_COLORS, C_ACCENT, C_MANUAL, C_NEUTRAL, C_POSITIVE, C_WARNING } from './ui.js';
+import { useTerminalWidth, FLEX_COLORS, C_ACCENT, C_MANUAL, C_NEUTRAL, C_POSITIVE, C_WARNING } from './ui.js';
 import { useRefreshKey } from './RefreshContext.js';
 import { useSetTyping } from './TypingContext.js';
+import { ModalPanel, TextInput, SelectableRow, usePagination, useStatusMessage, ColumnHeader } from './components/index.js';
 
 type Flexibility = 'fixed' | 'flexible' | 'discretionary' | null;
 const FLEX_CYCLE: Flexibility[] = [null, 'fixed', 'flexible', 'discretionary'];
@@ -29,7 +30,7 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
   const [mode, setMode] = useState<Mode>('list');
   const [section, setSection] = useState<Section>('rules');
   const [uncategorized, setUncategorized] = useState(0);
-  const [statusMsg, setStatusMsg] = useState('');
+  const { statusMsg, showStatus } = useStatusMessage();
   const [hiddenSet, setHiddenSet] = useState<Set<string>>(new Set());
   const [categories, setCategories] = useState<string[]>([]);
   const [catListCursor, setCatListCursor] = useState(0);
@@ -89,15 +90,13 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
 
   function handleDeleteRule(id: number) {
     deleteCategoryRule(id);
-    setStatusMsg('Rule deleted');
-    setTimeout(() => setStatusMsg(''), 2000);
+    showStatus('Rule deleted');
     load();
   }
 
   function handleDeleteNameRule(id: number) {
     deleteNameRule(id);
-    setStatusMsg('Name rule deleted');
-    setTimeout(() => setStatusMsg(''), 2000);
+    showStatus('Name rule deleted');
     load();
   }
 
@@ -111,8 +110,7 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
       editingId: editingRuleId,
     });
     setEditingRuleId(null);
-    setStatusMsg(`Rule saved · recategorized ${count} transactions`);
-    setTimeout(() => setStatusMsg(''), 3000);
+    showStatus(`Rule saved · recategorized ${count} transactions`, 3000);
     setNewPattern('');
     setMode('list');
     load();
@@ -127,8 +125,7 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
       editingId: editingNameRuleId,
     });
     setEditingNameRuleId(null);
-    setStatusMsg('Name rule saved');
-    setTimeout(() => setStatusMsg(''), 3000);
+    showStatus('Name rule saved', 3000);
     setNewNamePattern('');
     setNewReplacement('');
     setNewNameMinAmount('');
@@ -204,8 +201,7 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
           const nowHidden = !hiddenSet.has(cat);
           toggleHiddenCategory(cat, hiddenSet);
           void getHiddenCategorySet().then(setHiddenSet);
-          setStatusMsg(`${cat} is now ${nowHidden ? 'hidden' : 'visible'}`);
-          setTimeout(() => setStatusMsg(''), 2000);
+          showStatus(`${cat} is now ${nowHidden ? 'hidden' : 'visible'}`);
           return;
         }
         if (input === 'f' && catDetails[catListCursor]) {
@@ -224,8 +220,7 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
         if (input === 'x' && categories[catListCursor]) {
           const name = categories[catListCursor];
           deleteCategory(name);
-          setStatusMsg(`Deleted "${name}"`);
-          setTimeout(() => setStatusMsg(''), 2000);
+          showStatus(`Deleted "${name}"`);
           load();
           setCatListCursor((c) => Math.max(0, c - 1));
         }
@@ -282,8 +277,7 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
       if (key.escape) { setMode('list'); return; }
       if (key.return && newCategoryName.trim()) {
         createCategory(newCategoryName.trim());
-        setStatusMsg(`Added "${newCategoryName.trim()}"`);
-        setTimeout(() => setStatusMsg(''), 2000);
+        showStatus(`Added "${newCategoryName.trim()}"`);
         setNewCategoryName('');
         setMode('list');
         load();
@@ -298,8 +292,7 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
         const newName = renameCatInput.trim();
         if (oldName && newName !== oldName) {
           renameCategory(oldName, newName);
-          setStatusMsg(`Renamed to "${newName}"`);
-          setTimeout(() => setStatusMsg(''), 2000);
+          showStatus(`Renamed to "${newName}"`);
           load();
         }
         setMode('list');
@@ -319,8 +312,7 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
     : nameRules;
 
   const PAGE = 20;
-  const pageStart = Math.max(0, Math.min(cursor - Math.floor(PAGE / 2), filteredRules.length - PAGE));
-  const visible = filteredRules.slice(pageStart, pageStart + PAGE);
+  const { visible } = usePagination(filteredRules, cursor, PAGE);
 
   return (
     <Box flexDirection="column" paddingX={2} paddingY={1}>
@@ -345,10 +337,9 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
       </Box>
 
       {mode === 'search' ? (
-        <Box marginTop={1}>
+        <Box marginTop={1} gap={1}>
           <Text color={C_ACCENT}>/</Text>
-          <Text>{search}</Text>
-          <Text color={C_ACCENT}>█</Text>
+          <TextInput value={search} />
           <Text dimColor>  Esc clear</Text>
         </Box>
       ) : search ? (
@@ -361,12 +352,13 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
 
       {section === 'rules' && (
         <>
-          <Box gap={2} marginTop={1}>
-            <Text dimColor>{'TYPE  '.padEnd(6)}</Text>
-            <Text dimColor>{'PATTERN'.padEnd(rulePatW)}</Text>
-            <Text dimColor>{'CATEGORY'.padEnd(ruleCatW)}</Text>
-            <Text dimColor>PRI</Text>
-          </Box>
+          <ColumnHeader hasCursor columns={[
+            { label: 'TYPE', width: 5 },
+            { label: 'PATTERN', width: rulePatW },
+            { label: 'AMOUNT', width: 10 },
+            { label: 'CATEGORY', width: ruleCatW },
+            { label: 'PRI' },
+          ]} />
           {visible.map((rule) => {
             const isSelected = rule.id === filteredRules[cursor]?.id;
             const amtLabel = rule.min_amount !== null && rule.max_amount !== null && rule.min_amount === rule.max_amount
@@ -377,8 +369,7 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
               : rule.max_amount !== null ? `≤$${rule.max_amount}`
               : '';
             return (
-              <Box key={rule.id} gap={2}>
-                <Text color={isSelected ? C_ACCENT : C_NEUTRAL}>{isSelected ? '▶ ' : '  '}</Text>
+              <SelectableRow key={rule.id} selected={isSelected}>
                 <Text color={C_WARNING} dimColor={!isSelected}>{rule.match_type.padEnd(5)}</Text>
                 <Text dimColor={!isSelected}>
                   {rule.pattern.length > rulePatW ? rule.pattern.slice(0, rulePatW - 1) + '…' : rule.pattern.padEnd(rulePatW)}
@@ -386,7 +377,7 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
                 {amtLabel ? <Text color={C_MANUAL} dimColor={!isSelected}>{truncate(amtLabel, 10).padEnd(10)}</Text> : <Text>{' '.repeat(10)}</Text>}
                 <Text color={C_ACCENT} dimColor={!isSelected}>{rule.category.length > ruleCatW ? rule.category.slice(0, ruleCatW - 1) + '…' : rule.category.padEnd(ruleCatW)}</Text>
                 <Text dimColor>{rule.priority}</Text>
-              </Box>
+              </SelectableRow>
             );
           })}
           <Divider />
@@ -399,12 +390,12 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
 
       {section === 'names' && (
         <>
-          <Box gap={2} marginTop={1}>
-            <Text dimColor>{'TYPE  '.padEnd(6)}</Text>
-            <Text dimColor>{'PATTERN'.padEnd(namePatW)}</Text>
-            <Text dimColor>{'AMOUNT'.padEnd(12)}</Text>
-            <Text dimColor>REPLACEMENT</Text>
-          </Box>
+          <ColumnHeader hasCursor columns={[
+            { label: 'TYPE', width: 5 },
+            { label: 'PATTERN', width: namePatW },
+            { label: 'AMOUNT', width: 12 },
+            { label: 'REPLACEMENT' },
+          ]} />
           {filteredNameRules.length === 0
             ? <Box marginTop={1}><Text dimColor>{nameRules.length === 0 ? 'No name rules yet. [a] to add one.' : 'No matches.'}</Text></Box>
             : filteredNameRules.map((rule, i) => {
@@ -417,8 +408,7 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
                   : rule.max_amount !== null ? `≤$${rule.max_amount}`
                   : '';
                 return (
-                  <Box key={rule.id} gap={2}>
-                    <Text color={isSelected ? C_ACCENT : C_NEUTRAL}>{isSelected ? '▶ ' : '  '}</Text>
+                  <SelectableRow key={rule.id} selected={isSelected}>
                     <Text color={C_WARNING} dimColor={!isSelected}>{rule.match_type.padEnd(5)}</Text>
                     <Text dimColor={!isSelected}>
                       {rule.pattern.length > namePatW ? rule.pattern.slice(0, namePatW - 1) + '…' : rule.pattern.padEnd(namePatW)}
@@ -427,7 +417,7 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
                       ? <Text color={C_MANUAL} dimColor={!isSelected}>{truncate(amtLabel, 12).padEnd(12)}</Text>
                       : <Text>{' '.repeat(12)}</Text>}
                     <Text color={C_POSITIVE} dimColor={!isSelected}>{rule.replacement.length > nameReplW ? rule.replacement.slice(0, nameReplW - 1) + '…' : rule.replacement}</Text>
-                  </Box>
+                  </SelectableRow>
                 );
               })}
           <Divider />
@@ -437,19 +427,18 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
 
       {section === 'categories' && (
         <>
-          <Box gap={2} marginTop={1} marginBottom={1}>
-            <Text dimColor>{'NAME'.padEnd(catNameW + 2)}</Text>
-            <Text dimColor>{'FLEXIBILITY'.padEnd(16)}</Text>
-            <Text dimColor>HIDDEN</Text>
-          </Box>
+          <ColumnHeader hasCursor marginTop={0} columns={[
+            { label: 'NAME', width: catNameW },
+            { label: 'FLEXIBILITY', width: 14 },
+            { label: 'HIDDEN' },
+          ]} />
           <Box flexDirection="column">
             {catDetails.map((cat, i) => {
               const isSelected = catListCursor === i;
               const isHidden = hiddenSet.has(cat.name);
               const flexColor = cat.flexibility ? FLEX_COLORS[cat.flexibility] : undefined;
               return (
-                <Box key={cat.name} gap={2}>
-                  <Text color={isSelected ? C_ACCENT : undefined}>{isSelected ? '▶ ' : '  '}</Text>
+                <SelectableRow key={cat.name} selected={isSelected}>
                   <Text color={isSelected ? C_ACCENT : undefined} dimColor={!isSelected}>{cat.name.length > catNameW ? cat.name.slice(0, catNameW - 1) + '…' : cat.name.padEnd(catNameW)}</Text>
                   {cat.flexibility
                     ? <Text color={flexColor} dimColor={!isSelected}>{cat.flexibility.padEnd(14)}</Text>
@@ -457,7 +446,7 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
                   {isHidden
                     ? <Text color={C_WARNING} dimColor={!isSelected}>hidden</Text>
                     : <Text dimColor>—</Text>}
-                </Box>
+                </SelectableRow>
               );
             })}
           </Box>
@@ -472,103 +461,91 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
       {statusMsg && <Text color={C_POSITIVE} bold>{statusMsg}</Text>}
 
       {mode === 'add-pattern' && (
-        <Box flexDirection="column" marginTop={1} borderStyle="round" borderColor={C_ACCENT} paddingX={2} paddingY={1}>
-          <Text bold>{editingRuleId !== null ? 'Edit' : 'New'} Rule — Pattern</Text>
+        <ModalPanel title={`${editingRuleId !== null ? 'Edit' : 'New'} Rule — Pattern`}>
           <Text dimColor>Type pattern · Enter · Esc cancel</Text>
-          <Box marginTop={1}><Text>Pattern: </Text><Text color={C_WARNING}>{newPattern}<Text color={C_ACCENT}>█</Text></Text></Box>
-        </Box>
+          <Box marginTop={1} gap={1}><Text>Pattern: </Text><TextInput value={newPattern} color={C_WARNING} /></Box>
+        </ModalPanel>
       )}
       {mode === 'add-type' && (
-        <Box flexDirection="column" marginTop={1} borderStyle="round" borderColor={C_ACCENT} paddingX={2} paddingY={1}>
-          <Text bold>{editingRuleId !== null ? 'Edit' : 'New'} Rule — Match Type</Text>
+        <ModalPanel title={`${editingRuleId !== null ? 'Edit' : 'New'} Rule — Match Type`}>
           <Text>Pattern: <Text color={C_WARNING}>"{newPattern}"</Text></Text>
           <Box gap={4} marginTop={1}>
             <Text color={C_ACCENT}>[n] name match</Text>
             <Text color={C_ACCENT}>[r] regex match</Text>
           </Box>
-        </Box>
+        </ModalPanel>
       )}
       {mode === 'add-min-amount' && (
-        <Box flexDirection="column" marginTop={1} borderStyle="round" borderColor={C_ACCENT} paddingX={2} paddingY={1}>
-          <Text bold>{editingRuleId !== null ? 'Edit' : 'New'} Rule — Min Amount <Text dimColor>(optional)</Text></Text>
+        <ModalPanel title={`${editingRuleId !== null ? 'Edit' : 'New'} Rule — Min Amount (optional)`}>
           <Text>Pattern: <Text color={C_WARNING}>"{newPattern}"</Text>  Type: <Text color={C_WARNING}>{newType}</Text></Text>
           <Text dimColor>Enter to skip · Esc cancel</Text>
-          <Box marginTop={1}><Text>Min $: </Text><Text color={C_WARNING}>{newMinAmount}<Text color={C_ACCENT}>█</Text></Text></Box>
-        </Box>
+          <Box marginTop={1} gap={1}><Text>Min $: </Text><TextInput value={newMinAmount} color={C_WARNING} /></Box>
+        </ModalPanel>
       )}
       {mode === 'add-max-amount' && (
-        <Box flexDirection="column" marginTop={1} borderStyle="round" borderColor={C_ACCENT} paddingX={2} paddingY={1}>
-          <Text bold>{editingRuleId !== null ? 'Edit' : 'New'} Rule — Max Amount <Text dimColor>(optional)</Text></Text>
+        <ModalPanel title={`${editingRuleId !== null ? 'Edit' : 'New'} Rule — Max Amount (optional)`}>
           <Text>Pattern: <Text color={C_WARNING}>"{newPattern}"</Text>  {newMinAmount && <Text>Min: <Text color={C_MANUAL}>${newMinAmount}</Text></Text>}</Text>
           <Text dimColor>Enter to skip · Esc cancel</Text>
-          <Box marginTop={1}><Text>Max $: </Text><Text color={C_WARNING}>{newMaxAmount}<Text color={C_ACCENT}>█</Text></Text></Box>
-        </Box>
+          <Box marginTop={1} gap={1}><Text>Max $: </Text><TextInput value={newMaxAmount} color={C_WARNING} /></Box>
+        </ModalPanel>
       )}
       {mode === 'add-category' && (
-        <Box flexDirection="column" marginTop={1} borderStyle="round" borderColor={C_ACCENT} paddingX={2} paddingY={1}>
-          <Text bold>{editingRuleId !== null ? 'Edit' : 'New'} Rule — Category</Text>
+        <ModalPanel title={`${editingRuleId !== null ? 'Edit' : 'New'} Rule — Category`}>
           <Text>Pattern: <Text color={C_WARNING}>"{newPattern}"</Text>  Type: <Text color={C_WARNING}>{newType}</Text></Text>
           <Text dimColor>↑↓ select · Enter save · Esc cancel</Text>
           <Box flexDirection="column" marginTop={1}>
             {categories.map((cat, i) => (
-              <Text key={cat} color={i === catCursor ? C_ACCENT : C_NEUTRAL} dimColor={i !== catCursor}>
-                {i === catCursor ? '▶ ' : '  '}{cat}
-              </Text>
+              <SelectableRow key={cat} selected={i === catCursor}>
+                <Text color={i === catCursor ? C_ACCENT : C_NEUTRAL} dimColor={i !== catCursor}>{cat}</Text>
+              </SelectableRow>
             ))}
           </Box>
-        </Box>
+        </ModalPanel>
       )}
 
       {mode === 'add-name-pattern' && (
-        <Box flexDirection="column" marginTop={1} borderStyle="round" borderColor={C_POSITIVE} paddingX={2} paddingY={1}>
-          <Text bold>{editingNameRuleId !== null ? 'Edit' : 'New'} Name Rule — Pattern</Text>
+        <ModalPanel title={`${editingNameRuleId !== null ? 'Edit' : 'New'} Name Rule — Pattern`} borderColor={C_POSITIVE}>
           <Text dimColor>Matches against the raw transaction name</Text>
-          <Box marginTop={1}><Text>Pattern: </Text><Text color={C_WARNING}>{newNamePattern}<Text color={C_POSITIVE}>█</Text></Text></Box>
-        </Box>
+          <Box marginTop={1} gap={1}><Text>Pattern: </Text><TextInput value={newNamePattern} color={C_WARNING} /></Box>
+        </ModalPanel>
       )}
       {mode === 'add-name-type' && (
-        <Box flexDirection="column" marginTop={1} borderStyle="round" borderColor={C_POSITIVE} paddingX={2} paddingY={1}>
-          <Text bold>{editingNameRuleId !== null ? 'Edit' : 'New'} Name Rule — Match Type</Text>
+        <ModalPanel title={`${editingNameRuleId !== null ? 'Edit' : 'New'} Name Rule — Match Type`} borderColor={C_POSITIVE}>
           <Text>Pattern: <Text color={C_WARNING}>"{newNamePattern}"</Text></Text>
           <Box gap={4} marginTop={1}>
             <Text color={C_POSITIVE}>[n] name match (replaces whole name)</Text>
             <Text color={C_POSITIVE}>[r] regex (can use capture groups)</Text>
           </Box>
-        </Box>
+        </ModalPanel>
       )}
       {mode === 'add-category-name' && (
-        <Box flexDirection="column" marginTop={1} borderStyle="round" borderColor={C_WARNING} paddingX={2} paddingY={1}>
-          <Text bold>New Category</Text>
+        <ModalPanel title="New Category" borderColor={C_WARNING}>
           <Text dimColor>Type a name · Enter save · Esc cancel</Text>
-          <Box marginTop={1}><Text>Name: </Text><Text color={C_WARNING}>{newCategoryName}<Text color={C_ACCENT}>{CURSOR}</Text></Text></Box>
-        </Box>
+          <Box marginTop={1} gap={1}><Text>Name: </Text><TextInput value={newCategoryName} color={C_WARNING} /></Box>
+        </ModalPanel>
       )}
       {mode === 'rename-category' && (
-        <Box flexDirection="column" marginTop={1} borderStyle="round" borderColor={C_WARNING} paddingX={2} paddingY={1}>
-          <Text bold>Rename Category</Text>
+        <ModalPanel title="Rename Category" borderColor={C_WARNING}>
           <Text dimColor>Updates all transactions, rules, and hidden settings · Enter save · Esc cancel</Text>
-          <Box marginTop={1}><Text>Name: </Text><Text color={C_WARNING}>{renameCatInput}<Text color={C_ACCENT}>{CURSOR}</Text></Text></Box>
-        </Box>
+          <Box marginTop={1} gap={1}><Text>Name: </Text><TextInput value={renameCatInput} color={C_WARNING} /></Box>
+        </ModalPanel>
       )}
       {mode === 'add-name-min-amount' && (
-        <Box flexDirection="column" marginTop={1} borderStyle="round" borderColor={C_POSITIVE} paddingX={2} paddingY={1}>
-          <Text bold>{editingNameRuleId !== null ? 'Edit' : 'New'} Name Rule — Min Amount <Text dimColor>(optional)</Text></Text>
+        <ModalPanel title={`${editingNameRuleId !== null ? 'Edit' : 'New'} Name Rule — Min Amount (optional)`} borderColor={C_POSITIVE}>
           <Text>Pattern: <Text color={C_WARNING}>"{newNamePattern}"</Text>  Type: <Text color={C_WARNING}>{newNameType}</Text></Text>
           <Text dimColor>Enter to skip · Esc cancel</Text>
-          <Box marginTop={1}><Text>Min $: </Text><Text color={C_WARNING}>{newNameMinAmount}<Text color={C_POSITIVE}>█</Text></Text></Box>
-        </Box>
+          <Box marginTop={1} gap={1}><Text>Min $: </Text><TextInput value={newNameMinAmount} color={C_WARNING} /></Box>
+        </ModalPanel>
       )}
       {mode === 'add-name-max-amount' && (
-        <Box flexDirection="column" marginTop={1} borderStyle="round" borderColor={C_POSITIVE} paddingX={2} paddingY={1}>
-          <Text bold>{editingNameRuleId !== null ? 'Edit' : 'New'} Name Rule — Max Amount <Text dimColor>(optional)</Text></Text>
+        <ModalPanel title={`${editingNameRuleId !== null ? 'Edit' : 'New'} Name Rule — Max Amount (optional)`} borderColor={C_POSITIVE}>
           <Text>Pattern: <Text color={C_WARNING}>"{newNamePattern}"</Text>  {newNameMinAmount && <Text>Min: <Text color={C_MANUAL}>${newNameMinAmount}</Text>  </Text>}</Text>
           <Text dimColor>Enter to skip · Esc cancel</Text>
-          <Box marginTop={1}><Text>Max $: </Text><Text color={C_WARNING}>{newNameMaxAmount}<Text color={C_POSITIVE}>█</Text></Text></Box>
-        </Box>
+          <Box marginTop={1} gap={1}><Text>Max $: </Text><TextInput value={newNameMaxAmount} color={C_WARNING} /></Box>
+        </ModalPanel>
       )}
       {mode === 'add-name-replacement' && (
-        <Box flexDirection="column" marginTop={1} borderStyle="round" borderColor={C_POSITIVE} paddingX={2} paddingY={1}>
-          <Text bold>{editingNameRuleId !== null ? 'Edit' : 'New'} Name Rule — Replacement</Text>
+        <ModalPanel title={`${editingNameRuleId !== null ? 'Edit' : 'New'} Name Rule — Replacement`} borderColor={C_POSITIVE}>
           <Text>
             Pattern: <Text color={C_WARNING}>"{newNamePattern}"</Text>  Type: <Text color={C_WARNING}>{newNameType}</Text>
             {(newNameMinAmount || newNameMaxAmount) && (
@@ -582,8 +559,8 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
             )}
           </Text>
           <Text dimColor>The display name to show instead</Text>
-          <Box marginTop={1}><Text>Replace with: </Text><Text color={C_POSITIVE}>{newReplacement}<Text color={C_POSITIVE}>█</Text></Text></Box>
-        </Box>
+          <Box marginTop={1} gap={1}><Text>Replace with: </Text><TextInput value={newReplacement} color={C_POSITIVE} /></Box>
+        </ModalPanel>
       )}
     </Box>
   );

--- a/tui/Setup.tsx
+++ b/tui/Setup.tsx
@@ -7,6 +7,7 @@ import { seedRules } from '../core/seed-rules.js';
 import { DATA_DIR } from '../core/paths.js';
 import { getSetting, setSetting, daysFromStartDate, DEFAULT_START_DATE_KEY, MAX_DAYS_REQUESTED, START_DATE_BUFFER_DAYS } from '../core/settings.js';
 import { C_POSITIVE, C_NEGATIVE, C_WARNING, C_ACCENT } from './ui.js';
+import { TextInput } from './components/index.js';
 
 type Step =
   | 'welcome'
@@ -272,8 +273,7 @@ export function Setup() {
           <Text dimColor>Found in your Plaid dashboard under Team Settings → Keys</Text>
           <Box marginTop={1}>
             <Text>Client ID: </Text>
-            <Text color={C_WARNING}>{clientId}</Text>
-            <Text color={C_ACCENT}>█</Text>
+            <TextInput value={clientId} color={C_WARNING} />
           </Box>
           <Text dimColor>Enter to continue · Esc back</Text>
         </Box>
@@ -285,8 +285,7 @@ export function Setup() {
           <Text dimColor>The secret key for your chosen environment</Text>
           <Box marginTop={1}>
             <Text>Secret: </Text>
-            <Text color={C_WARNING}>{'*'.repeat(secret.length)}</Text>
-            <Text color={C_ACCENT}>█</Text>
+            <TextInput value={'*'.repeat(secret.length)} color={C_WARNING} />
           </Box>
           <Text dimColor>Enter to continue · Esc back</Text>
         </Box>
@@ -320,8 +319,7 @@ export function Setup() {
           </Text>
           <Box marginTop={1}>
             <Text>Start date (YYYY-MM-DD): </Text>
-            <Text color={C_WARNING}>{startDateInput}</Text>
-            <Text color={C_ACCENT}>█</Text>
+            <TextInput value={startDateInput} color={C_WARNING} />
           </Box>
           {startDateRequestedDays != null && (
             <Text dimColor>= {startDateRequestedDays} days of history requested (incl. {START_DATE_BUFFER_DAYS}-day buffer)</Text>

--- a/tui/Tags.tsx
+++ b/tui/Tags.tsx
@@ -168,7 +168,7 @@ export function Tags({ onNavigate, isActive, showHints, initialFilter }: { onNav
 
       {mode === 'detail' && tag && tagSummary ? (
         <>
-          <Box justifyContent="space-between" marginTop={1} marginBottom={1}>
+          <Box flexDirection="column" marginTop={1} marginBottom={1}>
             <Text bold>Tags <Text dimColor>— # {tag.name}  ← {cursor + 1} / {tags.length} →</Text></Text>
             {showHints && <Text dimColor>← → tag  ·  ↑↓ category  ·  Enter txns  ·  [t] all txns  ·  Esc back</Text>}
           </Box>
@@ -208,10 +208,14 @@ export function Tags({ onNavigate, isActive, showHints, initialFilter }: { onNav
         </>
       ) : (
         <>
-          <Box justifyContent="space-between" marginTop={1}>
+          <Box marginTop={1}>
             <Text bold>Tags{search ? <Text color={C_WARNING}>  /{search}</Text> : null}</Text>
-            {showHints && <Text dimColor>[/] search  ·  [a] add  [n] rename  [x] delete  ·  Enter detail  ·  [t] transactions</Text>}
           </Box>
+          <Text dimColor>
+            {showHints
+              ? '[/] search  ·  [a] add  [n] rename  [x] delete  ·  Enter detail  ·  [t] transactions'
+              : '[/] search'}
+          </Text>
           {mode === 'search' && <SearchBar value={search} />}
           <Box marginTop={1}><Divider /></Box>
 

--- a/tui/Tags.tsx
+++ b/tui/Tags.tsx
@@ -5,7 +5,8 @@ import { createTag, renameTag, deleteTag } from '../core/tags.js';
 import type { Screen, TxFilter } from './App.js';
 import { fmt, bar, truncate, Divider } from './fmt.js';
 import { NavHints, handleNavKey } from './nav.js';
-import { useTerminalWidth, CURSOR, C_POSITIVE, C_NEGATIVE, C_WARNING, C_ACCENT } from './ui.js';
+import { useTerminalWidth, C_POSITIVE, C_NEGATIVE, C_WARNING, C_ACCENT } from './ui.js';
+import { StatCard, ModalPanel, SectionHeader, TextInput, SelectableRow, useStatusMessage } from './components/index.js';
 import { useSetTyping } from './TypingContext.js';
 import { useRefreshKey } from './RefreshContext.js';
 
@@ -17,7 +18,7 @@ export function Tags({ onNavigate, isActive, showHints, initialFilter }: { onNav
   const [cursor, setCursor] = useState(0);
   const [mode, setMode] = useState<Mode>('list');
   const [newName, setNewName] = useState('');
-  const [statusMsg, setStatusMsg] = useState('');
+  const { statusMsg, showStatus } = useStatusMessage();
   const [search, setSearch] = useState('');
   const [tagSummary, setTagSummary] = useState<MonthlySummary | null>(null);
   const [catCursor, setCatCursor] = useState(0);
@@ -143,8 +144,7 @@ export function Tags({ onNavigate, isActive, showHints, initialFilter }: { onNav
     if (input === 'x' && visibleTags[cursor]) {
       const tag = visibleTags[cursor];
       deleteTag(tag.id);
-      setStatusMsg(`Deleted "${tag.name}"`);
-      setTimeout(() => setStatusMsg(''), 2000);
+      showStatus(`Deleted "${tag.name}"`);
       setCursor((c) => Math.max(0, c - 1));
       load();
       return;
@@ -179,30 +179,16 @@ export function Tags({ onNavigate, isActive, showHints, initialFilter }: { onNav
           <Divider />
 
           <Box gap={6} marginY={1}>
-            <Box flexDirection="column">
-              <Text dimColor>Income</Text>
-              <Text color={C_POSITIVE} bold>{fmt(tagSummary.income)}</Text>
-            </Box>
-            <Box flexDirection="column">
-              <Text dimColor>Expenses</Text>
-              <Text color={C_NEGATIVE} bold>{fmt(tagSummary.expenses)}</Text>
-            </Box>
-            <Box flexDirection="column">
-              <Text dimColor>Net</Text>
-              <Text color={tagSummary.net >= 0 ? C_POSITIVE : C_NEGATIVE} bold>
-                {tagSummary.net >= 0 ? '+' : '-'}{fmt(tagSummary.net)}
-              </Text>
-            </Box>
-            <Box flexDirection="column">
-              <Text dimColor>Transactions</Text>
-              <Text bold>{tag.count}</Text>
-            </Box>
+            <StatCard label="Income" value={fmt(tagSummary.income)} color={C_POSITIVE} />
+            <StatCard label="Expenses" value={fmt(tagSummary.expenses)} color={C_NEGATIVE} />
+            <StatCard label="Net" value={(tagSummary.net >= 0 ? '+' : '-') + fmt(tagSummary.net)} color={tagSummary.net >= 0 ? C_POSITIVE : C_NEGATIVE} />
+            <StatCard label="Transactions" value={String(tag.count)} />
           </Box>
 
           <Divider />
 
           <Box flexDirection="column" marginTop={1}>
-            <Text bold dimColor>SPENDING BY CATEGORY</Text>
+            <SectionHeader>SPENDING BY CATEGORY</SectionHeader>
             <Box flexDirection="column" marginTop={1}>
               {tagSummary.byCategory.length === 0 ? (
                 <Text dimColor>No expense data for this tag.</Text>
@@ -210,14 +196,13 @@ export function Tags({ onNavigate, isActive, showHints, initialFilter }: { onNav
                 tagSummary.byCategory.map((row, i) => {
                   const isSelected = catCursor === i;
                   return (
-                    <Box key={row.category} gap={2}>
+                    <SelectableRow key={row.category} selected={isSelected}>
                       <Text color={isSelected ? C_ACCENT : undefined}>
-                        {isSelected ? '▶ ' : '  '}
                         {truncate(row.category, 20).padEnd(20)}
                       </Text>
                       <Text color={C_WARNING}>{fmt(row.total).padStart(10)}</Text>
                       <Text color={C_ACCENT} dimColor={!isSelected}>{bar(row.total, maxCategorySpend)}</Text>
-                    </Box>
+                    </SelectableRow>
                   );
                 })
               )}
@@ -231,10 +216,9 @@ export function Tags({ onNavigate, isActive, showHints, initialFilter }: { onNav
             {showHints && <Text dimColor>[/] search  ·  [a] add  [n] rename  [x] delete  ·  Enter detail  ·  [t] transactions</Text>}
           </Box>
           {mode === 'search' && (
-            <Box marginTop={1}>
+            <Box marginTop={1} gap={1}>
               <Text color={C_ACCENT}>/</Text>
-              <Text color={C_WARNING}>{search}</Text>
-              <Text color={C_ACCENT}>█</Text>
+              <TextInput value={search} color={C_WARNING} />
               <Text dimColor>  Esc cancel</Text>
             </Box>
           )}
@@ -243,18 +227,19 @@ export function Tags({ onNavigate, isActive, showHints, initialFilter }: { onNav
           {visibleTags.length === 0 ? (
             <Box marginTop={1}><Text dimColor>{search ? `No tags matching "${search}".` : 'No tags yet. [a] to create one.'}</Text></Box>
           ) : (
-            visibleTags.map((t, i) => {
-              const isSelected = i === cursor;
-              return (
-                <Box key={t.id} gap={2} marginTop={i === 0 ? 1 : 0}>
-                  <Text color={isSelected ? C_ACCENT : undefined}>{isSelected ? '▶ ' : '  '}</Text>
-                  <Text color={isSelected ? C_ACCENT : undefined} dimColor={!isSelected}>
-                    {t.name.length > tagNameW ? t.name.slice(0, tagNameW - 1) + '…' : t.name.padEnd(tagNameW)}
-                  </Text>
-                  <Text dimColor>{t.count} transaction{t.count !== 1 ? 's' : ''}</Text>
-                </Box>
-              );
-            })
+            <Box flexDirection="column" marginTop={1}>
+              {visibleTags.map((t, i) => {
+                const isSelected = i === cursor;
+                return (
+                  <SelectableRow key={t.id} selected={isSelected}>
+                    <Text color={isSelected ? C_ACCENT : undefined} dimColor={!isSelected}>
+                      {t.name.length > tagNameW ? t.name.slice(0, tagNameW - 1) + '…' : t.name.padEnd(tagNameW)}
+                    </Text>
+                    <Text dimColor>{t.count} transaction{t.count !== 1 ? 's' : ''}</Text>
+                  </SelectableRow>
+                );
+              })}
+            </Box>
           )}
 
           <Box marginTop={1}><Divider /></Box>
@@ -262,26 +247,22 @@ export function Tags({ onNavigate, isActive, showHints, initialFilter }: { onNav
           {statusMsg && <Text color={C_POSITIVE}>{statusMsg}</Text>}
 
           {mode === 'add' && (
-            <Box flexDirection="column" marginTop={1} borderStyle="round" borderColor={C_ACCENT} paddingX={2} paddingY={1}>
-              <Text bold>New Tag</Text>
+            <ModalPanel title="New Tag">
               <Text dimColor>Type name · Enter save · Esc cancel</Text>
-              <Box marginTop={1}>
+              <Box marginTop={1} gap={1}>
                 <Text>Name: </Text>
-                <Text color={C_WARNING}>{newName}</Text>
-                <Text color={C_ACCENT}>{CURSOR}</Text>
+                <TextInput value={newName} color={C_WARNING} />
               </Box>
-            </Box>
+            </ModalPanel>
           )}
           {mode === 'rename' && visibleTags[cursor] && (
-            <Box flexDirection="column" marginTop={1} borderStyle="round" borderColor={C_WARNING} paddingX={2} paddingY={1}>
-              <Text bold>Rename Tag</Text>
+            <ModalPanel title="Rename Tag" borderColor={C_WARNING}>
               <Text dimColor>Enter save · Esc cancel</Text>
-              <Box marginTop={1}>
+              <Box marginTop={1} gap={1}>
                 <Text>Name: </Text>
-                <Text color={C_WARNING}>{newName}</Text>
-                <Text color={C_ACCENT}>{CURSOR}</Text>
+                <TextInput value={newName} color={C_WARNING} />
               </Box>
-            </Box>
+            </ModalPanel>
           )}
         </>
       )}

--- a/tui/Tags.tsx
+++ b/tui/Tags.tsx
@@ -4,9 +4,9 @@ import { getTagSummary, getAllTags, type MonthlySummary, type Tag } from '../cor
 import { createTag, renameTag, deleteTag } from '../core/tags.js';
 import type { Screen, TxFilter } from './App.js';
 import { fmt, bar, truncate, Divider } from './fmt.js';
-import { NavHints, handleNavKey } from './nav.js';
+import { handleNavKey } from './nav.js';
 import { useTerminalWidth, C_POSITIVE, C_NEGATIVE, C_WARNING, C_ACCENT } from './ui.js';
-import { StatCard, ModalPanel, SectionHeader, TextInput, SelectableRow, useStatusMessage } from './components/index.js';
+import { StatCard, ModalPanel, SectionHeader, TextInput, SelectableRow, useStatusMessage, PageHeader, SearchBar } from './components/index.js';
 import { useSetTyping } from './TypingContext.js';
 import { useRefreshKey } from './RefreshContext.js';
 
@@ -164,10 +164,7 @@ export function Tags({ onNavigate, isActive, showHints, initialFilter }: { onNav
 
   return (
     <Box flexDirection="column" paddingX={2} paddingY={1}>
-      <Box justifyContent="space-between">
-        <Text bold color={C_ACCENT}>fungible</Text>
-        <NavHints current="tags" showHints={showHints} />
-      </Box>
+      <PageHeader current="tags" showHints={showHints} />
 
       {mode === 'detail' && tag && tagSummary ? (
         <>
@@ -215,13 +212,7 @@ export function Tags({ onNavigate, isActive, showHints, initialFilter }: { onNav
             <Text bold>Tags{search ? <Text color={C_WARNING}>  /{search}</Text> : null}</Text>
             {showHints && <Text dimColor>[/] search  ·  [a] add  [n] rename  [x] delete  ·  Enter detail  ·  [t] transactions</Text>}
           </Box>
-          {mode === 'search' && (
-            <Box marginTop={1} gap={1}>
-              <Text color={C_ACCENT}>/</Text>
-              <TextInput value={search} color={C_WARNING} />
-              <Text dimColor>  Esc cancel</Text>
-            </Box>
-          )}
+          {mode === 'search' && <SearchBar value={search} />}
           <Box marginTop={1}><Divider /></Box>
 
           {visibleTags.length === 0 ? (

--- a/tui/Transactions.tsx
+++ b/tui/Transactions.tsx
@@ -435,11 +435,11 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
           {filterLabel ? <Text color={C_WARNING}>  {filterLabel}</Text> : null}
         </Text>
       </Box>
-      {showHints && <Box justifyContent="flex-end">
-        <Text dimColor>
-          {from ? '← →  ·  ' : ''}[s] sort  ·  [/] search  ·  [e] edit  [g] tag  [i] ignore  [x] delete
-        </Text>
-      </Box>}
+      <Text dimColor>
+        {showHints
+          ? `${from ? '← →  ·  ' : ''}[s] sort  ·  [/] search  ·  [e] edit  [g] tag  [i] ignore  [x] delete`
+          : '[/] search'}
+      </Text>
 
       {mode === 'search' && <SearchBar value={searchInput} />}
       <Box marginTop={1}><Divider /></Box>

--- a/tui/Transactions.tsx
+++ b/tui/Transactions.tsx
@@ -15,10 +15,10 @@ import { applyCategoriesToAll } from '../core/categorize.js';
 import { countPatternMatches } from '../core/rule-utils.js';
 import { getTransactions, getAllCategories, getDataBounds, type TxRow, type SortMode } from '../core/queries.js';
 import type { Screen, TxFilter } from './App.js';
-import { NavHints, handleNavKey } from './nav.js';
+import { handleNavKey } from './nav.js';
 import { Divider } from './fmt.js';
 import { useTerminalWidth, MONTHS, C_POSITIVE, C_NEGATIVE, C_WARNING, C_NEUTRAL, C_MANUAL, C_ACCENT, C_DIM } from './ui.js';
-import { ModalPanel, usePagination, TextInput, SelectableRow, useStatusMessage } from './components/index.js';
+import { ModalPanel, usePagination, TextInput, SelectableRow, useStatusMessage, PageHeader, SearchBar } from './components/index.js';
 import { useRefreshKey } from './RefreshContext.js';
 import { useSetTyping } from './TypingContext.js';
 
@@ -428,10 +428,7 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
 
   return (
     <Box flexDirection="column" paddingX={2} paddingY={1}>
-      <Box justifyContent="space-between">
-        <Text bold color={C_ACCENT}>fungible</Text>
-        <NavHints current="transactions" showHints={showHints} />
-      </Box>
+      <PageHeader current="transactions" showHints={showHints} />
       <Box marginTop={1}>
         <Text bold>
           Transactions
@@ -444,13 +441,7 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
         </Text>
       </Box>}
 
-      {mode === 'search' && (
-        <Box marginTop={1} gap={1}>
-          <Text color={C_ACCENT}>/</Text>
-          <TextInput value={searchInput} />
-          <Text dimColor>  Esc cancel</Text>
-        </Box>
-      )}
+      {mode === 'search' && <SearchBar value={searchInput} />}
       <Box marginTop={1}><Divider /></Box>
 
       <Box marginTop={1}>

--- a/tui/Transactions.tsx
+++ b/tui/Transactions.tsx
@@ -437,7 +437,7 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
       </Box>
       <Text dimColor>
         {showHints
-          ? `${from ? '← →  ·  ' : ''}[s] sort  ·  [/] search  ·  [e] edit  [g] tag  [i] ignore  [x] delete`
+          ? `[/] search  ·  ${from ? '← →  ·  ' : ''}[s] sort  ·  [e] edit  [g] tag  [i] ignore  [x] delete`
           : '[/] search'}
       </Text>
 

--- a/tui/Transactions.tsx
+++ b/tui/Transactions.tsx
@@ -17,7 +17,8 @@ import { getTransactions, getAllCategories, getDataBounds, type TxRow, type Sort
 import type { Screen, TxFilter } from './App.js';
 import { NavHints, handleNavKey } from './nav.js';
 import { Divider } from './fmt.js';
-import { useTerminalWidth, CURSOR, MONTHS, C_POSITIVE, C_NEGATIVE, C_WARNING, C_NEUTRAL, C_MANUAL, C_ACCENT, C_DIM } from './ui.js';
+import { useTerminalWidth, MONTHS, C_POSITIVE, C_NEGATIVE, C_WARNING, C_NEUTRAL, C_MANUAL, C_ACCENT, C_DIM } from './ui.js';
+import { ModalPanel, usePagination, TextInput, SelectableRow, useStatusMessage } from './components/index.js';
 import { useRefreshKey } from './RefreshContext.js';
 import { useSetTyping } from './TypingContext.js';
 
@@ -61,7 +62,7 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
   const [txs, setTxs] = useState<Tx[]>([]);
   const [cursor, setCursor] = useState(0);
   const [mode, setMode] = useState<Mode>('list');
-  const [statusMsg, setStatusMsg] = useState('');
+  const { statusMsg, showStatus } = useStatusMessage();
   const [categories, setCategories] = useState<string[]>([]);
 
   // Edit panel state
@@ -159,9 +160,8 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
       setTransactionCategory(selected.id, newCat);
     }
 
-    if (nameChanged || catChanged) setStatusMsg('Transaction updated');
+    if (nameChanged || catChanged) showStatus('Transaction updated');
     setMode('list');
-    setTimeout(() => setStatusMsg(''), 2000);
     load(search, true);
   }
 
@@ -184,9 +184,8 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
       saved.push('name rule');
     }
 
-    setStatusMsg(saved.length ? `Saved: ${saved.join(' + ')}` : 'No changes');
+    showStatus(saved.length ? `Saved: ${saved.join(' + ')}` : 'No changes', 3000);
     setMode('list');
-    setTimeout(() => setStatusMsg(''), 3000);
     load(search, true);
   }
 
@@ -199,8 +198,7 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
   function clearOverride() {
     if (!selected || !selected.manual_category) return;
     clearTransactionOverride(selected.id);
-    setStatusMsg('Override cleared');
-    setTimeout(() => setStatusMsg(''), 2000);
+    showStatus('Override cleared');
     load(search, true);
   }
 
@@ -249,8 +247,7 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
         const t = filteredTags[tagCursor];
         const applyTag = (tagId: number) => {
           void addTagToTransactions(txs.map((tx) => tx.id), tagId);
-          setStatusMsg(`Tagged ${txs.length} transaction${txs.length !== 1 ? 's' : ''}`);
-          setTimeout(() => setStatusMsg(''), 2500);
+          showStatus(`Tagged ${txs.length} transaction${txs.length !== 1 ? 's' : ''}`, 2500);
           setMode('list');
           load(search, true);
         };
@@ -274,8 +271,7 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
         const newCat = categories[editCatCursor];
         if (newCat) {
           setTransactionCategoryBulk(txs.map((t) => t.id), newCat);
-          setStatusMsg(`Set category to "${newCat}" for ${txs.length} transaction${txs.length !== 1 ? 's' : ''}`);
-          setTimeout(() => setStatusMsg(''), 3000);
+          showStatus(`Set category to "${newCat}" for ${txs.length} transaction${txs.length !== 1 ? 's' : ''}`, 3000);
           setMode('list');
           load(search, true);
         }
@@ -374,8 +370,7 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
       if (input === 'C' && txs.length > 0) {
         clearOverridesBulk(txs.map((t) => t.id));
         const count = txs.filter((t) => t.manual_category).length;
-        setStatusMsg(`Cleared overrides on ${count} transaction${count !== 1 ? 's' : ''}`);
-        setTimeout(() => setStatusMsg(''), 2500);
+        showStatus(`Cleared overrides on ${count} transaction${count !== 1 ? 's' : ''}`, 2500);
         load(search, true);
         return;
       }
@@ -383,8 +378,7 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
       if (input === 'I' && txs.length > 0) {
         const target = !selected?.ignored;
         setIgnoredBulk(txs.map((t) => t.id), target);
-        setStatusMsg(`${target ? 'Ignored' : 'Un-ignored'} ${txs.length} transaction${txs.length !== 1 ? 's' : ''}`);
-        setTimeout(() => setStatusMsg(''), 2500);
+        showStatus(`${target ? 'Ignored' : 'Un-ignored'} ${txs.length} transaction${txs.length !== 1 ? 's' : ''}`, 2500);
         load(search, true);
         return;
       }
@@ -404,8 +398,7 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
   const catW  = Math.max(8,  txFlex - descW);
 
   const PAGE = 20;
-  const pageStart = Math.max(0, Math.min(cursor - Math.floor(PAGE / 2), txs.length - PAGE));
-  const visible = txs.slice(pageStart, pageStart + PAGE);
+  const { visible, pageStart } = usePagination(txs, cursor, PAGE);
 
   function dateLabel(): string | null {
     if (!from) return null;
@@ -452,28 +445,30 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
       </Box>}
 
       {mode === 'search' && (
-        <Box marginTop={1}>
+        <Box marginTop={1} gap={1}>
           <Text color={C_ACCENT}>/</Text>
-          <Text>{searchInput}</Text>
-          <Text color={C_ACCENT}>{CURSOR}</Text>
+          <TextInput value={searchInput} />
           <Text dimColor>  Esc cancel</Text>
         </Box>
       )}
       <Box marginTop={1}><Divider /></Box>
 
-      <Box gap={2} marginTop={1}>
-        <Text color={sort.startsWith('date') ? C_ACCENT : undefined} dimColor={!sort.startsWith('date')}>
-          {'  DATE ' + (sort === 'date-desc' ? '↓' : sort === 'date-asc' ? '↑' : ' ') + '   '}
-        </Text>
-        <Text color={sort.startsWith('name') ? C_ACCENT : undefined} dimColor={!sort.startsWith('name')}>
-          {('DESCRIPTION' + (sort === 'name-asc' ? ' ↑' : sort === 'name-desc' ? ' ↓' : '  ')).padEnd(descW)}
-        </Text>
-        <Text color={sort.startsWith('amount') ? C_ACCENT : undefined} dimColor={!sort.startsWith('amount')}>
-          {('AMOUNT' + (sort === 'amount-desc' ? ' ↓' : sort === 'amount-asc' ? ' ↑' : '  ')).padStart(10)}
-        </Text>
-        <Text color={sort.startsWith('category') ? C_ACCENT : undefined} dimColor={!sort.startsWith('category')}>
-          {'CATEGORY' + (sort === 'category-asc' ? ' ↑' : sort === 'category-desc' ? ' ↓' : '')}
-        </Text>
+      <Box marginTop={1}>
+        <Text>{'  '}</Text>
+        <Box gap={2}>
+          <Text color={sort.startsWith('date') ? C_ACCENT : undefined} dimColor={!sort.startsWith('date')}>
+            {('DATE' + (sort === 'date-desc' ? ' ↓' : sort === 'date-asc' ? ' ↑' : '  ')).padEnd(10)}
+          </Text>
+          <Text color={sort.startsWith('name') ? C_ACCENT : undefined} dimColor={!sort.startsWith('name')}>
+            {('DESCRIPTION' + (sort === 'name-asc' ? ' ↑' : sort === 'name-desc' ? ' ↓' : '  ')).padEnd(descW)}
+          </Text>
+          <Text color={sort.startsWith('amount') ? C_ACCENT : undefined} dimColor={!sort.startsWith('amount')}>
+            {('AMOUNT' + (sort === 'amount-desc' ? ' ↓' : sort === 'amount-asc' ? ' ↑' : '  ')).padStart(10)}
+          </Text>
+          <Text color={sort.startsWith('category') ? C_ACCENT : undefined} dimColor={!sort.startsWith('category')}>
+            {'CATEGORY' + (sort === 'category-asc' ? ' ↑' : sort === 'category-desc' ? ' ↓' : '')}
+          </Text>
+        </Box>
       </Box>
 
       {visible.map((tx) => {
@@ -483,9 +478,9 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
         const hasTags = !!tx.tag_names;
         return (
           <Box key={tx.id} flexDirection="column">
-            <Box gap={2}>
+            <SelectableRow selected={isSelected}>
               <Text color={isSelected ? C_ACCENT : undefined} dimColor={isIgnored && !isSelected}>
-                {isSelected ? '▶ ' : '  '}{tx.date}
+                {tx.date}
               </Text>
               <Text dimColor={isIgnored}>{truncate(tx.display_name ?? tx.name, descW).padEnd(descW)}</Text>
               <Text color={isIgnored ? undefined : tx.amount < 0 ? C_POSITIVE : undefined} dimColor={isIgnored}>
@@ -497,7 +492,7 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
               >
                 {truncate((isPinned ? '◆ ' : '  ') + (isIgnored ? '~' : '') + tx.category, catW).padEnd(catW)}
               </Text>
-            </Box>
+            </SelectableRow>
             {hasTags && isSelected && (
               <Box paddingLeft={14}>
                 <Text color={C_ACCENT}>{truncate('# ' + tx.tag_names, inner - 14)}</Text>
@@ -512,12 +507,11 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
       {statusMsg && <Text color={C_POSITIVE}>{statusMsg}</Text>}
 
       {mode === 'tag' && selected && (
-        <Box flexDirection="column" marginTop={1} borderStyle="round" borderColor={C_WARNING} paddingX={2} paddingY={1}>
+        <ModalPanel borderColor={C_WARNING}>
           <Text bold>Tags  <Text dimColor>{selected.display_name ?? selected.name}</Text></Text>
           <Box marginTop={1} gap={2}>
             <Text dimColor>Filter/new: </Text>
-            <Text color={C_WARNING}>{tagInput}</Text>
-            <Text color={C_WARNING}>█</Text>
+            <TextInput value={tagInput} color={C_WARNING} />
           </Box>
           {filteredTags.length === 0 && tagInput ? (
             <Box marginTop={1}><Text dimColor>Enter to create "{tagInput}"</Text></Box>
@@ -526,12 +520,11 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
               const isSelected = i === tagCursor;
               const has = txTagIds.has(t.id);
               return (
-                <Box key={t.id}>
-                  <Text color={isSelected ? C_ACCENT : undefined}>{isSelected ? '▶ ' : '  '}</Text>
+                <SelectableRow key={t.id} selected={isSelected}>
                   <Text color={has ? C_POSITIVE : undefined} dimColor={!isSelected && !has}>
                     {has ? '● ' : '○ '}{t.name}
                   </Text>
-                </Box>
+                </SelectableRow>
               );
             })
           )}
@@ -539,16 +532,15 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
             <Box marginTop={1}><Text dimColor>No tags yet — type a name and Enter to create one</Text></Box>
           )}
           <Box marginTop={1}><Text dimColor>Space/Enter toggle  ·  Esc close</Text></Box>
-        </Box>
+        </ModalPanel>
       )}
 
       {mode === 'tag-all' && (
-        <Box flexDirection="column" marginTop={1} borderStyle="round" borderColor={C_ACCENT} paddingX={2} paddingY={1}>
+        <ModalPanel>
           <Text bold>Tag all <Text color={C_ACCENT}>{txs.length}</Text> visible transactions</Text>
           <Box marginTop={1} gap={2}>
             <Text dimColor>Tag: </Text>
-            <Text color={C_WARNING}>{tagInput}</Text>
-            <Text color={C_ACCENT}>{CURSOR}</Text>
+            <TextInput value={tagInput} />
           </Box>
           {filteredTags.length === 0 && tagInput ? (
             <Box marginTop={1}><Text dimColor>Enter to create & apply "{tagInput}"</Text></Box>
@@ -556,19 +548,18 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
             filteredTags.map((t, i) => {
               const isSel = i === tagCursor;
               return (
-                <Box key={t.id}>
-                  <Text color={isSel ? C_ACCENT : undefined}>{isSel ? '▶ ' : '  '}</Text>
+                <SelectableRow key={t.id} selected={isSel}>
                   <Text dimColor={!isSel}>{t.name}</Text>
-                </Box>
+                </SelectableRow>
               );
             })
           )}
           <Box marginTop={1}><Text dimColor>↑↓ select  ·  Enter apply  ·  Esc cancel</Text></Box>
-        </Box>
+        </ModalPanel>
       )}
 
       {mode === 'edit-all' && (
-        <Box flexDirection="column" marginTop={1} borderStyle="round" borderColor={C_MANUAL} paddingX={2} paddingY={1}>
+        <ModalPanel borderColor={C_MANUAL}>
           <Text bold>Set category for all <Text color={C_ACCENT}>{txs.length}</Text> visible transactions</Text>
           <Text dimColor>↑↓ select  ·  Enter apply  ·  Esc cancel</Text>
           <Box flexDirection="column" marginTop={1}>
@@ -576,24 +567,24 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
               const idx = catWinStart + i;
               const isSel = idx === editCatCursor;
               return (
-                <Text key={cat} color={isSel ? C_ACCENT : undefined} dimColor={!isSel}>
-                  {isSel ? '▶ ' : '  '}{cat}
-                </Text>
+                <SelectableRow key={cat} selected={isSel}>
+                  <Text color={isSel ? C_ACCENT : undefined} dimColor={!isSel}>{cat}</Text>
+                </SelectableRow>
               );
             })}
           </Box>
-        </Box>
+        </ModalPanel>
       )}
 
       {mode === 'edit' && selected && (
-        <Box flexDirection="column" marginTop={1} borderStyle="round" borderColor={C_ACCENT} paddingX={2} paddingY={1}>
+        <ModalPanel>
           <Text bold>Edit  <Text dimColor>{selected.name}</Text></Text>
 
           <Box marginTop={1} gap={3}>
             <Box flexDirection="column">
               <Text color={editField === 'name' ? C_ACCENT : C_DIM} bold>Name</Text>
               {editField === 'name'
-                ? <Box><Text color={C_WARNING}>{editName || <Text dimColor>type new name…</Text>}</Text><Text color={C_ACCENT}>█</Text></Box>
+                ? <TextInput value={editName} color={C_WARNING} placeholder="type new name…" />
                 : <Text dimColor>{editName || '(unchanged)'}</Text>
               }
             </Box>
@@ -606,9 +597,9 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
                     const idx = catWinStart + i;
                     const isSel = idx === editCatCursor;
                     return (
-                      <Text key={cat} color={isSel ? C_ACCENT : undefined} dimColor={!isSel}>
-                        {isSel ? '▶ ' : '  '}{cat}
-                      </Text>
+                      <SelectableRow key={cat} selected={isSel}>
+                        <Text color={isSel ? C_ACCENT : undefined} dimColor={!isSel}>{cat}</Text>
+                      </SelectableRow>
                     );
                   })}
                 </Box>
@@ -624,11 +615,11 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
               : <><Text color={C_ACCENT}>[t] / Enter  this transaction</Text><Text color={C_ACCENT}>[r] make rule</Text><Text dimColor>← name  ·  Esc cancel</Text></>
             }
           </Box>
-        </Box>
+        </ModalPanel>
       )}
 
       {mode === 'edit-rule' && selected && (
-        <Box flexDirection="column" marginTop={1} borderStyle="round" borderColor={C_MANUAL} paddingX={2} paddingY={1}>
+        <ModalPanel borderColor={C_MANUAL}>
           <Text bold>Make Rule</Text>
           {categories[editCatCursor] !== selected.category && (
             <Text dimColor>Category: <Text color={C_NEGATIVE}>{selected.category}</Text> → <Text color={C_ACCENT}>{categories[editCatCursor]}</Text></Text>
@@ -639,7 +630,7 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
 
           <Box gap={2} marginTop={1}>
             <Text>Pattern </Text>
-            <Text color={C_MANUAL}>{editPattern}</Text><Text color={C_MANUAL}>█</Text>
+            <TextInput value={editPattern} color={C_MANUAL} />
           </Box>
           <Box gap={3} marginTop={1}>
             <Text color={editMatchType === 'name' ? C_NEUTRAL : undefined} dimColor={editMatchType !== 'name'}>[n] name</Text>
@@ -647,7 +638,7 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
             <Text color={C_WARNING}>{matchCount} transactions match</Text>
           </Box>
           <Box marginTop={1}><Text dimColor>Enter save  ·  Esc back</Text></Box>
-        </Box>
+        </ModalPanel>
       )}
     </Box>
   );

--- a/tui/Trends.tsx
+++ b/tui/Trends.tsx
@@ -133,10 +133,8 @@ export function Trends({
     <Box flexDirection="column" paddingX={2} paddingY={1}>
       <PageHeader current="trends" showHints={showHints} />
 
-      <Box justifyContent="space-between" marginTop={1}>
-        <Text bold>Trends</Text>
-        {showHints && <Text dimColor>[Tab] view  ·  ↑↓ navigate  ·  [r] range  ·  Enter txns</Text>}
-      </Box>
+      <Box marginTop={1}><Text bold>Trends</Text></Box>
+      {showHints && <Text dimColor>[Tab] view  ·  ↑↓ navigate  ·  [r] range  ·  Enter txns</Text>}
 
       <Box justifyContent="space-between" marginTop={1}>
         <Box gap={2}>

--- a/tui/Trends.tsx
+++ b/tui/Trends.tsx
@@ -4,9 +4,9 @@ import { type TrendsRange } from '../core/dateUtils.js';
 import { buildTrendViews, generateAllPeriods, getPeriodTotals, type View, type PeriodRow } from '../core/trends.js';
 import type { Screen, TxFilter } from './App.js';
 import { fmt, fmtSigned, bar, Divider } from './fmt.js';
-import { NavHints, handleNavKey } from './nav.js';
+import { handleNavKey } from './nav.js';
 import { useTerminalWidth, FLEX_COLORS, C_POSITIVE, C_NEGATIVE, C_NEUTRAL, C_ACCENT } from './ui.js';
-import { StatCard, usePagination, SelectableRow } from './components/index.js';
+import { StatCard, usePagination, SelectableRow, PageHeader } from './components/index.js';
 import { useRefreshKey } from './RefreshContext.js';
 
 const TRENDS_RANGES: TrendsRange[] = ['week', 'month', 'quarter', 'year'];
@@ -131,10 +131,7 @@ export function Trends({
 
   return (
     <Box flexDirection="column" paddingX={2} paddingY={1}>
-      <Box justifyContent="space-between">
-        <Text bold color={C_ACCENT}>fungible</Text>
-        <NavHints current="trends" showHints={showHints} />
-      </Box>
+      <PageHeader current="trends" showHints={showHints} />
 
       <Box justifyContent="space-between" marginTop={1}>
         <Text bold>Trends</Text>

--- a/tui/Trends.tsx
+++ b/tui/Trends.tsx
@@ -6,6 +6,7 @@ import type { Screen, TxFilter } from './App.js';
 import { fmt, fmtSigned, bar, Divider } from './fmt.js';
 import { NavHints, handleNavKey } from './nav.js';
 import { useTerminalWidth, FLEX_COLORS, C_POSITIVE, C_NEGATIVE, C_NEUTRAL, C_ACCENT } from './ui.js';
+import { StatCard, usePagination, SelectableRow } from './components/index.js';
 import { useRefreshKey } from './RefreshContext.js';
 
 const TRENDS_RANGES: TrendsRange[] = ['week', 'month', 'quarter', 'year'];
@@ -96,8 +97,7 @@ export function Trends({
   }, { isActive: isActive !== false });
 
   const PAGE = 30;
-  const pageStart = Math.max(0, Math.min(cursor - Math.floor(PAGE / 2), rows.length - PAGE));
-  const visible = rows.slice(pageStart, pageStart + PAGE);
+  const { visible, pageStart } = usePagination(rows, cursor, PAGE);
 
   // Scale maxes
   const maxIncome   = isNet ? Math.max(...rows.map((r) => r.income   ?? 0), 1) : 1;
@@ -160,21 +160,27 @@ export function Trends({
         <>
           <Box flexDirection="column" marginTop={1}>
             {isNet && (
-              <Box gap={1} marginBottom={1}>
-                <Text dimColor>{' '.repeat(2 + labelWidth)}</Text>
-                <Text dimColor>{''.padStart(13)}</Text>
-                <Text color={C_NEGATIVE} dimColor>{'expenses ←'.padStart(HALF_BAR)}</Text>
-                <Text dimColor>{'|'}</Text>
-                <Text color={C_POSITIVE}>{'→ income'}</Text>
+              <Box marginBottom={1}>
+                <Text>{'  '}</Text>
+                <Box gap={1}>
+                  <Text dimColor>{''.padEnd(labelWidth)}</Text>
+                  <Text dimColor>{''.padStart(13)}</Text>
+                  <Text color={C_NEGATIVE} dimColor>{'expenses ←'.padStart(HALF_BAR)}</Text>
+                  <Text dimColor>{'|'}</Text>
+                  <Text color={C_POSITIVE}>{'→ income'}</Text>
+                </Box>
               </Box>
             )}
             {isFlexBreakdown && (
-              <Box gap={2} marginBottom={1}>
-                <Text dimColor>{' '.repeat(2 + labelWidth)}</Text>
-                <Text dimColor>{''.padStart(13)}</Text>
-                <Text color={FLEX_COLORS.fixed} dimColor>{'fixed'.padEnd(FLEX_BAR)}</Text>
-                <Text color={FLEX_COLORS.flexible} dimColor>{'flexible'.padEnd(FLEX_BAR)}</Text>
-                <Text color={FLEX_COLORS.discretionary} dimColor>{'discr'}</Text>
+              <Box marginBottom={1}>
+                <Text>{'  '}</Text>
+                <Box gap={2}>
+                  <Text dimColor>{''.padEnd(labelWidth)}</Text>
+                  <Text dimColor>{''.padStart(13)}</Text>
+                  <Text color={FLEX_COLORS.fixed} dimColor>{'fixed'.padEnd(FLEX_BAR)}</Text>
+                  <Text color={FLEX_COLORS.flexible} dimColor>{'flexible'.padEnd(FLEX_BAR)}</Text>
+                  <Text color={FLEX_COLORS.discretionary} dimColor>{'discr'}</Text>
+                </Box>
               </Box>
             )}
             {visible.map((row, i) => {
@@ -187,17 +193,15 @@ export function Trends({
                 const rightBar = '█'.repeat(incFilled) + '░'.repeat(HALF_BAR - incFilled);
                 const net = row.income - row.expenses;
                 return (
-                  <Box key={row.from} gap={1}>
-                    <Text color={isSelected ? C_ACCENT : undefined}>
-                      {isSelected ? '▶ ' : '  '}{row.label.padEnd(labelWidth)}
-                    </Text>
+                  <SelectableRow key={row.from} selected={isSelected} gap={1}>
+                    <Text color={isSelected ? C_ACCENT : undefined}>{row.label.padEnd(labelWidth)}</Text>
                     <Text color={net >= 0 ? C_POSITIVE : C_NEGATIVE} dimColor={!isSelected}>
                       {fmtSigned(net).padStart(13)}
                     </Text>
                     <Text color={C_NEGATIVE} dimColor={!isSelected}>{leftBar}</Text>
                     <Text dimColor>|</Text>
                     <Text color={C_POSITIVE} dimColor={!isSelected}>{rightBar}</Text>
-                  </Box>
+                  </SelectableRow>
                 );
               }
 
@@ -206,56 +210,45 @@ export function Trends({
                 const flexF  = Math.min(FLEX_BAR, Math.max(0, Math.round(((row.flexible ?? 0) / flexMax) * FLEX_BAR)));
                 const discrF = Math.min(FLEX_BAR, Math.max(0, Math.round(((row.discretionary ?? 0) / flexMax) * FLEX_BAR)));
                 return (
-                  <Box key={row.from} gap={2}>
-                    <Text color={isSelected ? C_ACCENT : undefined}>
-                      {isSelected ? '▶ ' : '  '}{row.label.padEnd(labelWidth)}
-                    </Text>
+                  <SelectableRow key={row.from} selected={isSelected}>
+                    <Text color={isSelected ? C_ACCENT : undefined}>{row.label.padEnd(labelWidth)}</Text>
                     <Text color={isSelected ? C_NEUTRAL : undefined} dimColor={!isSelected}>
                       {fmt(row.total).padStart(13)}
                     </Text>
                     <Text color={FLEX_COLORS.fixed} dimColor={!isSelected}>{'█'.repeat(fixedF) + '░'.repeat(FLEX_BAR - fixedF)}</Text>
                     <Text color={FLEX_COLORS.flexible} dimColor={!isSelected}>{'█'.repeat(flexF)  + '░'.repeat(FLEX_BAR - flexF)}</Text>
                     <Text color={FLEX_COLORS.discretionary} dimColor={!isSelected}>{'█'.repeat(discrF) + '░'.repeat(FLEX_BAR - discrF)}</Text>
-                  </Box>
+                  </SelectableRow>
                 );
               }
 
               return (
-                <Box key={row.from} gap={2}>
-                  <Text color={isSelected ? C_ACCENT : undefined}>
-                    {isSelected ? '▶ ' : '  '}{row.label.padEnd(labelWidth)}
-                  </Text>
+                <SelectableRow key={row.from} selected={isSelected}>
+                  <Text color={isSelected ? C_ACCENT : undefined}>{row.label.padEnd(labelWidth)}</Text>
                   <Text color={isSelected ? C_NEUTRAL : undefined} dimColor={!isSelected}>
                     {fmt(row.total).padStart(13)}
                   </Text>
                   <Text color={color} dimColor={!isSelected}>
                     {bar(row.total, absMax, BAR_WIDTH)}
                   </Text>
-                </Box>
+                </SelectableRow>
               );
             })}
           </Box>
 
           <Box marginTop={1}><Divider /></Box>
           <Box gap={6} marginTop={1}>
-            <Box flexDirection="column">
-              <Text dimColor>periods</Text>
-              <Text bold>{rows.length}</Text>
-            </Box>
-            <Box flexDirection="column">
-              <Text dimColor>avg/{RANGE_LABELS[range].toLowerCase()}</Text>
-              <Text bold color={isNet ? (avg >= 0 ? C_POSITIVE : C_NEGATIVE) : undefined}>
-                {isNet ? fmtSigned(avg) : fmt(avg)}
-              </Text>
-            </Box>
+            <StatCard label="periods" value={String(rows.length)} />
+            <StatCard
+              label={`avg/${RANGE_LABELS[range].toLowerCase()}`}
+              value={isNet ? fmtSigned(avg) : fmt(avg)}
+              color={isNet ? (avg >= 0 ? C_POSITIVE : C_NEGATIVE) : undefined}
+            />
             {peak && peak.total > 0 && (
-              <Box flexDirection="column">
-                <Text dimColor>peak</Text>
-                <Text bold>
-                  {peak.label}{' '}
-                  <Text dimColor>{isNet ? fmtSigned(peak.total) : fmt(peak.total)}</Text>
-                </Text>
-              </Box>
+              <StatCard
+                label="peak"
+                value={<>{peak.label}{' '}<Text dimColor>{isNet ? fmtSigned(peak.total) : fmt(peak.total)}</Text></>}
+              />
             )}
           </Box>
         </>

--- a/tui/components/ColumnHeader.tsx
+++ b/tui/components/ColumnHeader.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Box, Text } from 'ink';
+
+type Col = { label: string; width?: number; align?: 'left' | 'right' };
+
+/**
+ * A row of dimColor column headers. Set hasCursor to align with SelectableRow rows
+ * (adds a 2-char placeholder matching the ▶ / space indicator).
+ */
+export function ColumnHeader({ columns, hasCursor = false, marginTop = 1 }: { columns: Col[]; hasCursor?: boolean; marginTop?: number }) {
+  const cells = columns.map(({ label, width, align }, i) => (
+    <Text key={i} dimColor>
+      {width ? (align === 'right' ? label.padStart(width) : label.padEnd(width)) : label}
+    </Text>
+  ));
+  if (hasCursor) {
+    return (
+      <Box marginTop={marginTop}>
+        <Text>{'  '}</Text>
+        <Box gap={2}>{cells}</Box>
+      </Box>
+    );
+  }
+  return <Box gap={2} marginTop={marginTop}>{cells}</Box>;
+}

--- a/tui/components/ModalPanel.tsx
+++ b/tui/components/ModalPanel.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Box, Text } from 'ink';
+import { C_ACCENT } from '../ui.js';
+
+export function ModalPanel({ title, borderColor, children }: { title?: string; borderColor?: string; children: React.ReactNode }) {
+  return (
+    <Box flexDirection="column" marginTop={1} borderStyle="round" borderColor={borderColor ?? C_ACCENT} paddingX={2} paddingY={1}>
+      {title && <Text bold>{title}</Text>}
+      {children}
+    </Box>
+  );
+}

--- a/tui/components/PageHeader.tsx
+++ b/tui/components/PageHeader.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Box, Text } from 'ink';
+import type { Screen } from '../App.js';
+import { NavHints } from '../nav.js';
+import { C_ACCENT } from '../ui.js';
+
+export function PageHeader({ current, showHints }: { current: Screen; showHints: boolean }) {
+  return (
+    <Box justifyContent="space-between">
+      <Text bold color={C_ACCENT}>fungible</Text>
+      <NavHints current={current} showHints={showHints} />
+    </Box>
+  );
+}

--- a/tui/components/SearchBar.tsx
+++ b/tui/components/SearchBar.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Box, Text } from 'ink';
+import { TextInput } from './TextInput.js';
+import { C_ACCENT, C_WARNING } from '../ui.js';
+
+export function SearchBar({ value, hint = 'Esc cancel' }: { value: string; hint?: string }) {
+  return (
+    <Box gap={1} marginTop={1}>
+      <Text color={C_ACCENT}>/</Text>
+      <TextInput value={value} color={C_WARNING} />
+      <Text dimColor>  {hint}</Text>
+    </Box>
+  );
+}

--- a/tui/components/SectionHeader.tsx
+++ b/tui/components/SectionHeader.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { Text } from 'ink';
+
+export function SectionHeader({ children }: { children: React.ReactNode }) {
+  return <Text bold dimColor>{children}</Text>;
+}

--- a/tui/components/SelectableRow.tsx
+++ b/tui/components/SelectableRow.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Box, Text } from 'ink';
+import { C_ACCENT } from '../ui.js';
+
+/**
+ * Row with a ▶ / space cursor indicator. The indicator is flush-adjacent to the
+ * first child (no gap between them), matching the existing cursor-embedded pattern.
+ * gap applies between all children in the content area.
+ */
+export function SelectableRow({ selected, gap = 2, children }: { selected: boolean; gap?: number; children: React.ReactNode }) {
+  return (
+    <Box>
+      <Text color={selected ? C_ACCENT : undefined}>{selected ? '▶ ' : '  '}</Text>
+      <Box gap={gap}>{children}</Box>
+    </Box>
+  );
+}

--- a/tui/components/StatCard.tsx
+++ b/tui/components/StatCard.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { Box, Text } from 'ink';
+
+export function StatCard({ label, value, color }: { label: string; value: React.ReactNode; color?: string }) {
+  return (
+    <Box flexDirection="column">
+      <Text dimColor>{label}</Text>
+      <Text bold color={color}>{value}</Text>
+    </Box>
+  );
+}

--- a/tui/components/TextInput.tsx
+++ b/tui/components/TextInput.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Box, Text } from 'ink';
+import { CURSOR, C_ACCENT } from '../ui.js';
+
+/** Inline text input display: shows value (or dimmed placeholder) followed by the block cursor. */
+export function TextInput({ value, color, placeholder }: { value: string; color?: string; placeholder?: string }) {
+  return (
+    <Box>
+      {value ? (
+        <Text color={color}>{value}</Text>
+      ) : placeholder ? (
+        <Text dimColor>{placeholder}</Text>
+      ) : null}
+      <Text color={C_ACCENT}>{CURSOR}</Text>
+    </Box>
+  );
+}

--- a/tui/components/TextInput.tsx
+++ b/tui/components/TextInput.tsx
@@ -3,7 +3,7 @@ import { Box, Text } from 'ink';
 import { CURSOR, C_ACCENT } from '../ui.js';
 
 /** Inline text input display: shows value (or dimmed placeholder) followed by the block cursor. */
-export function TextInput({ value, color, placeholder }: { value: string; color?: string; placeholder?: string }) {
+export function TextInput({ value, color, placeholder, showCursor = true }: { value: string; color?: string; placeholder?: string; showCursor?: boolean }) {
   return (
     <Box>
       {value ? (
@@ -11,7 +11,7 @@ export function TextInput({ value, color, placeholder }: { value: string; color?
       ) : placeholder ? (
         <Text dimColor>{placeholder}</Text>
       ) : null}
-      <Text color={C_ACCENT}>{CURSOR}</Text>
+      {showCursor && <Text color={C_ACCENT}>{CURSOR}</Text>}
     </Box>
   );
 }

--- a/tui/components/index.ts
+++ b/tui/components/index.ts
@@ -1,0 +1,8 @@
+export { StatCard } from './StatCard.js';
+export { ModalPanel } from './ModalPanel.js';
+export { SectionHeader } from './SectionHeader.js';
+export { SelectableRow } from './SelectableRow.js';
+export { TextInput } from './TextInput.js';
+export { usePagination } from './usePagination.js';
+export { useStatusMessage } from './useStatusMessage.js';
+export { ColumnHeader } from './ColumnHeader.js';

--- a/tui/components/index.ts
+++ b/tui/components/index.ts
@@ -6,3 +6,5 @@ export { TextInput } from './TextInput.js';
 export { usePagination } from './usePagination.js';
 export { useStatusMessage } from './useStatusMessage.js';
 export { ColumnHeader } from './ColumnHeader.js';
+export { PageHeader } from './PageHeader.js';
+export { SearchBar } from './SearchBar.js';

--- a/tui/components/usePagination.ts
+++ b/tui/components/usePagination.ts
@@ -1,0 +1,6 @@
+/** Returns the visible slice of items centered on cursor, and the index of the first visible item. */
+export function usePagination<T>(items: T[], cursor: number, pageSize: number): { visible: T[]; pageStart: number } {
+  const pageStart = Math.max(0, Math.min(cursor - Math.floor(pageSize / 2), items.length - pageSize));
+  const visible = items.slice(pageStart, pageStart + pageSize);
+  return { visible, pageStart };
+}

--- a/tui/components/useStatusMessage.ts
+++ b/tui/components/useStatusMessage.ts
@@ -1,0 +1,11 @@
+import { useState, useCallback } from 'react';
+
+/** Replaces the setStatusMsg + setTimeout(clear) pattern. */
+export function useStatusMessage(defaultDuration = 2000) {
+  const [statusMsg, setStatusMsg] = useState('');
+  const showStatus = useCallback((msg: string, ms = defaultDuration) => {
+    setStatusMsg(msg);
+    setTimeout(() => setStatusMsg(''), ms);
+  }, [defaultDuration]);
+  return { statusMsg, showStatus };
+}

--- a/tui/components/useStatusMessage.ts
+++ b/tui/components/useStatusMessage.ts
@@ -3,7 +3,7 @@ import { useState, useCallback, useRef, useEffect } from 'react';
 /** Replaces the setStatusMsg + setTimeout(clear) pattern. */
 export function useStatusMessage(defaultDuration = 2000) {
   const [statusMsg, setStatusMsg] = useState('');
-  const timerRef = useRef<ReturnType<typeof setTimeout>>();
+  const timerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
   useEffect(() => () => clearTimeout(timerRef.current), []);
 

--- a/tui/components/useStatusMessage.ts
+++ b/tui/components/useStatusMessage.ts
@@ -1,11 +1,17 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useRef, useEffect } from 'react';
 
 /** Replaces the setStatusMsg + setTimeout(clear) pattern. */
 export function useStatusMessage(defaultDuration = 2000) {
   const [statusMsg, setStatusMsg] = useState('');
+  const timerRef = useRef<ReturnType<typeof setTimeout>>();
+
+  useEffect(() => () => clearTimeout(timerRef.current), []);
+
   const showStatus = useCallback((msg: string, ms = defaultDuration) => {
+    clearTimeout(timerRef.current);
     setStatusMsg(msg);
-    setTimeout(() => setStatusMsg(''), ms);
+    timerRef.current = setTimeout(() => setStatusMsg(''), ms);
   }, [defaultDuration]);
+
   return { statusMsg, showStatus };
 }

--- a/tui/fmt.tsx
+++ b/tui/fmt.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Text } from 'ink';
-export { fmt, fmtSigned, fmtPct, fmtMonths } from '../core/fmt.js';
+export { fmt, fmtSigned, fmtPct, fmtMonths, fmtCompact } from '../core/fmt.js';
 export { BAR_WIDTH, bar, truncate } from './charUtils.js';
 
 export function Divider({ width }: { width?: number }) {


### PR DESCRIPTION
## Summary

- Extracts shared TUI components into `tui/components/`: `PageHeader`, `SearchBar`, `TextInput`, `StatCard`, `ModalPanel`, `SectionHeader`, `SelectableRow`, `ColumnHeader`, `usePagination`, `useStatusMessage`
- Applies components across all 8 screens — removes duplicated header/nav/input boilerplate from every screen
- Fixes `useStatusMessage` timer leak (replaces captured `setTimeout` id with `useRef` + `clearTimeout` on unmount)
- Moves per-screen hints onto their own line below the title so they never collide with the screen title
- On search-capable screens (Dashboard, Transactions, Tags, Rules), `[/] search` is always visible and leads the hint line — toggling hints just appends the rest to the right
- Adds `fmtCompact` formatter (`$1.84M`, `$68.6K`) used in Health's RETIREMENT section and debt descriptions to prevent overflow of the value column
- Unifies Health value column width (`padStart(V=12)`) across all sections so values right-align consistently
- Shortens Health DEBT description to fit at 80-col terminals without wrapping
- Adds 4 Trends screen tests and snapshot test harness for cross-branch visual comparison

## Test plan

- [ ] `npx vitest run` — 373 tests pass
- [ ] Toggle `[h]` on Dashboard, Transactions, Tags, Rules — confirm `[/] search` stays anchored at the start of the hint line in both states
- [ ] Navigate to Health screen, verify SNAPSHOT/RUNWAY/DEBT/RETIREMENT/ASSUMPTIONS all right-align cleanly
- [ ] Confirm FIRE number and net worth show compact format (`$X.XXM`) for million-scale values
- [ ] Verify all 8 screens show `fungible` header and nav hints via PageHeader

🤖 Generated with [Claude Code](https://claude.com/claude-code)