### PR TITLE
feat: Canvas screen — agent-generated interactive financial tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.db
 *.sqlite
 node_modules/
+dist/
 memory/
 PLANS.md
 scripts/seed-rules.ts

--- a/core/agent-context.ts
+++ b/core/agent-context.ts
@@ -26,14 +26,18 @@ export type BalanceSummary = {
   totalAssets: number;
   totalLiabilities: number;
   netWorth: number;
-  cash: number;       // depository only
-  liquid: number;     // depository + non-retirement brokerage
+  cash: number;        // depository only
+  liquid: number;      // depository + taxable brokerage
+  retirement: number;  // 401k / IRA / Roth / HSA
+  loanDebt: number;    // mortgage / auto / student loans
 };
 
 export type FinancialHealth = {
   netWorth: number;
   cash: number;
   liquid: number;
+  retirement: number;
+  loanDebt: number;
   avgMonthlyExpenses: number;
   avgMonthlySavings: number;
   cashRunwayMonths: number;
@@ -101,12 +105,22 @@ export async function getBalances(): Promise<BalanceSummary> {
     .filter((a) => a.type === 'depository')
     .reduce((s, a) => s + a.balance, 0);
 
-  const LIQUID_SUBTYPES = new Set(['brokerage', 'cash isa', 'non-taxable brokerage account']);
+  const LIQUID_SUBTYPES     = new Set(['brokerage', 'cash isa', 'non-taxable brokerage account']);
+  const RETIREMENT_SUBTYPES = new Set(['ira', '401k', 'roth', '403b', '457b', 'hsa', 'roth 401k', 'simple ira', 'sep ira', 'pension']);
+
   const liquid = accounts
     .filter((a) =>
       a.type === 'depository' ||
       (a.type === 'investment' && LIQUID_SUBTYPES.has((a.subtype ?? '').toLowerCase()))
     )
+    .reduce((s, a) => s + a.balance, 0);
+
+  const retirement = accounts
+    .filter((a) => a.type === 'investment' && RETIREMENT_SUBTYPES.has((a.subtype ?? '').toLowerCase()))
+    .reduce((s, a) => s + a.balance, 0);
+
+  const loanDebt = accounts
+    .filter((a) => a.type === 'loan')
     .reduce((s, a) => s + a.balance, 0);
 
   return {
@@ -116,6 +130,8 @@ export async function getBalances(): Promise<BalanceSummary> {
     netWorth: totalAssets - totalLiabilities,
     cash,
     liquid,
+    retirement,
+    loanDebt,
   };
 }
 
@@ -160,6 +176,8 @@ export async function getFinancialHealth(
     netWorth: balances.netWorth,
     cash: balances.cash,
     liquid: balances.liquid,
+    retirement: balances.retirement,
+    loanDebt: balances.loanDebt,
     avgMonthlyExpenses,
     avgMonthlySavings,
     cashRunwayMonths,

--- a/core/agent.ts
+++ b/core/agent.ts
@@ -8,6 +8,8 @@ import { streamResponse, makeAssistantMessage, detectProvider, getProviderModel 
 import type { Message, ContentBlock, ToolDef } from './llm-provider.js';
 import { APP_CONTEXT } from './agent-context.js';
 import { TOOL_DEFS, WRITE_TOOLS, describeToolCall, executeTool } from './tools.js';
+import { loadCanvasContext } from './canvas-agent.js';
+import { buildPriorCanvasesSection } from './canvas-history.js';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -63,11 +65,11 @@ Model in use: ${model}
 
 const SHOW_TOOL: ToolDef = {
   name: 'show',
-  description: 'Navigate the app UI to display a specific screen or filtered view. Use this to show the user relevant data visually.',
+  description: 'Navigate the app UI to display a specific screen or filtered view. Use this to show the user relevant data visually. For "canvas", pass the generated CanvasSpec as a JSON string in canvasSpec.',
   parameters: {
     type: 'object',
     properties: {
-      screen:      { type: 'string', description: 'Screen to navigate to', enum: ['dashboard', 'transactions', 'trends', 'networth', 'tags', 'rules', 'accounts', 'health'] },
+      screen:      { type: 'string', description: 'Screen to navigate to', enum: ['dashboard', 'transactions', 'trends', 'networth', 'tags', 'rules', 'accounts', 'health', 'canvas'] },
       category:    { type: 'string', description: 'Filter transactions by category' },
       from:        { type: 'string', description: 'Start date YYYY-MM-DD' },
       to:          { type: 'string', description: 'End date YYYY-MM-DD' },
@@ -77,12 +79,25 @@ const SHOW_TOOL: ToolDef = {
       search:      { type: 'string', description: 'Pre-fill the search box on the transactions screen (regex)' },
       range:       { type: 'string', description: 'Time range to show on dashboard or trends', enum: ['week', 'month', 'quarter', 'year', 'alltime'] },
       anchor:      { type: 'string', description: 'Which period to land on — any date within it, YYYY-MM-DD (e.g. "2026-03-01" for March 2026)' },
+      canvasSpec:  { type: 'string', description: 'JSON-encoded CanvasSpec (required when screen is "canvas")' },
     },
     required: ['screen'],
   },
 };
 
-const AGENT_TOOL_DEFS: ToolDef[] = [...TOOL_DEFS, SHOW_TOOL];
+const GENERATE_CANVAS_TOOL: ToolDef = {
+  name: 'generate_canvas',
+  description: 'Load live financial data and the canvas schema. Returns context needed to build a CanvasSpec — including any prior canvases that cover a similar problem, so you can build on them rather than starting from scratch. After calling this, generate the CanvasSpec JSON following the returned instructions, then call show_canvas({ spec: JSON.stringify(spec), prompt: "<original user question>" }) to render and save it.',
+  parameters: {
+    type: 'object',
+    properties: {
+      prompt: { type: 'string', description: 'The user\'s canvas question, used to search for relevant prior canvases' },
+    },
+    required: ['prompt'],
+  },
+};
+
+const AGENT_TOOL_DEFS: ToolDef[] = [...TOOL_DEFS, SHOW_TOOL, GENERATE_CANVAS_TOOL];
 
 // ─── Tool dispatch (agent layer: show + confirmation wrapper) ──────────────────
 
@@ -91,18 +106,29 @@ async function dispatchTool(
   input: Record<string, unknown>,
   callbacks: AgentCallbacks,
 ): Promise<string> {
+  // Load canvas context — agent generates spec, then calls show_canvas
+  if (name === 'generate_canvas') {
+    const prompt = String(input.prompt ?? '');
+    const { system, tool } = await loadCanvasContext();
+    return [
+      `## User prompt\n${prompt}`,
+      buildPriorCanvasesSection(prompt),
+      `## Canvas instructions\n${system}`,
+      `## render_canvas tool schema\n${JSON.stringify(tool, null, 2)}`,
+      `Now generate the CanvasSpec JSON following these instructions, then call show_canvas({ spec: JSON.stringify(spec), prompt: ${JSON.stringify(prompt)} }).`,
+    ].filter(Boolean).join('\n\n');
+  }
+
   // UI navigation — agent-only, no confirmation
   if (name === 'show') {
-    const { screen, ...rest } = input as Record<string, string>;
+    const { screen, canvasSpec, ...rest } = input as Record<string, string>;
     const filter: Record<string, string> = {};
     for (const [k, v] of Object.entries(rest)) {
       if (v !== undefined && v !== null) filter[k] = String(v);
     }
+    if (canvasSpec) filter['canvasSpec'] = canvasSpec;
     callbacks.onNavigate(screen, filter);
-    const desc = Object.keys(filter).length
-      ? `${screen} (${Object.entries(filter).map(([k, v]) => `${k}: ${v}`).join(', ')})`
-      : screen;
-    return `Navigated to ${desc}`;
+    return `Navigated to ${screen}`;
   }
 
   // Write tools — confirm before executing

--- a/core/canvas-agent.ts
+++ b/core/canvas-agent.ts
@@ -1,0 +1,221 @@
+import { streamResponse } from './llm-provider.js';
+import { loadHealthData } from './health.js';
+import { fmt, fmtPct, fmtCompact, fmtMonths } from './fmt.js';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type DialFormat = 'dollar' | 'percent' | 'integer' | 'months' | 'years';
+
+export type DialDef = {
+  key: string;
+  label: string;
+  default: number;
+  step: number;
+  min?: number;
+  max?: number;
+  format: DialFormat;
+  hint: string;
+};
+
+export type OutputDef = {
+  label: string;
+  expr: string;         // pure JS arithmetic over dial keys — no side effects
+  format: DialFormat;
+  color?: 'positive' | 'negative' | 'neutral' | 'accent';
+};
+
+export type CanvasElement =
+  | { type: 'section'; label: string }
+  | { type: 'text';    content: string }
+  | { type: 'dial';    dial: DialDef }
+  | { type: 'output';  output: OutputDef };
+
+export type CanvasSpec = {
+  title: string;
+  elements: CanvasElement[];
+};
+
+// ─── Expression evaluator ─────────────────────────────────────────────────────
+
+export function evalExpr(expr: string, values: Record<string, number>): number {
+  try {
+    const keys = Object.keys(values);
+    const vals = keys.map((k) => values[k]);
+    // eslint-disable-next-line @typescript-eslint/no-implied-eval
+    const result = new Function(...keys, `"use strict"; return (${expr});`)(...vals);
+    return typeof result === 'number' && isFinite(result) ? result : NaN;
+  } catch {
+    return NaN;
+  }
+}
+
+export function fmtValue(n: number, format: DialFormat): string {
+  if (!isFinite(n) || isNaN(n)) return '—';
+  switch (format) {
+    case 'dollar':  return fmtCompact(n);
+    case 'percent': return fmtPct(n);
+    case 'months':  return fmtMonths(n);
+    case 'years':   return `${Math.ceil(n)} yr`;
+    case 'integer': return String(Math.round(n));
+  }
+}
+
+export function fmtDialValue(n: number, format: DialFormat): string {
+  if (!isFinite(n) || isNaN(n)) return '—';
+  switch (format) {
+    case 'dollar':  return fmt(n);
+    case 'percent': return fmtPct(n);
+    case 'months':  return fmtMonths(n);
+    case 'years':   return `${n} yr`;
+    case 'integer': return String(Math.round(n));
+  }
+}
+
+// ─── System prompt ────────────────────────────────────────────────────────────
+
+function buildSystemPrompt(financialContext: string): string {
+  return `You are a financial canvas generator embedded in fungible, a personal finance TUI app.
+
+Given a user's financial question and their live account data, you generate an interactive canvas — a set of adjustable inputs (dials) and computed outputs that render in the terminal.
+
+## Live financial data
+
+${financialContext}
+
+## How the canvas renders
+
+Each element is rendered top-to-bottom:
+- \`section\`: a bold section header (e.g. "INPUTS", "RESULTS")
+- \`text\`: a dim explanatory line — use for assumptions, caveats, data sources
+- \`dial\`: an interactive row the user adjusts with ← → arrow keys. Shows: label [ value ] hint
+- \`output\`: a computed result row. Shows: label   value   (hint)
+
+Dial values update live — outputs re-evaluate instantly as dials change.
+
+## Output expressions
+
+Each output has an \`expr\` field: a single-line JavaScript arithmetic expression.
+- Variables are the \`key\` fields of the dials
+- Only use: + - * / Math.pow Math.log Math.abs Math.round Math.floor Math.ceil
+- No variables other than dial keys, no function calls besides the Math methods above
+- Expressions must be self-contained — they cannot reference other output values
+
+Example: monthly mortgage payment with principal P, monthly rate r, n payments:
+  expr: "P * r / (1 - Math.pow(1 + r, -n))"
+
+## Design rules
+
+1. Pre-fill dial defaults from the provided live data where relevant — show the user their real numbers
+2. Add a \`text\` element when you use live data: "based on your $X monthly income"
+3. Keep labels short (≤ 18 chars) — they're padded in a fixed-width column
+4. Keep it focused — 3–6 dials and 1–4 outputs is ideal
+5. Use \`section\` to group: "INPUTS" before dials, "RESULTS" before outputs
+6. Choose \`color\` for outputs: "positive" for gains/savings, "negative" for costs/debt, "neutral" otherwise
+7. Format dials and outputs consistently — if a dial is "dollar", its related output should be too
+
+## Existing screen conventions (for consistency)
+
+The app uses these formatters:
+- dollar: fmt($1234.56) → "$1,234.56", fmtCompact($1.84M) → "$1.84M"
+- percent: fmtPct(7.0) → "7.0%"
+- months: fmtMonths(63.4) → "63.4 mo"
+- years: Math.ceil(n) + " yr"
+
+Colors: positive=green (gains/savings), negative=red (costs/debt/loss), accent=blue (neutral emphasis)
+
+Example canvas for "how long to pay off my credit card":
+{
+  "title": "Credit Card Payoff",
+  "elements": [
+    { "type": "text", "content": "based on your $21,494 in credit card debt" },
+    { "type": "section", "label": "INPUTS" },
+    { "type": "dial", "dial": { "key": "balance", "label": "Balance", "default": 21494, "step": 500, "min": 0, "format": "dollar", "hint": "current balance" }},
+    { "type": "dial", "dial": { "key": "rate", "label": "APR", "default": 22, "step": 0.5, "min": 0, "max": 40, "format": "percent", "hint": "annual rate" }},
+    { "type": "dial", "dial": { "key": "monthly", "label": "Monthly payment", "default": 500, "step": 50, "min": 0, "format": "dollar", "hint": "what you pay each month" }},
+    { "type": "section", "label": "RESULTS" },
+    { "type": "output", "output": { "label": "Months to payoff", "expr": "monthly <= balance * rate/100/12 ? Infinity : -Math.log(1 - balance * rate/100/12 / monthly) / Math.log(1 + rate/100/12)", "format": "months", "color": "neutral" }},
+    { "type": "output", "output": { "label": "Total interest", "expr": "monthly * (-Math.log(1 - balance * rate/100/12 / monthly) / Math.log(1 + rate/100/12)) - balance", "format": "dollar", "color": "negative" }}
+  ]
+}`;
+}
+
+// ─── Canvas generation ────────────────────────────────────────────────────────
+
+const CANVAS_TOOL = {
+  name: 'render_canvas',
+  description: 'Render an interactive financial canvas with adjustable dials and computed outputs.',
+  parameters: {
+    type: 'object',
+    required: ['title', 'elements'],
+    properties: {
+      title: { type: 'string' },
+      elements: {
+        type: 'array',
+        items: {
+          type: 'object',
+          required: ['type'],
+          properties: {
+            type: { type: 'string', enum: ['section', 'text', 'dial', 'output'] },
+            label:   { type: 'string' },
+            content: { type: 'string' },
+            dial: {
+              type: 'object',
+              required: ['key', 'label', 'default', 'step', 'format', 'hint'],
+              properties: {
+                key:     { type: 'string' },
+                label:   { type: 'string' },
+                default: { type: 'number' },
+                step:    { type: 'number' },
+                min:     { type: 'number' },
+                max:     { type: 'number' },
+                format:  { type: 'string', enum: ['dollar', 'percent', 'integer', 'months', 'years'] },
+                hint:    { type: 'string' },
+              },
+            },
+            output: {
+              type: 'object',
+              required: ['label', 'expr', 'format'],
+              properties: {
+                label:  { type: 'string' },
+                expr:   { type: 'string' },
+                format: { type: 'string', enum: ['dollar', 'percent', 'integer', 'months', 'years'] },
+                color:  { type: 'string', enum: ['positive', 'negative', 'neutral', 'accent'] },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+export async function generateCanvas(
+  prompt: string,
+  onStatus: (msg: string) => void,
+): Promise<CanvasSpec> {
+  const health = await loadHealthData();
+  const financialContext = [
+    `Monthly income:    ${fmt(health.monthlyIncome)} (12-month avg)`,
+    `Monthly expenses:  ${fmt(health.avgMonthlyExpenses)} (12-month avg)`,
+    `Monthly surplus:   ${fmt(health.monthlySavings)}`,
+    `Cash (checking/savings): ${fmtCompact(health.cash)}`,
+    `Liquid (incl. brokerage): ${fmtCompact(health.liquid)}`,
+    `Total debt (credit cards): ${fmtCompact(health.totalDebt)}`,
+    `Net worth:         ${fmtCompact(health.netWorth)}`,
+  ].join('\n');
+
+  const system = buildSystemPrompt(financialContext);
+
+  onStatus('generating…');
+
+  let spec: CanvasSpec | null = null;
+
+  for await (const chunk of streamResponse(system, [{ role: 'user', content: prompt }], [CANVAS_TOOL])) {
+    if (chunk.type === 'tool_use' && chunk.name === 'render_canvas') {
+      spec = chunk.input as unknown as CanvasSpec;
+    }
+  }
+
+  if (!spec) throw new Error('Canvas generation failed — no spec returned.');
+  return spec;
+}

--- a/core/canvas-agent.ts
+++ b/core/canvas-agent.ts
@@ -1,6 +1,6 @@
 import { streamResponse } from './llm-provider.js';
 import { loadHealthData } from './health.js';
-import { fmt, fmtPct, fmtCompact, fmtMonths } from './fmt.js';
+import { fmt, fmtPct, fmtPctSigned, fmtCompact, fmtCompactSigned, fmtMonths } from './fmt.js';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -22,6 +22,7 @@ export type OutputDef = {
   expr: string;         // pure JS arithmetic over dial keys — no side effects
   format: DialFormat;
   color?: 'positive' | 'negative' | 'neutral' | 'accent';
+  signed?: boolean;     // show explicit +/- prefix (use for deltas and values that can be negative)
 };
 
 export type CanvasElement =
@@ -43,17 +44,18 @@ export function evalExpr(expr: string, values: Record<string, number>): number {
     const vals = keys.map((k) => values[k]);
     // eslint-disable-next-line @typescript-eslint/no-implied-eval
     const result = new Function(...keys, `"use strict"; return (${expr});`)(...vals);
-    return typeof result === 'number' && isFinite(result) ? result : NaN;
+    return typeof result === 'number' && !isNaN(result) && result !== -Infinity ? result : NaN;
   } catch {
     return NaN;
   }
 }
 
-export function fmtValue(n: number, format: DialFormat): string {
+export function fmtValue(n: number, format: DialFormat, signed = false): string {
+  if (n === Infinity) return 'never';
   if (!isFinite(n) || isNaN(n)) return '—';
   switch (format) {
-    case 'dollar':  return fmtCompact(n);
-    case 'percent': return fmtPct(n);
+    case 'dollar':  return signed ? fmtCompactSigned(n) : fmtCompact(n);
+    case 'percent': return signed ? fmtPctSigned(n) : fmtPct(n);
     case 'months':  return fmtMonths(n);
     case 'years':   return `${Math.ceil(n)} yr`;
     case 'integer': return String(Math.round(n));
@@ -112,6 +114,9 @@ Example: monthly mortgage payment with principal P, monthly rate r, n payments:
 5. Use \`section\` to group: "INPUTS" before dials, "RESULTS" before outputs
 6. Choose \`color\` for outputs: "positive" for gains/savings, "negative" for costs/debt, "neutral" otherwise
 7. Format dials and outputs consistently — if a dial is "dollar", its related output should be too
+8. Set \`signed: true\` on outputs that represent deltas or values that can be negative — e.g. net savings, surplus/deficit, change in portfolio. This shows an explicit +/- prefix so the sign is always unambiguous
+9. For any projection with a multi-year time horizon (retirement, investment growth, net worth, savings goals), show values in **real (inflation-adjusted) dollars** as the primary output — not nominal. Add an \`inflation\` dial (key: "inflation", default: 3, step: 0.5, min: 0, max: 8, format: "percent", hint: "annual inflation"). Convert nominal to real with: \`nominal / Math.pow(1 + inflation/100, years)\`. Label the output "Real value (today's $)" or similar. A nominal output may appear secondary.
+10. The live data does not include the user's age. If a canvas needs years-to-retirement or a birth-year assumption, add an \`age\` dial (default: 35, step: 1, min: 18, max: 80, format: "integer", hint: "your current age") so the user can set it accurately.
 
 ## Existing screen conventions (for consistency)
 
@@ -137,6 +142,31 @@ Example canvas for "how long to pay off my credit card":
     { "type": "output", "output": { "label": "Total interest", "expr": "monthly * (-Math.log(1 - balance * rate/100/12 / monthly) / Math.log(1 + rate/100/12)) - balance", "format": "dollar", "color": "negative" }}
   ]
 }`;
+}
+
+// ─── Context loader ───────────────────────────────────────────────────────────
+
+export type CanvasContext = {
+  system: string;
+  tool: typeof CANVAS_TOOL;
+};
+
+export async function loadCanvasContext(): Promise<CanvasContext> {
+  const health = await loadHealthData();
+  const taxableBrokerage = health.liquid - health.cash;
+  const financialContext = [
+    `Monthly income:    ${fmt(health.monthlyIncome)} (12-month avg)`,
+    `Monthly expenses:  ${fmt(health.avgMonthlyExpenses)} (12-month avg)`,
+    `Monthly surplus:   ${fmt(health.monthlySavings)} (savings rate: ${Math.round(health.savingsRate)}%)`,
+    `Cash (checking/savings): ${fmtCompact(health.cash)}`,
+    `Taxable investments (brokerage): ${fmtCompact(taxableBrokerage)}  ← no withdrawal restrictions`,
+    `Total accessible (cash + brokerage): ${fmtCompact(health.liquid)}`,
+    `Retirement accounts (401k/IRA/Roth): ${fmtCompact(health.retirement)}  ← restricted until ~59½`,
+    `Credit card debt:  ${fmtCompact(health.totalDebt)}`,
+    health.loanDebt > 0 ? `Loan debt (mortgage/auto/student): ${fmtCompact(health.loanDebt)}` : null,
+    `Net worth:         ${fmtCompact(health.netWorth)}`,
+  ].filter(Boolean).join('\n');
+  return { system: buildSystemPrompt(financialContext), tool: CANVAS_TOOL };
 }
 
 // ─── Canvas generation ────────────────────────────────────────────────────────
@@ -180,6 +210,7 @@ const CANVAS_TOOL = {
                 expr:   { type: 'string' },
                 format: { type: 'string', enum: ['dollar', 'percent', 'integer', 'months', 'years'] },
                 color:  { type: 'string', enum: ['positive', 'negative', 'neutral', 'accent'] },
+                signed: { type: 'boolean' },
               },
             },
           },
@@ -193,24 +224,13 @@ export async function generateCanvas(
   prompt: string,
   onStatus: (msg: string) => void,
 ): Promise<CanvasSpec> {
-  const health = await loadHealthData();
-  const financialContext = [
-    `Monthly income:    ${fmt(health.monthlyIncome)} (12-month avg)`,
-    `Monthly expenses:  ${fmt(health.avgMonthlyExpenses)} (12-month avg)`,
-    `Monthly surplus:   ${fmt(health.monthlySavings)}`,
-    `Cash (checking/savings): ${fmtCompact(health.cash)}`,
-    `Liquid (incl. brokerage): ${fmtCompact(health.liquid)}`,
-    `Total debt (credit cards): ${fmtCompact(health.totalDebt)}`,
-    `Net worth:         ${fmtCompact(health.netWorth)}`,
-  ].join('\n');
-
-  const system = buildSystemPrompt(financialContext);
+  const { system, tool } = await loadCanvasContext();
 
   onStatus('generating…');
 
   let spec: CanvasSpec | null = null;
 
-  for await (const chunk of streamResponse(system, [{ role: 'user', content: prompt }], [CANVAS_TOOL])) {
+  for await (const chunk of streamResponse(system, [{ role: 'user', content: prompt }], [tool])) {
     if (chunk.type === 'tool_use' && chunk.name === 'render_canvas') {
       spec = chunk.input as unknown as CanvasSpec;
     }

--- a/core/canvas-history.ts
+++ b/core/canvas-history.ts
@@ -1,0 +1,80 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { DATA_DIR } from './paths.js';
+import type { CanvasSpec } from './canvas-agent.js';
+
+export const CANVAS_HISTORY_PATH = join(DATA_DIR, 'canvas-history.json');
+export const CANVAS_SPEC_PATH    = join(DATA_DIR, 'canvas-spec.json');
+
+export type CanvasHistoryEntry = {
+  id: string;
+  title: string;
+  prompt: string;
+  spec: CanvasSpec;
+  createdAt: string;
+  updatedAt?: string;
+  versions?: number;
+};
+
+export function loadHistory(): CanvasHistoryEntry[] {
+  try {
+    return JSON.parse(readFileSync(CANVAS_HISTORY_PATH, 'utf-8')) as CanvasHistoryEntry[];
+  } catch {
+    return [];
+  }
+}
+
+export function appendHistory(entry: Omit<CanvasHistoryEntry, 'id' | 'createdAt'>): CanvasHistoryEntry {
+  const history = loadHistory();
+  const existing = history.find((e) => e.title === entry.title);
+  let saved: CanvasHistoryEntry;
+  if (existing) {
+    saved = {
+      ...existing,
+      spec: entry.spec,
+      prompt: entry.prompt,
+      updatedAt: new Date().toISOString(),
+      versions: (existing.versions ?? 1) + 1,
+    };
+    const rest = history.filter((e) => e.id !== existing.id);
+    writeFileSync(CANVAS_HISTORY_PATH, JSON.stringify([saved, ...rest], null, 2), 'utf-8');
+  } else {
+    saved = {
+      ...entry,
+      id: `${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+      createdAt: new Date().toISOString(),
+    };
+    writeFileSync(CANVAS_HISTORY_PATH, JSON.stringify([saved, ...history], null, 2), 'utf-8');
+  }
+  return saved;
+}
+
+export function searchHistory(query?: string): CanvasHistoryEntry[] {
+  const history = loadHistory();
+  if (!query) return history;
+  const q = query.toLowerCase();
+  return history.filter(
+    (e) => e.title.toLowerCase().includes(q) || e.prompt.toLowerCase().includes(q),
+  );
+}
+
+export function getHistoryEntry(id: string): CanvasHistoryEntry | undefined {
+  return loadHistory().find((e) => e.id === id);
+}
+
+export function deleteHistoryEntry(id: string): boolean {
+  const history = loadHistory();
+  const next = history.filter((e) => e.id !== id);
+  if (next.length === history.length) return false;
+  writeFileSync(CANVAS_HISTORY_PATH, JSON.stringify(next, null, 2), 'utf-8');
+  return true;
+}
+
+export function buildPriorCanvasesSection(prompt: string): string {
+  const priorCanvases = searchHistory(prompt).slice(0, 3);
+  if (!priorCanvases.length) return '';
+  const entries = priorCanvases.map(
+    (e) => `### ${e.title}\nprompt: ${e.prompt}\n\`\`\`json\n${JSON.stringify(e.spec, null, 2)}\n\`\`\``,
+  ).join('\n\n');
+  return `## Prior canvases on similar topics\n\nBefore generating from scratch, check if any of these existing canvases covers the same type of problem. If so, build on it — extend or adjust its dials/outputs to address the new question, and keep the same title so it updates in place rather than creating a duplicate.\n\n${entries}`;
+}

--- a/core/fmt.ts
+++ b/core/fmt.ts
@@ -10,6 +10,10 @@ export function fmtPct(n: number, decimals = 1): string {
   return `${n.toFixed(decimals)}%`;
 }
 
+export function fmtPctSigned(n: number, decimals = 1): string {
+  return `${n >= 0 ? '+' : ''}${fmtPct(n, decimals)}`;
+}
+
 export function fmtMonths(n: number): string {
   if (!isFinite(n) || n > 999) return '∞';
   return `${n.toFixed(1)} mo`;
@@ -17,7 +21,16 @@ export function fmtMonths(n: number): string {
 
 export function fmtCompact(n: number): string {
   const abs = Math.abs(n);
-  if (abs >= 1_000_000) return `$${(abs / 1_000_000).toFixed(2)}M`;
-  if (abs >= 10_000)    return `$${(abs / 1_000).toFixed(1)}K`;
-  return fmt(n);
+  const sign = n < 0 ? '-' : '';
+  if (abs >= 1_000_000) return `${sign}$${(abs / 1_000_000).toFixed(2)}M`;
+  if (abs >= 10_000)    return `${sign}$${(abs / 1_000).toFixed(1)}K`;
+  return `${sign}${fmt(abs)}`;
+}
+
+export function fmtCompactSigned(n: number): string {
+  const abs = Math.abs(n);
+  const sign = n >= 0 ? '+' : '-';
+  if (abs >= 1_000_000) return `${sign}$${(abs / 1_000_000).toFixed(2)}M`;
+  if (abs >= 10_000)    return `${sign}$${(abs / 1_000).toFixed(1)}K`;
+  return `${sign}${fmt(abs)}`;
 }

--- a/core/health.ts
+++ b/core/health.ts
@@ -5,14 +5,17 @@ export type HealthData = {
   avgMonthlyExpenses: number;
   monthlyIncome: number;
   monthlySavings: number;
+  savingsRate: number;  // monthlySavings / monthlyIncome as a percentage
   cash: number;
-  liquid: number;
-  totalDebt: number;
+  liquid: number;       // cash + taxable brokerage
+  retirement: number;   // 401k / IRA / Roth / HSA — restricted until ~59½
+  totalDebt: number;    // credit cards
+  loanDebt: number;     // mortgage / auto / student loans
   netWorth: number;
 };
 
 export async function loadHealthData(): Promise<HealthData> {
-  const [expRes, cashRes, liquidRes, debtRes, nwRes] = await Promise.all([
+  const [expRes, cashRes, liquidRes, retirementRes, debtRes, loanRes, nwRes] = await Promise.all([
     db.execute(`
       SELECT
         COALESCE(SUM(CASE WHEN amount > 0 THEN amount ELSE 0 END), 0) / 12.0  AS avg_expenses,
@@ -47,10 +50,28 @@ export async function loadHealthData(): Promise<HealthData> {
       AND bh.date = (SELECT MAX(date) FROM balance_history WHERE account_id = a.id)
     `),
     db.execute(`
+      SELECT COALESCE(SUM(bh.balance), 0) AS retirement
+      FROM accounts a
+      JOIN balance_history bh ON bh.account_id = a.id
+      WHERE a.type = 'investment'
+        AND LOWER(COALESCE(a.subtype, '')) IN (
+          'ira', '401k', 'roth', '403b', '457b', 'hsa',
+          'roth 401k', 'simple ira', 'sep ira', 'pension'
+        )
+        AND bh.date = (SELECT MAX(date) FROM balance_history WHERE account_id = a.id)
+    `),
+    db.execute(`
       SELECT COALESCE(SUM(bh.balance), 0) AS total_debt
       FROM accounts a
       JOIN balance_history bh ON bh.account_id = a.id
       WHERE a.type = 'credit'
+        AND bh.date = (SELECT MAX(date) FROM balance_history WHERE account_id = a.id)
+    `),
+    db.execute(`
+      SELECT COALESCE(SUM(bh.balance), 0) AS loan_debt
+      FROM accounts a
+      JOIN balance_history bh ON bh.account_id = a.id
+      WHERE a.type = 'loan'
         AND bh.date = (SELECT MAX(date) FROM balance_history WHERE account_id = a.id)
     `),
     db.execute(`
@@ -63,19 +84,27 @@ export async function loadHealthData(): Promise<HealthData> {
     `),
   ]);
 
-  const expRow  = expRes.rows[0]  as unknown as { avg_expenses: number; avg_income: number; avg_savings: number };
-  const cashRow = cashRes.rows[0] as unknown as { cash: number };
-  const liqRow  = liquidRes.rows[0] as unknown as { liquid: number };
-  const debtRow = debtRes.rows[0] as unknown as { total_debt: number };
-  const nwRow   = nwRes.rows[0]   as unknown as { net_worth: number };
+  const expRow  = expRes.rows[0]        as unknown as { avg_expenses: number; avg_income: number; avg_savings: number };
+  const cashRow = cashRes.rows[0]       as unknown as { cash: number };
+  const liqRow  = liquidRes.rows[0]     as unknown as { liquid: number };
+  const retRow  = retirementRes.rows[0] as unknown as { retirement: number };
+  const debtRow = debtRes.rows[0]       as unknown as { total_debt: number };
+  const loanRow = loanRes.rows[0]       as unknown as { loan_debt: number };
+  const nwRow   = nwRes.rows[0]         as unknown as { net_worth: number };
+
+  const monthlyIncome   = Number(expRow.avg_income);
+  const monthlySavings  = Number(expRow.avg_savings);
 
   return {
     avgMonthlyExpenses: Number(expRow.avg_expenses),
-    monthlyIncome:      Number(expRow.avg_income),
-    monthlySavings:     Number(expRow.avg_savings),
+    monthlyIncome,
+    monthlySavings,
+    savingsRate:        monthlyIncome > 0 ? (monthlySavings / monthlyIncome) * 100 : 0,
     cash:               Number(cashRow.cash),
     liquid:             Number(liqRow.liquid),
+    retirement:         Number(retRow.retirement),
     totalDebt:          Number(debtRow.total_debt),
+    loanDebt:           Number(loanRow.loan_debt),
     netWorth:           Number(nwRow.net_worth),
   };
 }

--- a/core/tools.ts
+++ b/core/tools.ts
@@ -7,7 +7,10 @@
  * embedded agent handles those before calling executeTool.
  */
 
+import { writeFileSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { notifyChange } from './refresh.js';
+import { DATA_DIR } from './paths.js';
 import { getRangeSummary, getMonthlySummary, getTagSummary, getCategoryDriftData, getMerchantSummary, getNetWorthHistory, type NetWorthGranularity } from './queries.js';
 import { solveTVM } from './calculator.js';
 import { getDriftWindows } from './dateUtils.js';
@@ -23,6 +26,8 @@ import { db } from './db.js';
 import { validateRegex } from './rule-utils.js';
 import type { ToolDef } from './llm-provider.js';
 
+import { CANVAS_SPEC_PATH, appendHistory, searchHistory, getHistoryEntry, deleteHistoryEntry } from './canvas-history.js';
+
 // ─── Constants ────────────────────────────────────────────────────────────────
 
 // Keep in sync with executeTool — any tool that mutates data must be listed here
@@ -31,6 +36,7 @@ export const WRITE_TOOLS = new Set([
   'edit_transaction', 'clear_edit', 'ignore_transaction',
   'add_rule', 'delete_rule', 'add_name_rule', 'delete_name_rule',
   'tag_transaction', 'toggle_hidden_category', 'sync',
+  'show_canvas', 'load_canvas', 'delete_canvas',
 ]);
 
 // ─── Tool definitions (all except the agent-only `show` tool) ─────────────────
@@ -330,6 +336,55 @@ export const TOOL_DEFS: ToolDef[] = [
     name: 'sync',
     description: 'Sync latest transactions from Plaid for all connected accounts.',
     parameters: { type: 'object', properties: {} },
+  },
+  {
+    name: 'show_canvas',
+    description: 'Render a CanvasSpec in the app\'s Canvas screen (screen 9) and save it to history. The TUI auto-navigates to canvas. Always pass the original user prompt so the canvas is findable later.',
+    parameters: {
+      type: 'object',
+      properties: {
+        spec:   { type: 'string', description: 'JSON-encoded CanvasSpec (title + elements array)' },
+        prompt: { type: 'string', description: 'The original user question that generated this canvas' },
+      },
+      required: ['spec', 'prompt'],
+    },
+  },
+  {
+    name: 'get_screen',
+    description: 'Return the current text content of the TUI exactly as the user sees it. Use this to understand what screen the user is on and what is displayed before navigating or generating canvases.',
+    parameters: { type: 'object', properties: {} },
+  },
+  {
+    name: 'list_canvases',
+    description: 'List previously generated canvases from history. Optionally filter by title or prompt text.',
+    parameters: {
+      type: 'object',
+      properties: {
+        search: { type: 'string', description: 'Filter by title or prompt (optional)' },
+      },
+    },
+  },
+  {
+    name: 'load_canvas',
+    description: 'Load a previously generated canvas from history and display it on screen 9.',
+    parameters: {
+      type: 'object',
+      properties: {
+        id: { type: 'string', description: 'Canvas history ID from list_canvases' },
+      },
+      required: ['id'],
+    },
+  },
+  {
+    name: 'delete_canvas',
+    description: 'Delete a canvas from history by ID.',
+    parameters: {
+      type: 'object',
+      properties: {
+        id: { type: 'string', description: 'Canvas history ID from list_canvases' },
+      },
+      required: ['id'],
+    },
   },
 ];
 
@@ -779,6 +834,43 @@ async function executeToolImpl(
       const total = results.reduce((s, r) => s + r.added, 0);
       return results.map((r) => `${r.itemId}: +${r.added} added, ${r.modified} modified, ${r.removed} removed`).join('\n')
         + `\n\nTotal new transactions: ${total}`;
+    }
+
+    case 'get_screen': {
+      const screenPath = join(DATA_DIR, 'screen.txt');
+      try {
+        return readFileSync(screenPath, 'utf-8');
+      } catch {
+        return 'Screen not available — TUI may not be running.';
+      }
+    }
+
+    case 'show_canvas': {
+      const specStr = str('spec');
+      const spec = JSON.parse(specStr);
+      const entry = appendHistory({ title: spec.title ?? 'Untitled', prompt: str('prompt'), spec });
+      writeFileSync(CANVAS_SPEC_PATH, JSON.stringify({ ...spec, _historyId: entry.id, _writtenAt: Date.now() }), 'utf-8');
+      return `Canvas "${entry.title}" rendered on screen 9 (id: ${entry.id}).`;
+    }
+
+    case 'list_canvases': {
+      const results = searchHistory(str('search') || undefined);
+      if (!results.length) return 'No canvases found.';
+      return results.map((e) =>
+        `${e.id}  ${e.title}\n  prompt: ${e.prompt}\n  created: ${e.createdAt.slice(0, 10)}`
+      ).join('\n\n');
+    }
+
+    case 'load_canvas': {
+      const entry = getHistoryEntry(str('id'));
+      if (!entry) return `No canvas found with id "${str('id')}".`;
+      writeFileSync(CANVAS_SPEC_PATH, JSON.stringify({ ...entry.spec, _historyId: entry.id, _writtenAt: Date.now() }), 'utf-8');
+      return `Canvas "${entry.title}" loaded on screen 9.`;
+    }
+
+    case 'delete_canvas': {
+      const deleted = deleteHistoryEntry(str('id'));
+      return deleted ? `Canvas deleted.` : `No canvas found with id "${str('id')}".`;
     }
 
     default:

--- a/mcp/create-server.ts
+++ b/mcp/create-server.ts
@@ -1,6 +1,8 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { executeTool, WRITE_TOOLS } from '../core/tools.js';
+import { loadCanvasContext } from '../core/canvas-agent.js';
+import { buildPriorCanvasesSection } from '../core/canvas-history.js';
 
 export function createMcpServer(opts: { afterWrite?: () => void } = {}): McpServer {
   async function run(name: string, input: Record<string, unknown>) {
@@ -317,6 +319,75 @@ export function createMcpServer(opts: { afterWrite?: () => void } = {}): McpServ
       granularity: z.enum(['day', 'week', 'month', 'quarter', 'year']).default('month').describe('Time grouping (default: month)'),
     },
     (input) => run('get_net_worth_history', input),
+  );
+
+  // ── get_screen ──────────────────────────────────────────────────────────────
+
+  server.tool(
+    'get_screen',
+    'Return the current text content of the TUI exactly as the user sees it.',
+    {},
+    () => run('get_screen', {}),
+  );
+
+  // ── show_canvas ─────────────────────────────────────────────────────────────
+
+  server.tool(
+    'show_canvas',
+    'Render a CanvasSpec in the app\'s Canvas screen (screen 9) and save it to history. The TUI auto-navigates to canvas. Always pass the original user prompt so the canvas is findable later.',
+    {
+      spec:   z.string().describe('JSON-encoded CanvasSpec (title + elements array)'),
+      prompt: z.string().describe('The original user question that generated this canvas'),
+    },
+    (input) => run('show_canvas', input),
+  );
+
+  server.tool(
+    'list_canvases',
+    'List previously generated canvases from history. Optionally filter by title or prompt text.',
+    {
+      search: z.string().optional().describe('Filter by title or prompt (optional)'),
+    },
+    (input) => run('list_canvases', input),
+  );
+
+  server.tool(
+    'load_canvas',
+    'Load a previously generated canvas from history and display it on screen 9.',
+    {
+      id: z.string().describe('Canvas history ID from list_canvases'),
+    },
+    (input) => run('load_canvas', input),
+  );
+
+  server.tool(
+    'delete_canvas',
+    'Delete a canvas from history by ID.',
+    {
+      id: z.string().describe('Canvas history ID from list_canvases'),
+    },
+    (input) => run('delete_canvas', input),
+  );
+
+  // ── generate_canvas ─────────────────────────────────────────────────────────
+
+  server.tool(
+    'generate_canvas',
+    'Returns financial context, prior canvases on similar topics, and the render_canvas tool schema. Use the returned context to produce a CanvasSpec — building on an existing canvas if one covers the same type of problem.',
+    {
+      prompt: z.string().describe('Natural language question or scenario, e.g. "how long to pay off my mortgage?" or "what if I save $500 more per month?"'),
+    },
+    async ({ prompt }) => {
+      const { system, tool } = await loadCanvasContext();
+      const text = [
+        `## User prompt\n${prompt}`,
+        buildPriorCanvasesSection(prompt),
+        `## Canvas instructions\n${system}`,
+        `## render_canvas tool schema\n${JSON.stringify(tool, null, 2)}`,
+        `Now generate the CanvasSpec JSON by calling render_canvas.`,
+      ].filter(Boolean).join('\n\n');
+      return { content: [{ type: 'text' as const, text }] };
+    },
   );
 
   // ── calculate_tvm ───────────────────────────────────────────────────────────

--- a/tests/fmt.test.ts
+++ b/tests/fmt.test.ts
@@ -83,9 +83,10 @@ describe('fmtCompact', () => {
     expect(fmtCompact(999)).toBe('$999.00');
   });
 
-  it('strips sign like fmt does', () => {
-    expect(fmtCompact(-2_000_000)).toBe('$2.00M');
-    expect(fmtCompact(-50_000)).toBe('$50.0K');
+  it('preserves sign for negative values', () => {
+    expect(fmtCompact(-2_000_000)).toBe('-$2.00M');
+    expect(fmtCompact(-50_000)).toBe('-$50.0K');
+    expect(fmtCompact(-5_000)).toBe('-$5,000.00');
   });
 });
 

--- a/tests/navigation.test.ts
+++ b/tests/navigation.test.ts
@@ -2,11 +2,11 @@
  * Navigation consistency test
  *
  * Screens are numbered:
- *   1=dashboard  2=transactions  3=trends  4=networth  5=tags  6=health  7=rules  8=accounts
+ *   1=dashboard  2=transactions  3=trends  4=networth  5=tags  6=health  7=rules  8=accounts  9=canvas
  *
  * Each screen must:
  *   1. Display a nav bar that shows [N] labels for every screen EXCEPT itself
- *   2. Handle every key 1–8 EXCEPT its own, navigating to the correct screen
+ *   2. Handle every key 1–9 EXCEPT its own, navigating to the correct screen
  *
  * This test parses the TSX source files to verify both invariants.
  */
@@ -28,6 +28,7 @@ const KEY_TO_SCREEN: Record<string, string> = {
   '6': 'health',
   '7': 'rules',
   '8': 'accounts',
+  '9': 'canvas',
 };
 
 const SCREENS = [
@@ -39,6 +40,7 @@ const SCREENS = [
   { file: 'Health.tsx',       screen: 'health',       key: '6' },
   { file: 'Rules.tsx',        screen: 'rules',        key: '7' },
   { file: 'Accounts.tsx',     screen: 'accounts',     key: '8' },
+  { file: 'Canvas.tsx',       screen: 'canvas',       key: '9' },
 ];
 
 /** Extract all [N] keys present in the nav bar of a source file.

--- a/tests/tui/canvas.test.tsx
+++ b/tests/tui/canvas.test.tsx
@@ -1,0 +1,121 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render } from 'ink-testing-library';
+import { evalExpr, fmtValue, fmtDialValue, type CanvasSpec } from '../../core/canvas-agent.js';
+import { CanvasView } from '../../tui/Canvas.js';
+
+// ─── evalExpr ─────────────────────────────────────────────────────────────────
+
+describe('evalExpr', () => {
+  it('evaluates simple arithmetic', () => {
+    expect(evalExpr('a + b', { a: 1, b: 2 })).toBe(3);
+    expect(evalExpr('a * b', { a: 3, b: 4 })).toBe(12);
+  });
+
+  it('evaluates mortgage payment formula', () => {
+    // $300k, 6% annual (0.5% monthly), 360 payments
+    const P = 300_000, r = 0.005, n = 360;
+    const result = evalExpr('P * r / (1 - Math.pow(1 + r, -n))', { P, r, n });
+    expect(result).toBeCloseTo(1798.65, 0);
+  });
+
+  it('returns NaN for bad expressions', () => {
+    expect(isNaN(evalExpr('not valid js!!!', {}))).toBe(true);
+  });
+
+  it('returns NaN when result is non-finite', () => {
+    // division by zero
+    expect(isNaN(evalExpr('a / b', { a: 1, b: 0 }))).toBe(true);
+  });
+});
+
+// ─── fmtValue / fmtDialValue ──────────────────────────────────────────────────
+
+describe('fmtValue', () => {
+  it('formats dollar with compact', () => {
+    expect(fmtValue(1_840_000, 'dollar')).toBe('$1.84M');
+    expect(fmtValue(68_619, 'dollar')).toBe('$68.6K');
+  });
+
+  it('formats percent', () => {
+    expect(fmtValue(7.5, 'percent')).toBe('7.5%');
+  });
+
+  it('formats months', () => {
+    expect(fmtValue(14.3, 'months')).toBe('14.3 mo');
+  });
+
+  it('formats years with ceil', () => {
+    expect(fmtValue(9.2, 'years')).toBe('10 yr');
+  });
+
+  it('returns — for NaN', () => {
+    expect(fmtValue(NaN, 'dollar')).toBe('—');
+  });
+});
+
+describe('fmtDialValue', () => {
+  it('formats dollar with full precision', () => {
+    expect(fmtDialValue(500, 'dollar')).toBe('$500.00');
+    expect(fmtDialValue(1234.56, 'dollar')).toBe('$1,234.56');
+  });
+
+  it('formats percent', () => {
+    expect(fmtDialValue(6.5, 'percent')).toBe('6.5%');
+  });
+});
+
+// ─── CanvasView rendering ─────────────────────────────────────────────────────
+
+const MORTGAGE_SPEC: CanvasSpec = {
+  title: 'Mortgage Payment',
+  elements: [
+    { type: 'section', label: 'INPUTS' },
+    { type: 'text', content: 'adjust dials to explore scenarios' },
+    { type: 'dial', dial: { key: 'price', label: 'Home price', default: 500_000, step: 10_000, min: 0, format: 'dollar', hint: 'purchase price' } },
+    { type: 'dial', dial: { key: 'down', label: 'Down payment', default: 20, step: 5, min: 0, max: 100, format: 'percent', hint: 'of purchase price' } },
+    { type: 'dial', dial: { key: 'rate', label: 'Interest rate', default: 6.5, step: 0.25, min: 0, max: 20, format: 'percent', hint: 'annual rate' } },
+    { type: 'dial', dial: { key: 'term', label: 'Term', default: 30, step: 5, min: 5, max: 30, format: 'years', hint: 'loan length' } },
+    { type: 'section', label: 'RESULTS' },
+    {
+      type: 'output', output: {
+        label: 'Monthly payment',
+        expr: '(price * (1 - down/100)) * (rate/100/12) / (1 - Math.pow(1 + rate/100/12, -(term*12)))',
+        format: 'dollar',
+        color: 'negative',
+      },
+    },
+  ],
+};
+
+describe('CanvasView', () => {
+  it('renders title and section headers', () => {
+    const { lastFrame } = render(<CanvasView spec={MORTGAGE_SPEC} />);
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('Mortgage Payment');
+    expect(frame).toContain('INPUTS');
+    expect(frame).toContain('RESULTS');
+  });
+
+  it('renders text element', () => {
+    const { lastFrame } = render(<CanvasView spec={MORTGAGE_SPEC} />);
+    expect(lastFrame()).toContain('adjust dials to explore scenarios');
+  });
+
+  it('renders dial labels and default values', () => {
+    const { lastFrame } = render(<CanvasView spec={MORTGAGE_SPEC} />);
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('Home price');
+    expect(frame).toContain('$500,000.00');
+    expect(frame).toContain('Down payment');
+    expect(frame).toContain('Interest rate');
+  });
+
+  it('computes and renders the mortgage output', () => {
+    const { lastFrame } = render(<CanvasView spec={MORTGAGE_SPEC} />);
+    // $500k, 20% down = $400k loan, 6.5% annual, 30yr → ~$2,528/mo
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('Monthly payment');
+    expect(frame).toContain('$2,528');
+  });
+});

--- a/tests/tui/canvas.test.tsx
+++ b/tests/tui/canvas.test.tsx
@@ -1,8 +1,59 @@
 import React from 'react';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render } from 'ink-testing-library';
 import { evalExpr, fmtValue, fmtDialValue, type CanvasSpec } from '../../core/canvas-agent.js';
 import { CanvasView } from '../../tui/Canvas.js';
+
+// ─── generateCanvas (mocked LLM) ──────────────────────────────────────────────
+
+const MOCK_HEALTH = {
+  avgMonthlyExpenses: 12000, monthlyIncome: 15000, monthlySavings: 3000,
+  cash: 60000, liquid: 800000, totalDebt: 20000, netWorth: 1_800_000,
+};
+
+const MOCK_SPEC: CanvasSpec = {
+  title: 'Credit Card Payoff',
+  elements: [
+    { type: 'section', label: 'INPUTS' },
+    { type: 'dial', dial: { key: 'balance', label: 'Balance', default: 20000, step: 500, min: 0, format: 'dollar', hint: 'current balance' } },
+    { type: 'dial', dial: { key: 'rate',    label: 'APR',     default: 22,    step: 0.5, min: 0, max: 40, format: 'percent', hint: 'annual rate' } },
+    { type: 'dial', dial: { key: 'monthly', label: 'Monthly payment', default: 500, step: 50, min: 0, format: 'dollar', hint: 'what you pay' } },
+    { type: 'section', label: 'RESULTS' },
+    { type: 'output', output: { label: 'Months to payoff', expr: '-Math.log(1 - balance * rate/100/12 / monthly) / Math.log(1 + rate/100/12)', format: 'months', color: 'neutral' } },
+    { type: 'output', output: { label: 'Total interest', expr: 'monthly * (-Math.log(1 - balance * rate/100/12 / monthly) / Math.log(1 + rate/100/12)) - balance', format: 'dollar', color: 'negative' } },
+  ],
+};
+
+vi.mock('../../core/health.js', () => ({ loadHealthData: async () => MOCK_HEALTH }));
+vi.mock('../../core/llm-provider.js', () => ({
+  streamResponse: vi.fn(async function* () {
+    yield { type: 'tool_use', id: 'test-id', name: 'render_canvas', input: MOCK_SPEC };
+    yield { type: 'done' };
+  }),
+}));
+
+describe('generateCanvas', () => {
+  it('returns the spec from the tool call', async () => {
+    const { generateCanvas } = await import('../../core/canvas-agent.js');
+    const statuses: string[] = [];
+    const spec = await generateCanvas('how long to pay off my credit card', (s) => { statuses.push(s); });
+    expect(spec.title).toBe('Credit Card Payoff');
+    expect(spec.elements.filter((e) => e.type === 'dial')).toHaveLength(3);
+    expect(spec.elements.filter((e) => e.type === 'output')).toHaveLength(2);
+    expect(statuses).toContain('generating…');
+  });
+
+  it('throws if no tool call is returned', async () => {
+    vi.mocked(
+      (await import('../../core/llm-provider.js')).streamResponse
+    ).mockImplementationOnce(async function* () {
+      yield { type: 'text', delta: 'sorry, I cannot help' };
+      yield { type: 'done' };
+    });
+    const { generateCanvas } = await import('../../core/canvas-agent.js');
+    await expect(generateCanvas('bad prompt', () => {})).rejects.toThrow('no spec returned');
+  });
+});
 
 // ─── evalExpr ─────────────────────────────────────────────────────────────────
 

--- a/tests/tui/canvas.test.tsx
+++ b/tests/tui/canvas.test.tsx
@@ -7,8 +7,8 @@ import { CanvasView } from '../../tui/Canvas.js';
 // ─── generateCanvas (mocked LLM) ──────────────────────────────────────────────
 
 const MOCK_HEALTH = {
-  avgMonthlyExpenses: 12000, monthlyIncome: 15000, monthlySavings: 3000,
-  cash: 60000, liquid: 800000, totalDebt: 20000, netWorth: 1_800_000,
+  avgMonthlyExpenses: 12000, monthlyIncome: 15000, monthlySavings: 3000, savingsRate: 20,
+  cash: 60000, liquid: 800000, retirement: 900000, totalDebt: 20000, loanDebt: 0, netWorth: 1_800_000,
 };
 
 const MOCK_SPEC: CanvasSpec = {
@@ -74,9 +74,12 @@ describe('evalExpr', () => {
     expect(isNaN(evalExpr('not valid js!!!', {}))).toBe(true);
   });
 
-  it('returns NaN when result is non-finite', () => {
-    // division by zero
-    expect(isNaN(evalExpr('a / b', { a: 1, b: 0 }))).toBe(true);
+  it('passes Infinity through (used for "never" payoff sentinel)', () => {
+    expect(evalExpr('a / b', { a: 1, b: 0 })).toBe(Infinity);
+  });
+
+  it('returns NaN for negative-infinity and invalid expressions', () => {
+    expect(isNaN(evalExpr('-a / b', { a: 1, b: 0 }))).toBe(true);
   });
 });
 
@@ -98,6 +101,11 @@ describe('fmtValue', () => {
 
   it('formats years with ceil', () => {
     expect(fmtValue(9.2, 'years')).toBe('10 yr');
+  });
+
+  it('returns never for Infinity', () => {
+    expect(fmtValue(Infinity, 'months')).toBe('never');
+    expect(fmtValue(Infinity, 'dollar')).toBe('never');
   });
 
   it('returns — for NaN', () => {

--- a/tui/App.tsx
+++ b/tui/App.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { Box, useInput, useApp } from 'ink';
+import { readFileSync } from 'node:fs';
 import { TypingContext } from './TypingContext.js';
 import { Dashboard } from './Dashboard.js';
 import { Transactions } from './Transactions.js';
@@ -11,7 +12,9 @@ import { Accounts } from './Accounts.js';
 import { Health } from './Health.js';
 import { Canvas } from './Canvas.js';
 import { Chat } from './Chat.js';
-import { RefreshProvider } from './RefreshContext.js';
+import { RefreshProvider, useRefreshKey } from './RefreshContext.js';
+import type { CanvasSpec } from '../core/canvas-agent.js';
+import { CANVAS_SPEC_PATH } from '../core/canvas-history.js';
 
 export type Screen = 'dashboard' | 'transactions' | 'trends' | 'networth' | 'tags' | 'rules' | 'accounts' | 'health' | 'canvas';
 
@@ -25,17 +28,46 @@ export type TxFilter = {
   search?: string;
   range?: string;   // 'week' | 'month' | 'quarter' | 'year' | 'alltime'
   anchor?: string;  // YYYY-MM-DD — which specific period to land on
+  canvasSpec?: string; // JSON-encoded CanvasSpec, used when navigating to 'canvas'
 };
 
-export function App() {
+function AppInner() {
   const [screen, setScreen]         = useState<Screen>('dashboard');
   const [txFilter, setTxFilter]     = useState<TxFilter>({});
+  const [canvasSpec, setCanvasSpec] = useState<CanvasSpec | null>(null);
+  const [specKey,    setSpecKey]    = useState(0);
   const [chatFocused, setChatFocused] = useState(false);
   const [screenTyping, setScreenTyping] = useState(false);
   const [showHints, setShowHints]   = useState(false);
   const { exit } = useApp();
+  const refreshKey = useRefreshKey();
+  const lastSpecRef = useRef<string>('');
+
+  useEffect(() => {
+    try {
+      const raw = readFileSync(CANVAS_SPEC_PATH, 'utf-8');
+      if (raw !== lastSpecRef.current) {
+        lastSpecRef.current = raw;
+        const parsed = JSON.parse(raw);
+        setCanvasSpec(parsed);
+        setSpecKey((k) => k + 1);
+        // only auto-navigate if freshly written (within 30s)
+        if (parsed._writtenAt && Date.now() - parsed._writtenAt < 30_000) {
+          setScreen('canvas');
+        }
+      }
+    } catch { /* file doesn't exist yet */ }
+  }, [refreshKey]);
+
+  function loadSpec(s: CanvasSpec) {
+    setCanvasSpec(s);
+    setSpecKey((k) => k + 1);
+  }
 
   function navigate(s: Screen, filter?: TxFilter) {
+    if (s === 'canvas' && filter?.canvasSpec) {
+      try { loadSpec(JSON.parse(filter.canvasSpec)); } catch { /* ignore malformed spec */ }
+    }
     setTxFilter(filter ?? {});
     setScreen(s);
   }
@@ -58,25 +90,31 @@ export function App() {
       case 'rules':        return <Rules        onNavigate={navigate} isActive={screenIsActive} showHints={showHints} />;
       case 'accounts':     return <Accounts     onNavigate={navigate} isActive={screenIsActive} showHints={showHints} />;
       case 'health':       return <Health       onNavigate={navigate} isActive={screenIsActive} showHints={showHints} />;
-      case 'canvas':       return <Canvas       onNavigate={navigate} isActive={screenIsActive} showHints={showHints} />;
+      case 'canvas':       return <Canvas       onNavigate={navigate} onLoadSpec={loadSpec} isActive={screenIsActive} showHints={showHints} spec={canvasSpec} specKey={specKey} />;
     }
   })();
 
   return (
-    <RefreshProvider>
-      <TypingContext.Provider value={setScreenTyping}>
-        <Box flexDirection="column" height="100%">
-          <Box flexGrow={1}>
-            {currentScreen}
-          </Box>
-          <Chat
-            isActive={chatFocused}
-            onActivate={() => setChatFocused(true)}
-            onDeactivate={() => setChatFocused(false)}
-            onNavigate={navigate}
-          />
+    <TypingContext.Provider value={setScreenTyping}>
+      <Box flexDirection="column" height="100%">
+        <Box flexGrow={1}>
+          {currentScreen}
         </Box>
-      </TypingContext.Provider>
+        <Chat
+          isActive={chatFocused}
+          onActivate={() => setChatFocused(true)}
+          onDeactivate={() => setChatFocused(false)}
+          onNavigate={navigate}
+        />
+      </Box>
+    </TypingContext.Provider>
+  );
+}
+
+export function App() {
+  return (
+    <RefreshProvider>
+      <AppInner />
     </RefreshProvider>
   );
 }

--- a/tui/App.tsx
+++ b/tui/App.tsx
@@ -9,10 +9,11 @@ import { Tags } from './Tags.js';
 import { Rules } from './Rules.js';
 import { Accounts } from './Accounts.js';
 import { Health } from './Health.js';
+import { Canvas } from './Canvas.js';
 import { Chat } from './Chat.js';
 import { RefreshProvider } from './RefreshContext.js';
 
-export type Screen = 'dashboard' | 'transactions' | 'trends' | 'networth' | 'tags' | 'rules' | 'accounts' | 'health';
+export type Screen = 'dashboard' | 'transactions' | 'trends' | 'networth' | 'tags' | 'rules' | 'accounts' | 'health' | 'canvas';
 
 export type TxFilter = {
   category?: string;
@@ -57,6 +58,7 @@ export function App() {
       case 'rules':        return <Rules        onNavigate={navigate} isActive={screenIsActive} showHints={showHints} />;
       case 'accounts':     return <Accounts     onNavigate={navigate} isActive={screenIsActive} showHints={showHints} />;
       case 'health':       return <Health       onNavigate={navigate} isActive={screenIsActive} showHints={showHints} />;
+      case 'canvas':       return <Canvas       onNavigate={navigate} isActive={screenIsActive} showHints={showHints} />;
     }
   })();
 

--- a/tui/Canvas.tsx
+++ b/tui/Canvas.tsx
@@ -1,0 +1,204 @@
+import React, { useState, useCallback } from 'react';
+import { Box, Text, useInput } from 'ink';
+import type { Screen } from './App.js';
+import { handleNavKey } from './nav.js';
+import { Divider } from './fmt.js';
+import { C_POSITIVE, C_NEGATIVE, C_NEUTRAL, C_ACCENT, C_WARNING } from './ui.js';
+import { PageHeader, SectionHeader, DialRow, TextInput } from './components/index.js';
+import { generateCanvas, evalExpr, fmtValue, fmtDialValue, type CanvasSpec, type DialDef, type DialFormat } from '../core/canvas-agent.js';
+import { useSetTyping } from './TypingContext.js';
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const LABEL_W  = 18;
+const VALUE_W  = 12;
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function outputColor(color: string | undefined): string | undefined {
+  switch (color) {
+    case 'positive': return C_POSITIVE;
+    case 'negative': return C_NEGATIVE;
+    case 'accent':   return C_ACCENT;
+    default:         return C_NEUTRAL;
+  }
+}
+
+function dialStep(dial: DialDef, dir: 1 | -1, val: number): number {
+  const next = parseFloat((val + dir * dial.step).toFixed(10));
+  if (dial.min !== undefined && next < dial.min) return dial.min;
+  if (dial.max !== undefined && next > dial.max) return dial.max;
+  return next;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+type Mode = 'prompt' | 'dials';
+
+export function Canvas({ onNavigate, isActive, showHints }: {
+  onNavigate: (s: Screen) => void;
+  isActive?: boolean;
+  showHints: boolean;
+}) {
+  const [mode,       setMode]       = useState<Mode>('prompt');
+  const [prompt,     setPrompt]     = useState('');
+  const [status,     setStatus]     = useState('');
+  const [spec,       setSpec]       = useState<CanvasSpec | null>(null);
+  const [dialValues, setDialValues] = useState<Record<string, number>>({});
+  const [dialIdx,    setDialIdx]    = useState(0);
+  const [error,      setError]      = useState('');
+
+  const setTyping = useSetTyping();
+
+  // Dials from the spec in order
+  const dials = spec
+    ? spec.elements.flatMap((el) => el.type === 'dial' ? [el.dial] : [])
+    : [];
+
+  const currentKey = dials[dialIdx]?.key;
+
+  const runGenerate = useCallback(async (p: string) => {
+    setError('');
+    setSpec(null);
+    setTyping(false);
+    setMode('dials');
+    try {
+      const s = await generateCanvas(p, setStatus);
+      const defaults: Record<string, number> = {};
+      s.elements.forEach((el) => { if (el.type === 'dial') defaults[el.dial.key] = el.dial.default; });
+      setSpec(s);
+      setDialValues(defaults);
+      setDialIdx(0);
+      setStatus('');
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      setStatus('');
+      setMode('prompt');
+    }
+  }, []);
+
+  useInput((input, key) => {
+    if (key.escape) {
+      if (mode === 'dials') { setMode('prompt'); setTyping(true); return; }
+      onNavigate('dashboard');
+      return;
+    }
+    handleNavKey(input, 'canvas', onNavigate);
+
+    if (mode === 'prompt') {
+      setTyping(true);
+      if (key.return && prompt.trim()) { void runGenerate(prompt.trim()); return; }
+      if (key.backspace || key.delete) { setPrompt((p) => p.slice(0, -1)); return; }
+      if (!key.ctrl && !key.meta && input) setPrompt((p) => p + input);
+      return;
+    }
+
+    // mode === 'dials'
+    if (input === 'p' || input === '/') { setMode('prompt'); setTyping(true); return; }
+    if (key.upArrow)   { setDialIdx((i) => (i - 1 + dials.length) % dials.length); return; }
+    if (key.downArrow) { setDialIdx((i) => (i + 1) % dials.length); return; }
+    if (key.rightArrow && currentKey) {
+      setDialValues((v) => ({ ...v, [currentKey]: dialStep(dials[dialIdx], 1, v[currentKey] ?? dials[dialIdx].default) }));
+      return;
+    }
+    if (key.leftArrow && currentKey) {
+      setDialValues((v) => ({ ...v, [currentKey]: dialStep(dials[dialIdx], -1, v[currentKey] ?? dials[dialIdx].default) }));
+      return;
+    }
+    if (input === 'r' && currentKey) {
+      setDialValues((v) => ({ ...v, [currentKey]: dials[dialIdx].default }));
+      return;
+    }
+  }, { isActive: isActive !== false });
+
+  return (
+    <Box flexDirection="column" paddingX={2} paddingY={1}>
+      <PageHeader current="canvas" showHints={showHints} />
+
+      <Box marginTop={1}><Text bold>Canvas</Text></Box>
+      {showHints && mode === 'dials' && dials.length > 0 && (
+        <Text dimColor>↑↓ select  ·  ← → adjust  ·  [r] reset  ·  [p] new prompt  ·  Esc back</Text>
+      )}
+
+      {/* ── Prompt bar ─────────────────────────────────────────────────── */}
+      <Box marginTop={1} gap={1}>
+        <Text color={C_ACCENT}>›</Text>
+        {mode === 'prompt'
+          ? <TextInput value={prompt} placeholder="what do you want to calculate?" />
+          : <Text dimColor>{prompt || 'no prompt'}</Text>
+        }
+        {mode === 'prompt' && showHints && prompt.trim() && (
+          <Text dimColor>  Enter to generate</Text>
+        )}
+      </Box>
+
+      <Box marginTop={1}><Divider /></Box>
+
+      {/* ── States ─────────────────────────────────────────────────────── */}
+      {error && (
+        <Box marginTop={1}><Text color={C_WARNING}>{error}</Text></Box>
+      )}
+
+      {!spec && !error && status && (
+        <Box marginTop={1}><Text dimColor>{status}</Text></Box>
+      )}
+
+      {!spec && !error && !status && mode === 'prompt' && (
+        <Box marginTop={1}>
+          <Text dimColor>Ask a financial question and press Enter.</Text>
+        </Box>
+      )}
+
+      {/* ── Canvas ─────────────────────────────────────────────────────── */}
+      {spec && (
+        <Box flexDirection="column" marginTop={1}>
+          <Text bold>{spec.title}</Text>
+
+          {spec.elements.map((el, i) => {
+            if (el.type === 'section') {
+              return <Box key={i} marginTop={1}><SectionHeader>{el.label}</SectionHeader></Box>;
+            }
+
+            if (el.type === 'text') {
+              return <Box key={i} marginTop={0}><Text dimColor>{el.content}</Text></Box>;
+            }
+
+            if (el.type === 'dial') {
+              const d = el.dial;
+              const val = dialValues[d.key] ?? d.default;
+              const isSelected = mode === 'dials' && dials[dialIdx]?.key === d.key;
+              const atDefault = val === d.default;
+              return (
+                <DialRow
+                  key={i}
+                  label={d.label}
+                  value={fmtDialValue(val, d.format)}
+                  selected={isSelected}
+                  labelWidth={LABEL_W}
+                  valueWidth={VALUE_W}
+                  description={isSelected
+                    ? `← → ±${fmtDialValue(d.step, d.format)}${!atDefault ? '  ·  [r] reset' : ''}`
+                    : `${d.hint}${!atDefault ? ' (modified)' : ''}`}
+                />
+              );
+            }
+
+            if (el.type === 'output') {
+              const out = el.output;
+              const val = evalExpr(out.expr, dialValues);
+              const formatted = fmtValue(val, out.format);
+              return (
+                <Box key={i} gap={3}>
+                  <Text dimColor>{out.label.padEnd(LABEL_W)}</Text>
+                  <Text bold color={outputColor(out.color)}>{formatted.padStart(VALUE_W)}</Text>
+                </Box>
+              );
+            }
+
+            return null;
+          })}
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/tui/Canvas.tsx
+++ b/tui/Canvas.tsx
@@ -5,13 +5,13 @@ import { handleNavKey } from './nav.js';
 import { Divider } from './fmt.js';
 import { C_POSITIVE, C_NEGATIVE, C_NEUTRAL, C_ACCENT, C_WARNING } from './ui.js';
 import { PageHeader, SectionHeader, DialRow, TextInput } from './components/index.js';
-import { generateCanvas, evalExpr, fmtValue, fmtDialValue, type CanvasSpec, type DialDef, type DialFormat } from '../core/canvas-agent.js';
+import { generateCanvas, evalExpr, fmtValue, fmtDialValue, type CanvasSpec, type DialDef } from '../core/canvas-agent.js';
 import { useSetTyping } from './TypingContext.js';
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
-const LABEL_W  = 18;
-const VALUE_W  = 12;
+const LABEL_W = 18;
+const VALUE_W = 12;
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -31,7 +31,84 @@ function dialStep(dial: DialDef, dir: 1 | -1, val: number): number {
   return next;
 }
 
-// ─── Component ────────────────────────────────────────────────────────────────
+// ─── CanvasView — testable rendering of a CanvasSpec ─────────────────────────
+
+export function CanvasView({ spec, isActive }: { spec: CanvasSpec; isActive?: boolean }) {
+  const dials = spec.elements.flatMap((el) => el.type === 'dial' ? [el.dial] : []);
+  const [dialValues, setDialValues] = useState<Record<string, number>>(() => {
+    const d: Record<string, number> = {};
+    dials.forEach((dl) => { d[dl.key] = dl.default; });
+    return d;
+  });
+  const [dialIdx, setDialIdx] = useState(0);
+
+  const currentKey = dials[dialIdx]?.key;
+
+  useInput((_input, key) => {
+    if (key.upArrow)   { setDialIdx((i) => (i - 1 + dials.length) % dials.length); return; }
+    if (key.downArrow) { setDialIdx((i) => (i + 1) % dials.length); return; }
+    if (key.rightArrow && currentKey) {
+      setDialValues((v) => ({ ...v, [currentKey]: dialStep(dials[dialIdx], 1,  v[currentKey] ?? dials[dialIdx].default) }));
+    }
+    if (key.leftArrow && currentKey) {
+      setDialValues((v) => ({ ...v, [currentKey]: dialStep(dials[dialIdx], -1, v[currentKey] ?? dials[dialIdx].default) }));
+    }
+    if (_input === 'r' && currentKey) {
+      setDialValues((v) => ({ ...v, [currentKey]: dials[dialIdx].default }));
+    }
+  }, { isActive: isActive !== false });
+
+  return (
+    <Box flexDirection="column">
+      <Text bold>{spec.title}</Text>
+
+      {spec.elements.map((el, i) => {
+        if (el.type === 'section') {
+          return <Box key={i} marginTop={1}><SectionHeader>{el.label}</SectionHeader></Box>;
+        }
+
+        if (el.type === 'text') {
+          return <Box key={i}><Text dimColor>{el.content}</Text></Box>;
+        }
+
+        if (el.type === 'dial') {
+          const d = el.dial;
+          const val = dialValues[d.key] ?? d.default;
+          const isSelected = dials[dialIdx]?.key === d.key;
+          const atDefault = val === d.default;
+          return (
+            <DialRow
+              key={i}
+              label={d.label}
+              value={fmtDialValue(val, d.format)}
+              selected={isSelected}
+              labelWidth={LABEL_W}
+              valueWidth={VALUE_W}
+              description={isSelected
+                ? `← → ±${fmtDialValue(d.step, d.format)}${!atDefault ? '  ·  [r] reset' : ''}`
+                : `${d.hint}${!atDefault ? ' (modified)' : ''}`}
+            />
+          );
+        }
+
+        if (el.type === 'output') {
+          const out = el.output;
+          const val = evalExpr(out.expr, dialValues);
+          return (
+            <Box key={i} gap={3}>
+              <Text dimColor>{out.label.padEnd(LABEL_W)}</Text>
+              <Text bold color={outputColor(out.color)}>{fmtValue(val, out.format).padStart(VALUE_W)}</Text>
+            </Box>
+          );
+        }
+
+        return null;
+      })}
+    </Box>
+  );
+}
+
+// ─── Canvas screen ────────────────────────────────────────────────────────────
 
 type Mode = 'prompt' | 'dials';
 
@@ -40,22 +117,13 @@ export function Canvas({ onNavigate, isActive, showHints }: {
   isActive?: boolean;
   showHints: boolean;
 }) {
-  const [mode,       setMode]       = useState<Mode>('prompt');
-  const [prompt,     setPrompt]     = useState('');
-  const [status,     setStatus]     = useState('');
-  const [spec,       setSpec]       = useState<CanvasSpec | null>(null);
-  const [dialValues, setDialValues] = useState<Record<string, number>>({});
-  const [dialIdx,    setDialIdx]    = useState(0);
-  const [error,      setError]      = useState('');
+  const [mode,   setMode]   = useState<Mode>('prompt');
+  const [prompt, setPrompt] = useState('');
+  const [status, setStatus] = useState('');
+  const [spec,   setSpec]   = useState<CanvasSpec | null>(null);
+  const [error,  setError]  = useState('');
 
   const setTyping = useSetTyping();
-
-  // Dials from the spec in order
-  const dials = spec
-    ? spec.elements.flatMap((el) => el.type === 'dial' ? [el.dial] : [])
-    : [];
-
-  const currentKey = dials[dialIdx]?.key;
 
   const runGenerate = useCallback(async (p: string) => {
     setError('');
@@ -64,11 +132,7 @@ export function Canvas({ onNavigate, isActive, showHints }: {
     setMode('dials');
     try {
       const s = await generateCanvas(p, setStatus);
-      const defaults: Record<string, number> = {};
-      s.elements.forEach((el) => { if (el.type === 'dial') defaults[el.dial.key] = el.dial.default; });
       setSpec(s);
-      setDialValues(defaults);
-      setDialIdx(0);
       setStatus('');
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
@@ -93,22 +157,7 @@ export function Canvas({ onNavigate, isActive, showHints }: {
       return;
     }
 
-    // mode === 'dials'
-    if (input === 'p' || input === '/') { setMode('prompt'); setTyping(true); return; }
-    if (key.upArrow)   { setDialIdx((i) => (i - 1 + dials.length) % dials.length); return; }
-    if (key.downArrow) { setDialIdx((i) => (i + 1) % dials.length); return; }
-    if (key.rightArrow && currentKey) {
-      setDialValues((v) => ({ ...v, [currentKey]: dialStep(dials[dialIdx], 1, v[currentKey] ?? dials[dialIdx].default) }));
-      return;
-    }
-    if (key.leftArrow && currentKey) {
-      setDialValues((v) => ({ ...v, [currentKey]: dialStep(dials[dialIdx], -1, v[currentKey] ?? dials[dialIdx].default) }));
-      return;
-    }
-    if (input === 'r' && currentKey) {
-      setDialValues((v) => ({ ...v, [currentKey]: dials[dialIdx].default }));
-      return;
-    }
+    if (input === 'p' || input === '/') { setMode('prompt'); setTyping(true); }
   }, { isActive: isActive !== false });
 
   return (
@@ -116,8 +165,8 @@ export function Canvas({ onNavigate, isActive, showHints }: {
       <PageHeader current="canvas" showHints={showHints} />
 
       <Box marginTop={1}><Text bold>Canvas</Text></Box>
-      {showHints && mode === 'dials' && dials.length > 0 && (
-        <Text dimColor>↑↓ select  ·  ← → adjust  ·  [r] reset  ·  [p] new prompt  ·  Esc back</Text>
+      {showHints && mode === 'dials' && spec && (
+        <Text dimColor>↑↓ select  ·  ← → adjust  ·  [r] reset  ·  [p] new prompt</Text>
       )}
 
       {/* ── Prompt bar ─────────────────────────────────────────────────── */}
@@ -125,7 +174,7 @@ export function Canvas({ onNavigate, isActive, showHints }: {
         <Text color={C_ACCENT}>›</Text>
         {mode === 'prompt'
           ? <TextInput value={prompt} placeholder="what do you want to calculate?" />
-          : <Text dimColor>{prompt || 'no prompt'}</Text>
+          : <Text dimColor>{prompt}</Text>
         }
         {mode === 'prompt' && showHints && prompt.trim() && (
           <Text dimColor>  Enter to generate</Text>
@@ -134,71 +183,15 @@ export function Canvas({ onNavigate, isActive, showHints }: {
 
       <Box marginTop={1}><Divider /></Box>
 
-      {/* ── States ─────────────────────────────────────────────────────── */}
-      {error && (
-        <Box marginTop={1}><Text color={C_WARNING}>{error}</Text></Box>
+      {error && <Box marginTop={1}><Text color={C_WARNING}>{error}</Text></Box>}
+
+      {!spec && !error && status && <Box marginTop={1}><Text dimColor>{status}</Text></Box>}
+
+      {!spec && !error && !status && (
+        <Box marginTop={1}><Text dimColor>Ask a financial question and press Enter.</Text></Box>
       )}
 
-      {!spec && !error && status && (
-        <Box marginTop={1}><Text dimColor>{status}</Text></Box>
-      )}
-
-      {!spec && !error && !status && mode === 'prompt' && (
-        <Box marginTop={1}>
-          <Text dimColor>Ask a financial question and press Enter.</Text>
-        </Box>
-      )}
-
-      {/* ── Canvas ─────────────────────────────────────────────────────── */}
-      {spec && (
-        <Box flexDirection="column" marginTop={1}>
-          <Text bold>{spec.title}</Text>
-
-          {spec.elements.map((el, i) => {
-            if (el.type === 'section') {
-              return <Box key={i} marginTop={1}><SectionHeader>{el.label}</SectionHeader></Box>;
-            }
-
-            if (el.type === 'text') {
-              return <Box key={i} marginTop={0}><Text dimColor>{el.content}</Text></Box>;
-            }
-
-            if (el.type === 'dial') {
-              const d = el.dial;
-              const val = dialValues[d.key] ?? d.default;
-              const isSelected = mode === 'dials' && dials[dialIdx]?.key === d.key;
-              const atDefault = val === d.default;
-              return (
-                <DialRow
-                  key={i}
-                  label={d.label}
-                  value={fmtDialValue(val, d.format)}
-                  selected={isSelected}
-                  labelWidth={LABEL_W}
-                  valueWidth={VALUE_W}
-                  description={isSelected
-                    ? `← → ±${fmtDialValue(d.step, d.format)}${!atDefault ? '  ·  [r] reset' : ''}`
-                    : `${d.hint}${!atDefault ? ' (modified)' : ''}`}
-                />
-              );
-            }
-
-            if (el.type === 'output') {
-              const out = el.output;
-              const val = evalExpr(out.expr, dialValues);
-              const formatted = fmtValue(val, out.format);
-              return (
-                <Box key={i} gap={3}>
-                  <Text dimColor>{out.label.padEnd(LABEL_W)}</Text>
-                  <Text bold color={outputColor(out.color)}>{formatted.padStart(VALUE_W)}</Text>
-                </Box>
-              );
-            }
-
-            return null;
-          })}
-        </Box>
-      )}
+      {spec && <Box marginTop={1}><CanvasView spec={spec} isActive={mode === 'dials'} /></Box>}
     </Box>
   );
 }

--- a/tui/Canvas.tsx
+++ b/tui/Canvas.tsx
@@ -1,12 +1,13 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Box, Text, useInput } from 'ink';
 import type { Screen } from './App.js';
 import { handleNavKey } from './nav.js';
 import { Divider } from './fmt.js';
-import { C_POSITIVE, C_NEGATIVE, C_NEUTRAL, C_ACCENT, C_WARNING } from './ui.js';
-import { PageHeader, SectionHeader, DialRow, TextInput } from './components/index.js';
-import { generateCanvas, evalExpr, fmtValue, fmtDialValue, type CanvasSpec, type DialDef } from '../core/canvas-agent.js';
-import { useSetTyping } from './TypingContext.js';
+import { C_POSITIVE, C_NEGATIVE, C_NEUTRAL, C_ACCENT } from './ui.js';
+import { PageHeader, SectionHeader, DialRow, SearchBar, SelectableRow } from './components/index.js';
+import { evalExpr, fmtValue, fmtDialValue, type CanvasSpec, type DialDef } from '../core/canvas-agent.js';
+import { loadHistory, deleteHistoryEntry, type CanvasHistoryEntry } from '../core/canvas-history.js';
+import { useRefreshKey } from './RefreshContext.js';
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -66,11 +67,9 @@ export function CanvasView({ spec, isActive }: { spec: CanvasSpec; isActive?: bo
         if (el.type === 'section') {
           return <Box key={i} marginTop={1}><SectionHeader>{el.label}</SectionHeader></Box>;
         }
-
         if (el.type === 'text') {
           return <Box key={i}><Text dimColor>{el.content}</Text></Box>;
         }
-
         if (el.type === 'dial') {
           const d = el.dial;
           const val = dialValues[d.key] ?? d.default;
@@ -90,18 +89,16 @@ export function CanvasView({ spec, isActive }: { spec: CanvasSpec; isActive?: bo
             />
           );
         }
-
         if (el.type === 'output') {
           const out = el.output;
           const val = evalExpr(out.expr, dialValues);
           return (
             <Box key={i} gap={3}>
               <Text dimColor>{out.label.padEnd(LABEL_W)}</Text>
-              <Text bold color={outputColor(out.color)}>{fmtValue(val, out.format).padStart(VALUE_W)}</Text>
+              <Text bold color={outputColor(out.color)}>{fmtValue(val, out.format, out.signed).padStart(VALUE_W)}</Text>
             </Box>
           );
         }
-
         return null;
       })}
     </Box>
@@ -110,54 +107,61 @@ export function CanvasView({ spec, isActive }: { spec: CanvasSpec; isActive?: bo
 
 // ─── Canvas screen ────────────────────────────────────────────────────────────
 
-type Mode = 'prompt' | 'dials';
+type Mode = 'view' | 'history';
 
-export function Canvas({ onNavigate, isActive, showHints }: {
+export function Canvas({ onNavigate, onLoadSpec, isActive, showHints, spec, specKey }: {
   onNavigate: (s: Screen) => void;
+  onLoadSpec: (spec: CanvasSpec) => void;
   isActive?: boolean;
   showHints: boolean;
+  spec: CanvasSpec | null;
+  specKey: number;
 }) {
-  const [mode,   setMode]   = useState<Mode>('prompt');
-  const [prompt, setPrompt] = useState('');
-  const [status, setStatus] = useState('');
-  const [spec,   setSpec]   = useState<CanvasSpec | null>(null);
-  const [error,  setError]  = useState('');
+  const [mode, setMode]           = useState<Mode>('view');
+  const [search, setSearch]       = useState('');
+  const [history, setHistory]     = useState<CanvasHistoryEntry[]>([]);
+  const [historyIdx, setHistoryIdx] = useState(0);
+  const refreshKey = useRefreshKey();
 
-  const setTyping = useSetTyping();
+  const filtered = search
+    ? history.filter((e) =>
+        e.title.toLowerCase().includes(search.toLowerCase()) ||
+        e.prompt.toLowerCase().includes(search.toLowerCase()))
+    : history;
 
-  const runGenerate = useCallback(async (p: string) => {
-    setError('');
-    setSpec(null);
-    setTyping(false);
-    setMode('dials');
-    try {
-      const s = await generateCanvas(p, setStatus);
-      setSpec(s);
-      setStatus('');
-    } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
-      setStatus('');
-      setMode('prompt');
-    }
-  }, []);
+  useEffect(() => {
+    if (mode === 'history') setHistory(loadHistory());
+  }, [mode, refreshKey]);
+
+  useEffect(() => { setHistoryIdx(0); }, [search]);
 
   useInput((input, key) => {
-    if (key.escape) {
-      if (mode === 'dials') { setMode('prompt'); setTyping(true); return; }
-      onNavigate('dashboard');
+    if (mode === 'history') {
+      if (key.escape)    { setMode('view'); setSearch(''); return; }
+      if (key.upArrow)   { setHistoryIdx((i) => Math.max(0, i - 1)); return; }
+      if (key.downArrow) { setHistoryIdx((i) => Math.min(filtered.length - 1, i + 1)); return; }
+      if (key.return && filtered[historyIdx]) {
+        onLoadSpec(filtered[historyIdx].spec);
+        setMode('view');
+        setSearch('');
+        return;
+      }
+      if (key.ctrl && input === 'd' && filtered[historyIdx]) {
+        deleteHistoryEntry(filtered[historyIdx].id);
+        const next = loadHistory();
+        setHistory(next);
+        setHistoryIdx((i) => Math.min(i, Math.max(0, next.length - 1)));
+        return;
+      }
+      if (key.backspace || key.delete) { setSearch((s) => s.slice(0, -1)); return; }
+      if (!key.ctrl && !key.meta && input) { setSearch((s) => s + input); return; }
       return;
     }
+
+    // view mode
+    if (key.escape) { onNavigate('dashboard'); return; }
+    if (input === '/') { setMode('history'); setHistory(loadHistory()); return; }
     handleNavKey(input, 'canvas', onNavigate);
-
-    if (mode === 'prompt') {
-      setTyping(true);
-      if (key.return && prompt.trim()) { void runGenerate(prompt.trim()); return; }
-      if (key.backspace || key.delete) { setPrompt((p) => p.slice(0, -1)); return; }
-      if (!key.ctrl && !key.meta && input) setPrompt((p) => p + input);
-      return;
-    }
-
-    if (input === 'p' || input === '/') { setMode('prompt'); setTyping(true); }
   }, { isActive: isActive !== false });
 
   return (
@@ -165,33 +169,43 @@ export function Canvas({ onNavigate, isActive, showHints }: {
       <PageHeader current="canvas" showHints={showHints} />
 
       <Box marginTop={1}><Text bold>Canvas</Text></Box>
-      {showHints && mode === 'dials' && spec && (
-        <Text dimColor>↑↓ select  ·  ← → adjust  ·  [r] reset  ·  [p] new prompt</Text>
+      {showHints && (
+        <Text dimColor>
+          {mode === 'history'
+            ? '↑↓ select  ·  type to filter  ·  Enter load  ·  ctrl + d delete  ·  Esc back'
+            : spec
+              ? '↑↓ select  ·  ← → adjust  ·  [r] reset  ·  [/] history'
+              : '[/] history  ·  or ask the agent (`)'}
+        </Text>
       )}
 
-      {/* ── Prompt bar ─────────────────────────────────────────────────── */}
-      <Box marginTop={1} gap={1}>
-        <Text color={C_ACCENT}>›</Text>
-        {mode === 'prompt'
-          ? <TextInput value={prompt} placeholder="what do you want to calculate?" />
-          : <Text dimColor>{prompt}</Text>
-        }
-        {mode === 'prompt' && showHints && prompt.trim() && (
-          <Text dimColor>  Enter to generate</Text>
-        )}
-      </Box>
-
-      <Box marginTop={1}><Divider /></Box>
-
-      {error && <Box marginTop={1}><Text color={C_WARNING}>{error}</Text></Box>}
-
-      {!spec && !error && status && <Box marginTop={1}><Text dimColor>{status}</Text></Box>}
-
-      {!spec && !error && !status && (
-        <Box marginTop={1}><Text dimColor>Ask a financial question and press Enter.</Text></Box>
+      {mode === 'history' ? (
+        <>
+          <SearchBar value={search} hint="↑↓ select  Enter load  ctrl+d delete  Esc back" />
+          <Box marginTop={1}><Divider /></Box>
+          <Box flexDirection="column" marginTop={1}>
+            {filtered.length === 0
+              ? <Text dimColor>No canvases found.</Text>
+              : filtered.map((e, i) => (
+                  <SelectableRow key={e.id} selected={i === historyIdx} gap={2}>
+                    <Text color={i === historyIdx ? C_ACCENT : undefined}>{e.title.padEnd(24)}</Text>
+                    <Text dimColor>{e.prompt.length > 44 ? e.prompt.slice(0, 43) + '…' : e.prompt.padEnd(44)}</Text>
+                    {(e.versions ?? 0) > 1 && <Text dimColor>v{e.versions}</Text>}
+                    <Text dimColor>{(e.updatedAt ?? e.createdAt).slice(0, 10)}</Text>
+                  </SelectableRow>
+                ))
+            }
+          </Box>
+        </>
+      ) : (
+        <>
+          <Box marginTop={1}><Divider /></Box>
+          {spec
+            ? <Box marginTop={1}><CanvasView key={specKey} spec={spec} isActive={isActive} /></Box>
+            : <Box marginTop={1}><Text dimColor>Ask the agent (`) to generate a canvas — or press [/] to browse history.</Text></Box>
+          }
+        </>
       )}
-
-      {spec && <Box marginTop={1}><CanvasView spec={spec} isActive={mode === 'dials'} /></Box>}
     </Box>
   );
 }

--- a/tui/Health.tsx
+++ b/tui/Health.tsx
@@ -39,7 +39,7 @@ function progressBar(ratio: number, width = PROGRESS_BAR_WIDTH) {
 
 // ─── Component ────────────────────────────────────────────────────────────────
 
-const DEFAULT_HEALTH: HealthData = { avgMonthlyExpenses: 0, monthlyIncome: 0, monthlySavings: 0, cash: 0, liquid: 0, totalDebt: 0, netWorth: 0 };
+const DEFAULT_HEALTH: HealthData = { avgMonthlyExpenses: 0, monthlyIncome: 0, monthlySavings: 0, savingsRate: 0, cash: 0, liquid: 0, retirement: 0, totalDebt: 0, loanDebt: 0, netWorth: 0 };
 
 export function Health({ onNavigate, isActive, showHints }: { onNavigate: (s: Screen) => void; isActive?: boolean; showHints: boolean }) {
   const refreshKey = useRefreshKey();

--- a/tui/Health.tsx
+++ b/tui/Health.tsx
@@ -5,7 +5,7 @@ import { fmt, fmtSigned, fmtPct, fmtMonths, fmtCompact, Divider } from './fmt.js
 import { handleNavKey } from './nav.js';
 import { loadHealthData, yearsToFire, coastYears, type HealthData } from '../core/health.js';
 import { C_POSITIVE, C_NEGATIVE, C_WARNING, C_NEUTRAL, C_ACCENT } from './ui.js';
-import { SectionHeader, SelectableRow, PageHeader } from './components/index.js';
+import { SectionHeader, PageHeader, DialRow } from './components/index.js';
 import { useRefreshKey } from './RefreshContext.js';
 
 function savingsRateColor(rate: number): string {
@@ -261,45 +261,31 @@ export function Health({ onNavigate, isActive, showHints }: { onNavigate: (s: Sc
       <SectionHeader>ASSUMPTIONS</SectionHeader>
 
       <Box flexDirection="column" marginTop={1}>
-        <SelectableRow selected={currentDial === 'spend'} gap={2}>
-          <Text color={currentDial === 'spend' ? C_ACCENT : undefined}>{'Monthly spending'.padEnd(16)}</Text>
-          <Text color={currentDial === 'spend' ? C_ACCENT : C_NEUTRAL}>{'[ '}{fmt(monthlySpend).padStart(V)}{' ]'}</Text>
-          <Text dimColor>
-            {currentDial === 'spend'
-              ? (spendChanged ? `default ${fmt(defaultSpend)} · [r] reset` : `avg past 12 months  ← → ±${fmt(SPEND_STEP)}`)
-              : `avg past 12 months${spendChanged ? ' (modified)' : ''}`}
-          </Text>
-        </SelectableRow>
-
-        <SelectableRow selected={currentDial === 'savings'} gap={2}>
-          <Text color={currentDial === 'savings' ? C_ACCENT : undefined}>{'Monthly savings'.padEnd(16)}</Text>
-          <Text color={currentDial === 'savings' ? C_ACCENT : monthlySavings < 0 ? C_NEGATIVE : C_NEUTRAL}>{'[ '}{fmtSigned(monthlySavings).padStart(V)}{' ]'}</Text>
-          <Text dimColor>
-            {currentDial === 'savings'
-              ? (savingsChanged ? `default ${fmt(defaultSavings)} · [r] reset` : `avg surplus past 12 mo  ← → ±${fmt(SPEND_STEP)}`)
-              : `avg surplus past 12 mo${savingsChanged ? ' (modified)' : ''}`}
-          </Text>
-        </SelectableRow>
-
-        <SelectableRow selected={currentDial === 'withdrawal'} gap={2}>
-          <Text color={currentDial === 'withdrawal' ? C_ACCENT : undefined}>{'Withdrawal rate'.padEnd(16)}</Text>
-          <Text color={currentDial === 'withdrawal' ? C_ACCENT : C_NEUTRAL}>{'[ '}{fmtPct(withdrawal).padStart(V)}{' ]'}</Text>
-          <Text dimColor>
-            {currentDial === 'withdrawal'
-              ? `← → ±${fmtPct(WITHDRAW_STEP)}${withdrawChanged ? ' · [r] reset' : ''}`
-              : `safe withdrawal rate${withdrawChanged ? ' (modified)' : ''}`}
-          </Text>
-        </SelectableRow>
-
-        <SelectableRow selected={currentDial === 'growth'} gap={2}>
-          <Text color={currentDial === 'growth' ? C_ACCENT : undefined}>{'Growth rate'.padEnd(16)}</Text>
-          <Text color={currentDial === 'growth' ? C_ACCENT : C_NEUTRAL}>{'[ '}{fmtPct(growth).padStart(V)}{' ]'}</Text>
-          <Text dimColor>
-            {currentDial === 'growth'
-              ? `← → ±${fmtPct(GROWTH_STEP)}${growthChanged ? ' · [r] reset' : ''}`
-              : `real annual return${growthChanged ? ' (modified)' : ''}`}
-          </Text>
-        </SelectableRow>
+        <DialRow
+          label="Monthly spending" value={fmt(monthlySpend)} selected={currentDial === 'spend'}
+          description={currentDial === 'spend'
+            ? (spendChanged ? `default ${fmt(defaultSpend)} · [r] reset` : `avg past 12 months  ← → ±${fmt(SPEND_STEP)}`)
+            : `avg past 12 months${spendChanged ? ' (modified)' : ''}`}
+        />
+        <DialRow
+          label="Monthly savings" value={fmtSigned(monthlySavings)} selected={currentDial === 'savings'}
+          valueColor={monthlySavings < 0 ? C_NEGATIVE : C_NEUTRAL}
+          description={currentDial === 'savings'
+            ? (savingsChanged ? `default ${fmt(defaultSavings)} · [r] reset` : `avg surplus past 12 mo  ← → ±${fmt(SPEND_STEP)}`)
+            : `avg surplus past 12 mo${savingsChanged ? ' (modified)' : ''}`}
+        />
+        <DialRow
+          label="Withdrawal rate" value={fmtPct(withdrawal)} selected={currentDial === 'withdrawal'}
+          description={currentDial === 'withdrawal'
+            ? `← → ±${fmtPct(WITHDRAW_STEP)}${withdrawChanged ? ' · [r] reset' : ''}`
+            : `safe withdrawal rate${withdrawChanged ? ' (modified)' : ''}`}
+        />
+        <DialRow
+          label="Growth rate" value={fmtPct(growth)} selected={currentDial === 'growth'}
+          description={currentDial === 'growth'
+            ? `← → ±${fmtPct(GROWTH_STEP)}${growthChanged ? ' · [r] reset' : ''}`
+            : `real annual return${growthChanged ? ' (modified)' : ''}`}
+        />
       </Box>
     </Box>
   );

--- a/tui/components/DialRow.tsx
+++ b/tui/components/DialRow.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Text } from 'ink';
+import { SelectableRow } from './SelectableRow.js';
+import { C_ACCENT, C_NEUTRAL } from '../ui.js';
+
+export function DialRow({
+  label,
+  value,
+  description,
+  selected,
+  labelWidth = 16,
+  valueWidth = 12,
+  valueColor,
+}: {
+  label: string;
+  value: string;
+  description: string;
+  selected: boolean;
+  labelWidth?: number;
+  valueWidth?: number;
+  valueColor?: string;
+}) {
+  return (
+    <SelectableRow selected={selected} gap={2}>
+      <Text color={selected ? C_ACCENT : undefined}>{label.padEnd(labelWidth)}</Text>
+      <Text color={selected ? C_ACCENT : (valueColor ?? C_NEUTRAL)}>{'[ '}{value.padStart(valueWidth)}{' ]'}</Text>
+      <Text dimColor>{description}</Text>
+    </SelectableRow>
+  );
+}

--- a/tui/components/index.ts
+++ b/tui/components/index.ts
@@ -8,3 +8,4 @@ export { useStatusMessage } from './useStatusMessage.js';
 export { ColumnHeader } from './ColumnHeader.js';
 export { PageHeader } from './PageHeader.js';
 export { SearchBar } from './SearchBar.js';
+export { DialRow } from './DialRow.js';

--- a/tui/index.tsx
+++ b/tui/index.tsx
@@ -4,6 +4,8 @@ import { DATA_DIR } from '../core/paths.js';
 config({ path: join(DATA_DIR, '.env'), quiet: true });
 import React from 'react';
 import { render } from 'ink';
+import { writeFileSync } from 'node:fs';
+import stripAnsi from 'strip-ansi';
 import { initDb } from '../core/db.js';
 import { backupDb } from '../core/backup.js';
 import { syncAll } from '../core/sync.js';
@@ -12,6 +14,22 @@ import { App } from './App.js';
 import { Setup } from './Setup.js';
 import { startMcpHttpServer } from '../mcp/http.js';
 import { startApiServer } from '../api/server.js';
+
+// ── Screen capture ─────────────────────────────────────────────────────────────
+const SCREEN_PATH = join(DATA_DIR, 'screen.txt');
+let _captureTimer: ReturnType<typeof setTimeout> | undefined;
+let _lastChunk = '';
+const _origWrite = process.stdout.write.bind(process.stdout);
+(process.stdout.write as typeof process.stdout.write) = function (chunk, enc?, cb?) {
+  const result = (_origWrite as any)(chunk, enc, cb);
+  _lastChunk = typeof chunk === 'string' ? chunk : (chunk as Buffer).toString();
+  clearTimeout(_captureTimer);
+  _captureTimer = setTimeout(() => {
+    const clean = stripAnsi(_lastChunk).trimEnd();
+    if (clean) try { writeFileSync(SCREEN_PATH, clean, 'utf-8'); } catch { /* ignore */ }
+  }, 80);
+  return result;
+};
 
 const isDemo = process.argv.includes('--demo');
 

--- a/tui/nav.tsx
+++ b/tui/nav.tsx
@@ -11,16 +11,18 @@ const SCREEN_KEYS: Record<string, Screen> = {
   '6': 'health',
   '7': 'rules',
   '8': 'accounts',
+  '9': 'canvas',
 };
 
 const LABELS: Record<Screen, string> = {
   dashboard: 'dash', transactions: 'txns', trends: 'trends',
   networth: 'worth', tags: 'tags', health: 'health', rules: 'rules', accounts: 'accounts',
+  canvas: 'canvas',
 };
 
 // Split into two rows so each row stays short enough for narrow terminals
 const ROW1: Screen[] = ['dashboard', 'transactions', 'trends', 'networth'];
-const ROW2: Screen[] = ['tags', 'health', 'rules', 'accounts'];
+const ROW2: Screen[] = ['tags', 'health', 'rules', 'accounts', 'canvas'];
 
 const keyOf = (s: Screen) => Object.entries(SCREEN_KEYS).find(([, v]) => v === s)![0];
 const hint  = (s: Screen) => `[${keyOf(s)}] ${LABELS[s]}`;


### PR DESCRIPTION
## Summary

Adds screen 9 (Canvas) — a new mode where the agent generates interactive financial calculators on demand. The user prompts the agent (via backtick), the LLM produces a `CanvasSpec` with adjustable dials and computed outputs, and the TUI renders it as a live calculator.

- **Dials**: ← → arrow keys adjust inputs in real time
- **Outputs**: JS expressions re-evaluate instantly as dials change
- **History**: canvases are saved, searchable, and reloadable via `/`
- **MCP tools**: `generate_canvas`, `show_canvas`, `list_canvases`, `load_canvas`, `delete_canvas`

## Canvas context improvements (from testing session)

After generating 10 test canvases and doing a post-mortem, several systematic issues were fixed:

- **`never` instead of `—`** for infinite payoff times (e.g. payment below minimum interest)
- **Real (inflation-adjusted) dollars** as default for long-horizon projections — inflation dial included automatically, real value is the primary output
- **Retirement accounts broken out** from taxable brokerage in financial context — generator now knows which pool is restricted until ~59½
- **Savings rate %** added to context
- **Loan debt** (mortgage/auto/student) added as separate field from credit card debt
- **Age dial rule** added to system prompt for retirement canvases (age not in Plaid data)

## Related issues

- #59 — Settings: personal profile (age, spouse, kids) to enrich canvas context further
- #60 — Accounts: store APR on debt accounts so canvas payoff dials can pre-fill with real rates

## Test plan

- [ ] Press `` ` `` to open agent, ask "how long to pay off my credit card?" — canvas renders on screen 9
- [ ] Arrow keys adjust dials, outputs update live
- [ ] Press `/` to browse history, Enter to reload a canvas
- [ ] Ask a long-horizon question (retirement, investment growth) — confirm inflation dial present and real value is primary output
- [ ] Set monthly payment below minimum interest on payoff canvas — confirm output shows `never` not `—`

🤖 Generated with [Claude Code](https://claude.com/claude-code)