### PR TITLE
feat: UX polish — arrow nav, period telegraphing, savings sign

### DIFF
--- a/core/backup.ts
+++ b/core/backup.ts
@@ -1,7 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { DATA_DIR } from './paths.js';
-import { db } from './db.js';
 
 const DB_PATH = path.join(DATA_DIR, 'fungible.db');
 const BACKUP_DIR = path.join(DATA_DIR, 'backups');
@@ -18,8 +17,15 @@ export async function backupDb(): Promise<void> {
   const backupPath = path.join(BACKUP_DIR, `fungible.${today}.bak`);
 
   if (!fs.existsSync(backupPath)) {
-    await db.execute('PRAGMA wal_checkpoint(TRUNCATE)');
     await fs.promises.copyFile(DB_PATH, backupPath);
+    // Copy WAL and SHM alongside so SQLite can replay all committed data when
+    // the backup is opened. The main .db file may lag behind by days in WAL mode.
+    for (const suffix of ['-wal', '-shm']) {
+      const src = `${DB_PATH}${suffix}`;
+      if (fs.existsSync(src)) {
+        await fs.promises.copyFile(src, `${backupPath}${suffix}`);
+      }
+    }
   }
 
   const files = fs.readdirSync(BACKUP_DIR)
@@ -27,6 +33,11 @@ export async function backupDb(): Promise<void> {
     .sort();
 
   for (const file of files.slice(0, -keepDays)) {
-    fs.unlinkSync(path.join(BACKUP_DIR, file));
+    const base = path.join(BACKUP_DIR, file);
+    fs.unlinkSync(base);
+    for (const suffix of ['-wal', '-shm']) {
+      const side = `${base}${suffix}`;
+      if (fs.existsSync(side)) fs.unlinkSync(side);
+    }
   }
 }

--- a/core/backup.ts
+++ b/core/backup.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { DATA_DIR } from './paths.js';
+import { db } from './db.js';
 
 const DB_PATH = path.join(DATA_DIR, 'fungible.db');
 const BACKUP_DIR = path.join(DATA_DIR, 'backups');
@@ -17,15 +18,7 @@ export async function backupDb(): Promise<void> {
   const backupPath = path.join(BACKUP_DIR, `fungible.${today}.bak`);
 
   if (!fs.existsSync(backupPath)) {
-    await fs.promises.copyFile(DB_PATH, backupPath);
-    // Copy WAL and SHM alongside so SQLite can replay all committed data when
-    // the backup is opened. The main .db file may lag behind by days in WAL mode.
-    for (const suffix of ['-wal', '-shm']) {
-      const src = `${DB_PATH}${suffix}`;
-      if (fs.existsSync(src)) {
-        await fs.promises.copyFile(src, `${backupPath}${suffix}`);
-      }
-    }
+    await db.execute({ sql: 'VACUUM INTO ?', args: [backupPath] });
   }
 
   const files = fs.readdirSync(BACKUP_DIR)
@@ -33,11 +26,6 @@ export async function backupDb(): Promise<void> {
     .sort();
 
   for (const file of files.slice(0, -keepDays)) {
-    const base = path.join(BACKUP_DIR, file);
-    fs.unlinkSync(base);
-    for (const suffix of ['-wal', '-shm']) {
-      const side = `${base}${suffix}`;
-      if (fs.existsSync(side)) fs.unlinkSync(side);
-    }
+    fs.unlinkSync(path.join(BACKUP_DIR, file));
   }
 }

--- a/core/backup.ts
+++ b/core/backup.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { DATA_DIR } from './paths.js';
+import { db } from './db.js';
 
 const DB_PATH = path.join(DATA_DIR, 'fungible.db');
 const BACKUP_DIR = path.join(DATA_DIR, 'backups');
@@ -17,6 +18,7 @@ export async function backupDb(): Promise<void> {
   const backupPath = path.join(BACKUP_DIR, `fungible.${today}.bak`);
 
   if (!fs.existsSync(backupPath)) {
+    await db.execute('PRAGMA wal_checkpoint(TRUNCATE)');
     await fs.promises.copyFile(DB_PATH, backupPath);
   }
 

--- a/tests/backup.test.ts
+++ b/tests/backup.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createClient } from '@libsql/client';
+
+// vi.hoisted runs before vi.mock factories, giving us a temp dir that backup.ts
+// can pick up when it computes its module-level DB_PATH and BACKUP_DIR constants.
+const { TEST_DATA_DIR } = vi.hoisted(() => {
+  const os = require('os') as typeof import('os');
+  const fs = require('fs') as typeof import('fs');
+  const path = require('path') as typeof import('path');
+  const dir = path.join(os.tmpdir(), `fungible-backup-${Date.now()}`);
+  fs.mkdirSync(dir, { recursive: true });
+  return { TEST_DATA_DIR: dir };
+});
+
+vi.mock('../core/paths.js', () => ({ DATA_DIR: TEST_DATA_DIR }));
+vi.mock('../core/db.js', async () => {
+  const { makeTestDb } = await import('./helpers/makeTestDb.js');
+  return { db: await makeTestDb() };
+});
+
+import { db } from '../core/db.js';
+import { backupDb } from '../core/backup.js';
+
+const BACKUP_DIR = path.join(TEST_DATA_DIR, 'backups');
+const TODAY = new Date().toISOString().slice(0, 10);
+const BACKUP_PATH = path.join(BACKUP_DIR, `fungible.${TODAY}.bak`);
+
+beforeEach(async () => {
+  // Fake db file on disk so the existsSync guard passes
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+  fs.writeFileSync(path.join(TEST_DATA_DIR, 'fungible.db'), '');
+  // Reset backup dir and in-memory data between tests
+  if (fs.existsSync(BACKUP_DIR)) fs.rmSync(BACKUP_DIR, { recursive: true });
+  await db.execute('DELETE FROM tags');
+});
+
+afterAll(() => {
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+describe('backupDb', () => {
+  it('creates a single backup file containing data written to the db', async () => {
+    await db.execute("INSERT INTO tags (name) VALUES ('brussels-trip')");
+
+    await backupDb();
+
+    expect(fs.existsSync(BACKUP_PATH)).toBe(true);
+    const backup = createClient({ url: `file:${BACKUP_PATH}` });
+    const { rows } = await backup.execute('SELECT name FROM tags');
+    expect(rows.map((r) => r.name)).toContain('brussels-trip');
+  });
+
+  it('does not overwrite an existing backup for today', async () => {
+    await backupDb();
+    const sizeBefore = fs.statSync(BACKUP_PATH).size;
+
+    await db.execute("INSERT INTO tags (name) VALUES ('extra-tag')");
+    await backupDb();
+
+    expect(fs.statSync(BACKUP_PATH).size).toBe(sizeBefore);
+  });
+
+  it('rotates backups older than keepDays', async () => {
+    fs.mkdirSync(BACKUP_DIR, { recursive: true });
+    for (const d of ['2026-01-01', '2026-01-02', '2026-01-03']) {
+      fs.writeFileSync(path.join(BACKUP_DIR, `fungible.${d}.bak`), '');
+    }
+
+    process.env.FUNGIBLE_BACKUP_DAYS = '2';
+    try {
+      await backupDb();
+    } finally {
+      delete process.env.FUNGIBLE_BACKUP_DAYS;
+    }
+
+    const files = fs.readdirSync(BACKUP_DIR).filter((f) => f.endsWith('.bak'));
+    // keepDays=2: today + 2026-01-03 kept; 2026-01-01 and 2026-01-02 rotated out
+    expect(files).not.toContain('fungible.2026-01-01.bak');
+    expect(files).not.toContain('fungible.2026-01-02.bak');
+    expect(files).toContain('fungible.2026-01-03.bak');
+    expect(files).toContain(`fungible.${TODAY}.bak`);
+  });
+
+  it('skips backup when FUNGIBLE_BACKUP_DAYS is 0', async () => {
+    process.env.FUNGIBLE_BACKUP_DAYS = '0';
+    try {
+      await backupDb();
+    } finally {
+      delete process.env.FUNGIBLE_BACKUP_DAYS;
+    }
+
+    expect(fs.existsSync(BACKUP_PATH)).toBe(false);
+  });
+});

--- a/tests/tui/screens.test.tsx
+++ b/tests/tui/screens.test.tsx
@@ -396,12 +396,12 @@ describe('Trends', () => {
     expect(onNavigate).toHaveBeenCalledWith('dashboard');
   });
 
-  it('Tab cycles through the base views in order', async () => {
+  it('right arrow cycles through the base views in order', async () => {
     const r = trends();
     const viewLabels = ['Expenses', 'Income', 'Net', 'Flexibility', 'Fixed', 'Flexible', 'Discretionary'];
     await waitFor(() => expect(frame(r)).toContain('Expenses'));
     for (let i = 1; i < viewLabels.length; i++) {
-      r.stdin.write('\t');
+      r.stdin.write('\x1B[C');
       await waitFor(() => expect(frame(r)).toContain(viewLabels[i]));
     }
   });
@@ -409,9 +409,9 @@ describe('Trends', () => {
   it('Net view shows expense/income direction headers', async () => {
     const r = trends();
     await waitFor(() => expect(frame(r)).toContain('Expenses'));
-    r.stdin.write('\t'); // Income
+    r.stdin.write('\x1B[C'); // Income
     await waitFor(() => expect(frame(r)).toContain('Income'));
-    r.stdin.write('\t'); // Net
+    r.stdin.write('\x1B[C'); // Net
     await waitFor(() => {
       const f = frame(r);
       expect(f).toContain('Net');
@@ -423,7 +423,7 @@ describe('Trends', () => {
   it('Flexibility view shows fixed/flexible/discr column headers', async () => {
     const r = trends();
     await waitFor(() => expect(frame(r)).toContain('Expenses'));
-    for (let i = 0; i < 3; i++) r.stdin.write('\t'); // Expenses→Income→Net→Flexibility
+    for (let i = 0; i < 3; i++) r.stdin.write('\x1B[C'); // Expenses→Income→Net→Flexibility
     await waitFor(() => {
       const f = frame(r);
       expect(f).toContain('Flexibility');

--- a/tui/Dashboard.tsx
+++ b/tui/Dashboard.tsx
@@ -380,7 +380,10 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
           {showHints && <Text dimColor>[r]</Text>}
         </Box>
         <Box gap={2}>
-          <Text bold>{formatPeriodLabel(range, anchor)}</Text>
+          {range !== 'alltime'
+            ? <Text><Text dimColor>← </Text><Text bold>{formatPeriodLabel(range, anchor)}</Text><Text dimColor> →</Text></Text>
+            : <Text bold>{formatPeriodLabel(range, anchor)}</Text>
+          }
           {selectedAccount && <Text color={C_WARNING}>{selectedAccount.name}</Text>}
           {driftMode && <Text color={C_MANUAL} bold>delta</Text>}
           <Text dimColor>

--- a/tui/Health.tsx
+++ b/tui/Health.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Box, Text, useInput } from 'ink';
 import type { Screen } from './App.js';
-import { fmt, fmtPct, fmtMonths, fmtCompact, Divider } from './fmt.js';
+import { fmt, fmtSigned, fmtPct, fmtMonths, fmtCompact, Divider } from './fmt.js';
 import { handleNavKey } from './nav.js';
 import { loadHealthData, yearsToFire, coastYears, type HealthData } from '../core/health.js';
 import { C_POSITIVE, C_NEGATIVE, C_WARNING, C_NEUTRAL, C_ACCENT } from './ui.js';
@@ -20,7 +20,6 @@ function runwayColor(months: number, green: number, yellow: number): string {
   if (months >= yellow) return C_WARNING;
   return C_NEGATIVE;
 }
-
 // ─── Constants ────────────────────────────────────────────────────────────────
 
 const DEFAULT_WITHDRAWAL    = 4.0;
@@ -274,7 +273,7 @@ export function Health({ onNavigate, isActive, showHints }: { onNavigate: (s: Sc
 
         <SelectableRow selected={currentDial === 'savings'} gap={2}>
           <Text color={currentDial === 'savings' ? C_ACCENT : undefined}>{'Monthly savings'.padEnd(16)}</Text>
-          <Text color={currentDial === 'savings' ? C_ACCENT : C_NEUTRAL}>{'[ '}{fmt(monthlySavings).padStart(V)}{' ]'}</Text>
+          <Text color={currentDial === 'savings' ? C_ACCENT : monthlySavings < 0 ? C_NEGATIVE : C_NEUTRAL}>{'[ '}{fmtSigned(monthlySavings).padStart(V)}{' ]'}</Text>
           <Text dimColor>
             {currentDial === 'savings'
               ? (savingsChanged ? `default ${fmt(defaultSavings)} · [r] reset` : `avg surplus past 12 mo  ← → ±${fmt(SPEND_STEP)}`)
@@ -287,7 +286,7 @@ export function Health({ onNavigate, isActive, showHints }: { onNavigate: (s: Sc
           <Text color={currentDial === 'withdrawal' ? C_ACCENT : C_NEUTRAL}>{'[ '}{fmtPct(withdrawal).padStart(V)}{' ]'}</Text>
           <Text dimColor>
             {currentDial === 'withdrawal'
-              ? `↑↓ ±${fmtPct(WITHDRAW_STEP)}${withdrawChanged ? ' · [r] reset' : ''}`
+              ? `← → ±${fmtPct(WITHDRAW_STEP)}${withdrawChanged ? ' · [r] reset' : ''}`
               : `safe withdrawal rate${withdrawChanged ? ' (modified)' : ''}`}
           </Text>
         </SelectableRow>
@@ -297,7 +296,7 @@ export function Health({ onNavigate, isActive, showHints }: { onNavigate: (s: Sc
           <Text color={currentDial === 'growth' ? C_ACCENT : C_NEUTRAL}>{'[ '}{fmtPct(growth).padStart(V)}{' ]'}</Text>
           <Text dimColor>
             {currentDial === 'growth'
-              ? `↑↓ ±${fmtPct(GROWTH_STEP)}${growthChanged ? ' · [r] reset' : ''}`
+              ? `← → ±${fmtPct(GROWTH_STEP)}${growthChanged ? ' · [r] reset' : ''}`
               : `real annual return${growthChanged ? ' (modified)' : ''}`}
           </Text>
         </SelectableRow>

--- a/tui/Transactions.tsx
+++ b/tui/Transactions.tsx
@@ -410,12 +410,12 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
     return `${from} – ${to ?? ''}`;
   }
 
+  const dl = dateLabel();
   const filterLabel = [
     accountName,
     tag ? `#${tag}` : null,
     search ? `"${search}"` : null,
     category,
-    dateLabel(),
   ].filter(Boolean).join(' · ');
 
   // Category list window for edit panel
@@ -433,6 +433,12 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
         <Text bold>
           Transactions
           {filterLabel ? <Text color={C_WARNING}>  {filterLabel}</Text> : null}
+          {dl ? <Text>
+            <Text color={C_WARNING}>{filterLabel ? '  · ' : '  '}</Text>
+            <Text dimColor>← </Text>
+            <Text color={C_WARNING}>{dl}</Text>
+            <Text dimColor> →</Text>
+          </Text> : null}
         </Text>
       </Box>
       <Text dimColor>

--- a/tui/Trends.tsx
+++ b/tui/Trends.tsx
@@ -83,7 +83,8 @@ export function Trends({
       return;
     }
     if (handleNavKey(input, 'trends', onNavigate)) return;
-    if (key.tab)        { setViewIdx((i) => (i + 1) % views.length); return; }
+    if (key.leftArrow)  { setViewIdx((i) => (i - 1 + views.length) % views.length); return; }
+    if (key.rightArrow) { setViewIdx((i) => (i + 1) % views.length); return; }
     if (key.upArrow)   { setCursor((c) => Math.max(0, c - 1)); return; }
     if (key.downArrow) { setCursor((c) => Math.min(rows.length - 1, c + 1)); return; }
     if (input === 'r') {
@@ -133,8 +134,10 @@ export function Trends({
     <Box flexDirection="column" paddingX={2} paddingY={1}>
       <PageHeader current="trends" showHints={showHints} />
 
-      <Box marginTop={1}><Text bold>Trends</Text></Box>
-      {showHints && <Text dimColor>[Tab] view  ·  ↑↓ navigate  ·  [r] range  ·  Enter txns</Text>}
+      <Box justifyContent="space-between" marginTop={1}>
+        <Text bold>Trends</Text>
+        {showHints && <Text dimColor>←→ view  ·  ↑↓ navigate  ·  [r] range  ·  Enter txns</Text>}
+      </Box>
 
       <Box justifyContent="space-between" marginTop={1}>
         <Box gap={2}>
@@ -145,7 +148,7 @@ export function Trends({
           ))}
           {showHints && <Text dimColor>[r]</Text>}
         </Box>
-        <Text><Text bold>{view.label}</Text><Text dimColor>  {posLabel}</Text></Text>
+        <Text><Text dimColor>← </Text><Text bold>{view.label}</Text><Text dimColor> →  {posLabel}</Text></Text>
       </Box>
       <Divider />
 


### PR DESCRIPTION
## Summary

- **Trends**: replace Tab with ←/→ for view cycling; view label now shows `← Expenses →` to telegraph the interaction
- **Dashboard**: period label shows `← May 2026 →` for all ranges except All Time
- **Transactions**: date filter label shows `← January 2026 →` when a month filter is active, appended after other active filters
- **Health assumptions**: monthly savings now shows sign (`+$500` / `-$500`) and turns red when negative; withdrawal and growth hint text corrected from `↑↓` to `← →`
- **Backup fix**: `VACUUM INTO` replaces raw file copy — backups now capture all WAL data, so tags and other recent writes are no longer silently missing

## Test plan

- [ ] Trends: left/right arrows cycle views; wraps at both ends; `← label →` position counter updates
- [ ] Dashboard: `← May 2026 →` appears for month/quarter/year/week ranges; All Time shows no arrows
- [ ] Transactions: drill into a month from Dashboard, confirm `← January 2026 →` in header; verify it combines correctly with category/tag/search filters
- [ ] Health: set savings below zero, confirm red `-$X.XX`; check column alignment with other dials; confirm withdrawal/growth active hint says `← → ±...`
- [ ] Backup: delete today's `.bak`, restart app, confirm new backup is a single file with all tables and tags present

🤖 Generated with [Claude Code](https://claude.com/claude-code)