### PR TITLE
feat: spending by account owner (totals, expenses only)

### DIFF
--- a/core/accounts.ts
+++ b/core/accounts.ts
@@ -11,6 +11,10 @@ export async function updateAccountNickname(id: string, nickname: string | null)
   await db.execute({ sql: 'UPDATE accounts SET nickname = ? WHERE id = ?', args: [nickname, id] });
 }
 
+export async function updateAccountOwner(id: string, owner: string | null): Promise<void> {
+  await db.execute({ sql: 'UPDATE accounts SET owner = ? WHERE id = ?', args: [owner, id] });
+}
+
 export async function updateAccountValue(id: string, value: number): Promise<void> {
   const today = new Date().toISOString().slice(0, 10);
   await db.execute({

--- a/core/db.ts
+++ b/core/db.ts
@@ -112,6 +112,7 @@ export async function initDb() {
     'ALTER TABLE plaid_items ADD COLUMN last_synced_at INTEGER',
     'ALTER TABLE plaid_items ADD COLUMN days_requested INTEGER',
     'ALTER TABLE accounts ADD COLUMN nickname TEXT',
+    'ALTER TABLE accounts ADD COLUMN owner TEXT',
   ];
   for (const sql of migrations) {
     try {

--- a/core/profile.ts
+++ b/core/profile.ts
@@ -23,3 +23,20 @@ export function loadProfile(): Profile | null {
 export function saveProfile(p: Profile): void {
   fs.writeFileSync(PROFILE_PATH, JSON.stringify(p, null, 2), 'utf8');
 }
+
+/**
+ * The named household members an account can be assigned to as its owner —
+ * self, spouse, then each child, in that order. Used to populate the owner
+ * picker so the stored owner name comes from a known set rather than free text.
+ * Members without a name are omitted.
+ */
+export function householdMembers(p: Profile | null): string[] {
+  if (!p) return [];
+  const names: string[] = [];
+  if (p.self.name.trim()) names.push(p.self.name.trim());
+  if (p.spouse && p.spouse.name.trim()) names.push(p.spouse.name.trim());
+  for (const c of p.children) {
+    if (c.name.trim()) names.push(c.name.trim());
+  }
+  return names;
+}

--- a/core/queries.ts
+++ b/core/queries.ts
@@ -153,6 +153,32 @@ export async function getAccountRows(from: string, to: string): Promise<AccountR
   return result.rows as unknown as AccountRow[];
 }
 
+export type OwnerRow = { owner: string; spending: number };
+
+// Total expenses grouped by account owner, for splitting shared spending. Accounts
+// with no owner fall under 'Unassigned'. Uses the same expense definition as the
+// dashboard's headline Expenses (getRangeSummary): excludes hidden categories,
+// pending, and ignored transactions. Filters live in the LEFT JOIN ON clause (not
+// WHERE) so every owned account still yields a row even with zero spend this
+// period — callers rely on that to detect whether any owner has been assigned.
+export async function getOwnerRows(from: string, to: string): Promise<OwnerRow[]> {
+  const result = await db.execute({
+    sql: `SELECT COALESCE(NULLIF(TRIM(a.owner), ''), 'Unassigned') as owner,
+            COALESCE(SUM(t.amount), 0) as spending
+          FROM accounts a
+          LEFT JOIN transactions t
+            ON t.account_id = a.id
+            AND t.amount > 0
+            AND t.date >= ? AND t.date <= ?
+            AND t.pending = 0 AND t.ignored = 0
+            AND t.category NOT IN (SELECT category FROM hidden_categories)
+          GROUP BY COALESCE(NULLIF(TRIM(a.owner), ''), 'Unassigned')
+          ORDER BY spending DESC, owner`,
+    args: [from, to],
+  });
+  return result.rows as unknown as OwnerRow[];
+}
+
 // ── Drift ──────────────────────────────────────────────────────────────────────
 
 export type DriftSlice    = { current: number; lastPeriodDelta: number; lastYearDelta: number; avg12mDelta: number; avg12m: number };
@@ -445,11 +471,11 @@ export async function countSearchMatches(
   return { count: matches.length, expenses: matches.filter((r) => Number(r.amount) > 0).reduce((s, r) => s + Number(r.amount), 0) };
 }
 
-export type LinkedAccount = { id: string; name: string; nickname: string | null; type: string; subtype: string | null; institution_name: string | null; mask: string | null; last_synced: string | null };
+export type LinkedAccount = { id: string; name: string; nickname: string | null; owner: string | null; type: string; subtype: string | null; institution_name: string | null; mask: string | null; last_synced: string | null };
 
 export async function getLinkedAccounts(): Promise<LinkedAccount[]> {
   const result = await db.execute(`
-    SELECT a.id, a.name, a.nickname, a.type, a.subtype, a.institution_name, a.mask,
+    SELECT a.id, a.name, a.nickname, a.owner, a.type, a.subtype, a.institution_name, a.mask,
       (SELECT MAX(date) FROM balance_history WHERE account_id = a.id) as last_synced
     FROM accounts a
     ORDER BY CASE a.type WHEN 'depository' THEN 0 WHEN 'investment' THEN 1 WHEN 'credit' THEN 2 ELSE 3 END, a.name

--- a/tests/helpers/makeTestDb.ts
+++ b/tests/helpers/makeTestDb.ts
@@ -8,7 +8,8 @@ const SCHEMA = `
     subtype TEXT,
     institution_name TEXT,
     mask TEXT,
-    nickname TEXT
+    nickname TEXT,
+    owner TEXT
   );
 
   CREATE TABLE transactions (

--- a/tests/queries.test.ts
+++ b/tests/queries.test.ts
@@ -12,6 +12,7 @@ import {
   getHiddenCategories,
   getRecentTransactions,
   getMerchantSummary,
+  getOwnerRows,
   hasAccounts,
 } from '../core/queries.js';
 
@@ -384,5 +385,63 @@ describe('hasAccounts', () => {
       args: [],
     });
     expect(await hasAccounts()).toBe(true);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────
+describe('getOwnerRows', () => {
+  const RANGE = ['2025-01-01', '2025-01-31'] as const;
+  const addAccount = (id: string, owner: string | null) =>
+    db.execute({
+      sql: "INSERT INTO accounts (id, name, type, owner) VALUES (?, ?, 'depository', ?)",
+      args: [id, id, owner],
+    });
+
+  it('sums expenses per owner, sorted by spend descending', async () => {
+    await addAccount('a1', 'Mark');
+    await addAccount('a2', 'Partner');
+    await insertTx({ accountId: 'a1', amount: 100 });
+    await insertTx({ accountId: 'a1', amount: 50 });
+    await insertTx({ accountId: 'a2', amount: 200 });
+    const rows = await getOwnerRows(...RANGE);
+    expect(rows).toEqual([
+      { owner: 'Partner', spending: 200 },
+      { owner: 'Mark', spending: 150 },
+    ]);
+  });
+
+  it('buckets accounts with no owner under Unassigned', async () => {
+    await addAccount('a1', 'Mark');
+    await addAccount('a2', null);
+    await addAccount('a3', '   '); // whitespace-only owner counts as unassigned
+    await insertTx({ accountId: 'a1', amount: 100 });
+    await insertTx({ accountId: 'a2', amount: 75 });
+    await insertTx({ accountId: 'a3', amount: 25 });
+    const rows = await getOwnerRows(...RANGE);
+    expect(rows.find((r) => r.owner === 'Unassigned')?.spending).toBe(100);
+  });
+
+  it('lists an owned account even when it has no spend this period (zero row)', async () => {
+    await addAccount('a1', 'Mark');
+    const rows = await getOwnerRows(...RANGE);
+    expect(rows).toEqual([{ owner: 'Mark', spending: 0 }]);
+  });
+
+  it('returns no rows when there are no accounts', async () => {
+    await insertTx({ amount: 100 }); // orphan tx, no account row
+    expect(await getOwnerRows(...RANGE)).toEqual([]);
+  });
+
+  it('excludes income, pending, ignored, hidden categories, and out-of-range txns', async () => {
+    await db.execute({ sql: 'INSERT INTO hidden_categories VALUES (?)', args: ['Transfer'] });
+    await addAccount('a1', 'Mark');
+    await insertTx({ accountId: 'a1', amount: 100 });                      // counts
+    await insertTx({ accountId: 'a1', amount: -500 });                     // income, excluded
+    await insertTx({ accountId: 'a1', amount: 40, pending: 1 });           // pending, excluded
+    await insertTx({ accountId: 'a1', amount: 40, ignored: 1 });           // ignored, excluded
+    await insertTx({ accountId: 'a1', amount: 40, category: 'Transfer' }); // hidden, excluded
+    await insertTx({ accountId: 'a1', amount: 999, date: '2024-12-31' });  // out of range, excluded
+    const rows = await getOwnerRows(...RANGE);
+    expect(rows).toEqual([{ owner: 'Mark', spending: 100 }]);
   });
 });

--- a/tests/tui/screens.test.tsx
+++ b/tests/tui/screens.test.tsx
@@ -133,6 +133,34 @@ describe('Dashboard', () => {
     });
   });
 
+  it('owner view is skipped in the Tab cycle when no account has an owner', async () => {
+    // Seeded accounts have no owner, so account → Tab should wrap back to categories.
+    const r = dash();
+    await waitFor(() => expect(frame(r)).toContain('Income'));
+    r.stdin.write('\t'); // flex
+    r.stdin.write('\t'); // account
+    await waitFor(() => expect(frame(r)).toContain('Test Checking'));
+    r.stdin.write('\t'); // would be owner, but skipped → categories
+    await waitFor(() => expect(frame(r)).toContain('SPENDING BY CATEGORY'));
+    expect(frame(r)).not.toContain('SPENDING BY OWNER');
+  });
+
+  it('owner view appears after the account view once an owner is assigned', async () => {
+    await db.execute({ sql: "UPDATE accounts SET owner = 'Alex' WHERE id = 'test-checking'", args: [] });
+    const r = dash();
+    await waitFor(() => expect(frame(r)).toContain('Income'));
+    r.stdin.write('\t'); // flex
+    r.stdin.write('\t'); // account
+    await waitFor(() => expect(frame(r)).toContain('Test Checking'));
+    r.stdin.write('\t'); // owner
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).toContain('SPENDING BY OWNER');
+      expect(f).toContain('Alex');         // the assigned owner
+      expect(f).toContain('Unassigned');   // test-credit has no owner
+    });
+  });
+
   it('r key cycles the range label', async () => {
     const r = dash();
     await waitFor(() => expect(frame(r)).toContain('Month'));
@@ -738,6 +766,42 @@ describe('Accounts', () => {
     const f = frame(r);
     expect(f).toContain('Test Checking');
     expect(f).not.toContain('Nickname set to');
+  });
+
+  it('setting an owner refreshes the list to show the owner on the account row', async () => {
+    const real = accountsApi.updateAccountOwner;
+    vi.spyOn(accountsApi, 'updateAccountOwner').mockImplementation(delayWrite(real));
+
+    const r = accounts();
+    await waitFor(() => expect(frame(r)).toContain('Test Checking'));
+    r.stdin.write('o');                 // open owner editor
+    await waitFor(() => expect(frame(r)).toContain('Who owns this account?'));
+    r.stdin.write('Alex Stark');        // type the owner
+    await waitFor(() => expect(frame(r)).toContain('Alex Stark'));
+    r.stdin.write('\r');                // save (separate chunk so it isn't merged)
+    // Owner is appended to the row (it doesn't replace the name), so presence alone
+    // can't tell the row apart from the status toast. Under the stale-list bug the
+    // owner shows only in the toast; with the await fix it appears in BOTH the toast
+    // and the reloaded row — so we require at least two occurrences. Whitespace is
+    // collapsed first because the owner can wrap across lines in the account row.
+    await waitFor(() => {
+      const flat = frame(r).replace(/\s+/g, ' ');
+      expect((flat.match(/Alex Stark/g) ?? []).length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  it('surfaces an error and does not apply the owner when the write fails', async () => {
+    vi.spyOn(accountsApi, 'updateAccountOwner').mockRejectedValue(new Error('db down'));
+
+    const r = accounts();
+    await waitFor(() => expect(frame(r)).toContain('Test Checking'));
+    r.stdin.write('o');
+    await waitFor(() => expect(frame(r)).toContain('Who owns this account?'));
+    r.stdin.write('Alex Stark');
+    await waitFor(() => expect(frame(r)).toContain('Alex Stark'));
+    r.stdin.write('\r');                 // save → write rejects
+    await waitFor(() => expect(frame(r)).toContain('Failed to save owner'));
+    expect(frame(r)).not.toContain('Owner set to');
   });
 });
 

--- a/tests/tui/screens.test.tsx
+++ b/tests/tui/screens.test.tsx
@@ -22,11 +22,15 @@ import { Health } from '../../tui/Health.js';
 import { Settings } from '../../tui/Settings.js';
 import { RefreshProvider } from '../../tui/RefreshContext.js';
 import { TypingContext } from '../../tui/TypingContext.js';
+import { loadProfile } from '../../core/profile.js';
 
-vi.mock('../../core/profile.js', () => ({
-  loadProfile: () => null,
-  saveProfile: () => {},
-}));
+// Keep householdMembers real (a pure helper used by the owner picker) but stub
+// the fs-backed loadProfile/saveProfile. loadProfile is a vi.fn so a test can
+// supply a profile whose members populate the cycle.
+vi.mock('../../core/profile.js', async (importActual) => {
+  const actual = await importActual<typeof import('../../core/profile.js')>();
+  return { ...actual, loadProfile: vi.fn(() => null), saveProfile: vi.fn() };
+});
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -63,6 +67,7 @@ const noop = () => {};
 // ── Setup ─────────────────────────────────────────────────────────────────────
 
 beforeEach(async () => {
+  vi.mocked(loadProfile).mockReturnValue(null); // no household members unless a test sets one
   for (const tbl of ['transactions', 'accounts', 'categories', 'tags', 'transaction_tags',
                      'category_rules', 'name_rules', 'hidden_categories', 'balance_history']) {
     await db.execute(`DELETE FROM ${tbl}`);
@@ -1193,6 +1198,8 @@ describe('Accounts', () => {
   });
 
   it('setting an owner refreshes the list to show the owner on the account row', async () => {
+    // The owner editor cycles over household members, so a profile must supply one.
+    vi.mocked(loadProfile).mockReturnValue({ self: { name: 'Alex Stark', birthYear: 0 }, children: [] });
     const real = accountsApi.updateAccountOwner;
     vi.spyOn(accountsApi, 'updateAccountOwner').mockImplementation(delayWrite(real));
 
@@ -1201,8 +1208,9 @@ describe('Accounts', () => {
     r.stdin.write('\r');                 // open unified edit panel (Nickname field active)
     await waitFor(() => expect(frame(r)).toContain('Edit: Test Checking'));
     r.stdin.write('\x1b[B');             // ↓ Nickname → Owner
-    r.stdin.write('Alex Stark');         // type the owner
-    await waitFor(() => expect(frame(r)).toContain('Alex Stark'));
+    await waitFor(() => expect(frame(r)).toContain('Unassigned')); // owner toggle, default Unassigned
+    r.stdin.write('\x1b[C');             // → cycle Unassigned → Alex Stark
+    await waitFor(() => expect(frame(r)).toContain('← Alex Stark'));
     r.stdin.write('\r');                 // save (separate chunk so it isn't merged)
     // The success toast is "Updated Test Checking" (it doesn't echo the owner), so
     // the owner appearing on the row proves the list reloaded after the write — under
@@ -1215,6 +1223,7 @@ describe('Accounts', () => {
   });
 
   it('surfaces an error and does not apply the owner when the write fails', async () => {
+    vi.mocked(loadProfile).mockReturnValue({ self: { name: 'Alex Stark', birthYear: 0 }, children: [] });
     vi.spyOn(accountsApi, 'updateAccountOwner').mockRejectedValue(new Error('db down'));
 
     const r = accounts();
@@ -1222,8 +1231,9 @@ describe('Accounts', () => {
     r.stdin.write('\r');                 // open unified edit panel
     await waitFor(() => expect(frame(r)).toContain('Edit: Test Checking'));
     r.stdin.write('\x1b[B');             // ↓ Nickname → Owner
-    r.stdin.write('Alex Stark');
-    await waitFor(() => expect(frame(r)).toContain('Alex Stark'));
+    await waitFor(() => expect(frame(r)).toContain('Unassigned'));
+    r.stdin.write('\x1b[C');             // → cycle to Alex Stark
+    await waitFor(() => expect(frame(r)).toContain('← Alex Stark'));
     r.stdin.write('\r');                 // save → write rejects
     await waitFor(() => expect(frame(r)).toContain('Failed to update'));
     expect(frame(r)).not.toContain('Updated Test Checking');

--- a/tui/Accounts.tsx
+++ b/tui/Accounts.tsx
@@ -7,6 +7,7 @@ import { syncAll } from '../core/sync.js';
 import { getCsvPlaidDupeCandidates, type DupePair } from '../core/dedup.js';
 import { parseCSV, parseDate } from '../core/csv.js';
 import { getLinkedAccounts, getCsvAccounts, type LinkedAccount, type CsvAccount } from '../core/queries.js';
+import { loadProfile, householdMembers } from '../core/profile.js';
 import { getDefaultDaysRequested, MIN_DAYS_REQUESTED, MAX_DAYS_REQUESTED } from '../core/settings.js';
 import {
   updateAccountTypeSubtype, updateAccountNickname, updateAccountOwner, updateAccountApr, updateAccountValue,
@@ -131,7 +132,10 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
 
   // Unified edit panel state
   const [editNickname, setEditNickname] = useState('');
+  // Owner holds the selected household-member name ('' = Unassigned); the editor
+  // cycles over the names defined in Settings rather than accepting free text.
   const [editOwner, setEditOwner] = useState('');
+  const [ownerMembers, setOwnerMembers] = useState<string[]>([]);
   const [editApr, setEditApr] = useState('');
 
   // Dupes view state
@@ -164,6 +168,8 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
     const subtypes = SUBTYPES[type] ?? [];
     const currentSub = acct.subtype ?? '';
     const snapped = subtypes.includes(currentSub) ? currentSub : (subtypes[0] ?? '');
+    // Re-read the profile each time so owner choices reflect the latest household.
+    setOwnerMembers(householdMembers(loadProfile()));
     setEditType(type);
     setEditSubtype(snapped);
     setEditNickname(acct.nickname ?? '');
@@ -354,7 +360,13 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
         if (key.escape) { setAcctMode('list'); return; }
         if (key.return) { void saveEdit(); return; }
         const isDebt = editType === 'credit' || editType === 'loan';
-        const editFields: EditField[] = isDebt ? ['nickname', 'owner', 'type', 'subtype', 'apr'] : ['nickname', 'owner', 'type', 'subtype'];
+        // Owner is only focusable once household members exist to cycle through.
+        const editFields: EditField[] = [
+          'nickname',
+          ...(ownerMembers.length > 0 ? ['owner'] as const : []),
+          'type', 'subtype',
+          ...(isDebt ? ['apr'] as const : []),
+        ];
         if (key.upArrow) {
           setEditField((f) => { const i = editFields.indexOf(f); return editFields[Math.max(0, i - 1)]; });
           return;
@@ -386,8 +398,12 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
           return;
         }
         if (editField === 'owner') {
-          if (key.backspace || key.delete) { setEditOwner((v) => v.slice(0, -1)); return; }
-          if (input && !key.ctrl && !key.meta) { setEditOwner((v) => v + input); return; }
+          if (key.leftArrow || key.rightArrow) {
+            const opts = ['', ...ownerMembers]; // '' = Unassigned
+            const idx = Math.max(0, opts.indexOf(editOwner));
+            const dir = key.leftArrow ? -1 : 1;
+            setEditOwner(opts[(idx + dir + opts.length) % opts.length]);
+          }
           return;
         }
         if (editField === 'apr') {
@@ -721,7 +737,14 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
               <ModalPanel title={`Edit: ${selectedAcct.name}${selectedAcct.mask ? ` ···${selectedAcct.mask}` : ''}`}>
                 <Box marginTop={1} flexDirection="column" gap={1}>
                   <EditTextField label="Nickname" labelWidth={10} active={editField === 'nickname'} value={editNickname} color={C_WARNING} placeholder="none" emptyText="none" />
-                  <EditTextField label="Owner" labelWidth={10} active={editField === 'owner'} value={editOwner} color={C_MANUAL} placeholder="none" emptyText="none" />
+                  {ownerMembers.length > 0
+                    ? <EditToggleField label="Owner" labelWidth={10} active={editField === 'owner'} value={editOwner || 'Unassigned'} valueColor={C_MANUAL} />
+                    : (
+                      <Box gap={2}>
+                        <Text color={C_NEUTRAL}>{'Owner'.padEnd(10)}</Text>
+                        <Text dimColor>Add household members in Settings [0]</Text>
+                      </Box>
+                    )}
                   <EditToggleField label="Type" labelWidth={10} active={editField === 'type'} value={editType} />
                   <EditToggleField label="Subtype" labelWidth={10} active={editField === 'subtype'} value={editSubtype || '—'} valueColor={C_DIM} />
                   {isDebt && <EditTextField label="APR %" labelWidth={10} active={editField === 'apr'} value={editApr} color={C_WARNING} placeholder="0.0" />}

--- a/tui/Accounts.tsx
+++ b/tui/Accounts.tsx
@@ -9,7 +9,7 @@ import { parseCSV, parseDate } from '../core/csv.js';
 import { getLinkedAccounts, getCsvAccounts, type LinkedAccount, type CsvAccount } from '../core/queries.js';
 import { getDefaultDaysRequested, MIN_DAYS_REQUESTED, MAX_DAYS_REQUESTED } from '../core/settings.js';
 import {
-  updateAccountTypeSubtype, updateAccountNickname, updateAccountValue,
+  updateAccountTypeSubtype, updateAccountNickname, updateAccountOwner, updateAccountValue,
   createManualAccount, createCsvAccount, deleteAccount, importCsvTransactions, deleteDuplicate, deleteAllDuplicates,
 } from '../core/accounts.js';
 import type { Screen, TxFilter } from './App.js';
@@ -21,7 +21,7 @@ import { ModalPanel, TextInput, SelectableRow, useStatusMessage, PageHeader } fr
 // ─── Types ────────────────────────────────────────────────────────────────────
 
 type MainView = 'accounts' | 'add-data' | 'dupes';
-type AcctMode = 'list' | 'edit' | 'update-value' | 'nickname' | 'confirm-delete';
+type AcctMode = 'list' | 'edit' | 'update-value' | 'nickname' | 'owner' | 'confirm-delete';
 type EditField = 'type' | 'subtype';
 
 type AddStep =
@@ -132,13 +132,16 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
   // Nickname mode state
   const [nicknameInput, setNicknameInput] = useState('');
 
+  // Owner mode state
+  const [ownerInput, setOwnerInput] = useState('');
+
   // Dupes view state
   const [dupes, setDupes] = useState<DupePair[]>([]);
   const [dupeCursor, setDupeCursor] = useState(0);
 
   const setTyping = useSetTyping();
   const TEXT_INPUT_STEPS = new Set<AddStep>(['link-days', 'file', 'manual-name', 'manual-value', 'new-acct-name']);
-  const TEXT_INPUT_MODES = new Set<AcctMode>(['nickname', 'update-value']);
+  const TEXT_INPUT_MODES = new Set<AcctMode>(['nickname', 'owner', 'update-value']);
   useEffect(() => {
     setTyping(TEXT_INPUT_STEPS.has(addStep) || TEXT_INPUT_MODES.has(acctMode));
   }, [addStep, acctMode]);
@@ -246,6 +249,20 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
       loadAccounts();
     } catch {
       showAcctErr('Failed to save nickname');
+    }
+  }
+
+  async function saveOwner() {
+    const acct = linkedAccounts[acctCursor];
+    if (!acct) return;
+    const owner = ownerInput.trim() || null;
+    try {
+      await updateAccountOwner(acct.id, owner);
+      setAcctMode('list');
+      showAcctMsg(owner ? `Owner set to "${owner}"` : 'Owner cleared');
+      loadAccounts();
+    } catch {
+      showAcctErr('Failed to save owner');
     }
   }
 
@@ -402,6 +419,14 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
         return;
       }
 
+      if (acctMode === 'owner') {
+        if (key.escape) { setAcctMode('list'); setOwnerInput(''); return; }
+        if (key.return) { void saveOwner(); return; }
+        if (key.backspace || key.delete) { setOwnerInput((v) => v.slice(0, -1)); return; }
+        if (input && !key.ctrl && !key.meta) { setOwnerInput((v) => v + input); return; }
+        return;
+      }
+
       if (acctMode === 'confirm-delete') {
         if (key.escape || input === 'n') { setAcctMode('list'); return; }
         if (input === 'y') { void handleDeleteAccount(); return; }
@@ -420,6 +445,11 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
       if (input === 'n' && linkedAccounts[acctCursor]) {
         setNicknameInput(linkedAccounts[acctCursor].nickname ?? '');
         setAcctMode('nickname');
+        return;
+      }
+      if (input === 'o' && linkedAccounts[acctCursor]) {
+        setOwnerInput(linkedAccounts[acctCursor].owner ?? '');
+        setAcctMode('owner');
         return;
       }
       if (input === 'v' && linkedAccounts[acctCursor]?.id.startsWith('manual-')) {
@@ -634,7 +664,7 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
       {showHints && <Box justifyContent="flex-end">
         <Text dimColor>
           {mainView === 'accounts' && acctMode === 'list'
-            ? `↑↓ select  ·  [e] edit  ·  [n] nickname${selectedAcct?.id.startsWith('manual-') ? '  ·  [v] update value' : '  ·  [r] repair link'}  ·  [x] delete  ·  [s] sync`
+            ? `↑↓ select  ·  [e] edit  ·  [n] nickname  ·  [o] owner${selectedAcct?.id.startsWith('manual-') ? '  ·  [v] update value' : '  ·  [r] repair link'}  ·  [x] delete  ·  [s] sync`
             : mainView === 'accounts' && acctMode === 'edit'
             ? 'Tab field  ·  ← → value  ·  Enter save  ·  Esc cancel'
             : mainView === 'dupes'
@@ -675,6 +705,7 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
                         : <Text color={C_WARNING}>not synced</Text>
                       }
                     </Text>
+                    {acct.owner && <Text color={isSelected ? C_MANUAL : undefined} dimColor={!isSelected}>{acct.owner}</Text>}
                   </SelectableRow>
                 );
               })}
@@ -710,6 +741,15 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
             <ModalPanel title={`Nickname: ${selectedAcct.name}`} borderColor={C_WARNING}>
               <Text dimColor>Leave empty to clear nickname</Text>
               <Box marginTop={1} gap={1}><Text>Nickname: </Text><TextInput value={nicknameInput} color={C_WARNING} /></Box>
+              <Box marginTop={1}><Text dimColor>Enter save · Esc cancel</Text></Box>
+            </ModalPanel>
+          )}
+
+          {/* Owner panel */}
+          {acctMode === 'owner' && selectedAcct && (
+            <ModalPanel title={`Owner: ${selectedAcct.nickname ?? selectedAcct.name}`} borderColor={C_MANUAL}>
+              <Text dimColor>Who owns this account? Leave empty to clear owner</Text>
+              <Box marginTop={1} gap={1}><Text>Owner: </Text><TextInput value={ownerInput} color={C_MANUAL} /></Box>
               <Box marginTop={1}><Text dimColor>Enter save · Esc cancel</Text></Box>
             </ModalPanel>
           )}

--- a/tui/Dashboard.tsx
+++ b/tui/Dashboard.tsx
@@ -1,9 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import { Box, Text, useInput } from 'ink';
 import {
-  getRangeSummary, getFlexSummary, getUncategorizedCount, getDataBounds, getAccountRows,
+  getRangeSummary, getFlexSummary, getUncategorizedCount, getDataBounds, getAccountRows, getOwnerRows,
   getCategoryDriftData, getFlexDriftData, getAccountDriftData, countSearchMatches, getSearchFilteredData, getMerchantSummary,
-  type MonthlySummary, type FlexSummary, type AccountRow,
+  type MonthlySummary, type FlexSummary, type AccountRow, type OwnerRow,
   type CategoryDrift, type FlexDriftData, type AccountDrift, type MerchantSummaryRow,
 } from '../core/queries.js';
 import {
@@ -21,7 +21,7 @@ import { useRefreshKey } from './RefreshContext.js';
 
 const BAR_WIDTH = 20;
 
-type DashView = 'categories' | 'flex' | 'account';
+type DashView = 'categories' | 'flex' | 'account' | 'owner';
 
 function pct(part: number, total: number) {
   if (total === 0) return '0%';
@@ -95,9 +95,13 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
   const [acctCursor, setAcctCursor] = useState(0);
   const [selectedAccount, setSelectedAccount] = useState<AccountRow | null>(null);
 
+  // Owner split
+  const [ownerRows, setOwnerRows] = useState<OwnerRow[]>([]);
+
   function load(r: Range, a: Date, acct: AccountRow | null) {
     const { from, to } = getPeriodDates(r, a);
     void getAccountRows(from, to).then(setAccountRows);
+    void getOwnerRows(from, to).then(setOwnerRows);
     setAcctCursor(0);
     if (acct) {
       void getRangeSummary(from, to, acct.id).then(setSummary);
@@ -171,6 +175,13 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [anchor.toISOString().slice(0, 10), range]);
 
+  // Don't strand the user on the owner view if the last owner gets unassigned elsewhere.
+  useEffect(() => {
+    if (view === 'owner' && ownerRows.length > 0 && !ownerRows.some((r) => r.owner !== 'Unassigned')) {
+      setView('categories');
+    }
+  }, [view, ownerRows]);
+
   const categories = summary?.byCategory ?? [];
 
   const termW = useTerminalWidth();
@@ -179,6 +190,12 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
   const catFlex      = Math.max(20, inner - 16);
   const dashCatNameW = Math.max(12, Math.floor(catFlex * 0.38));
   const dashBarW     = Math.max(8,  catFlex - dashCatNameW);
+
+  // Owner split view is only offered once at least one account has an owner assigned.
+  // Every owned account yields an OwnerRow (LEFT JOIN), so a non-'Unassigned' row here
+  // means an owner exists regardless of whether they spent anything this period.
+  const hasOwners = ownerRows.some((r) => r.owner !== 'Unassigned');
+  const maxOwnerSpend = ownerRows[0]?.spending || 1;
   // Drift categories: 3 delta cols × 9 chars + 4 gaps of 2 = 27+8=35 for cols; plus amount(10)+gaps
   // total fixed = 2(cursor) + 10(amt) + 4(gaps to amt) + 27(3×9) + 4(gaps between deltas) = 47
   const driftCatNameW = Math.max(12, inner - 47);
@@ -240,7 +257,7 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
     }
 
     if (key.tab) {
-      setView((v) => v === 'categories' ? 'flex' : v === 'flex' ? 'account' : 'categories');
+      setView((v) => v === 'categories' ? 'flex' : v === 'flex' ? 'account' : v === 'account' && hasOwners ? 'owner' : 'categories');
       return;
     }
 
@@ -365,7 +382,9 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
                   ? `[/] search  ·  ← → period  ·  ↑↓ select  ·  Enter txns  ·  Space ${selectedAccount ? 'unfilter' : 'filter'}  ·  [c] clear  ·  [Tab] view  ·  [d] delta`
                   : view === 'categories'
                     ? `[/] search  ·  ← → period  ·  ↑↓ select  ·  Enter txns${driftMode ? '' : '  ·  [m] merchants'}  ·  [Tab] view  ·  [d] delta`
-                    : '[/] search  ·  ← → period  ·  Enter txns  ·  [Tab] view  ·  [d] delta')
+                    : view === 'owner'
+                      ? '← → period  ·  [r] range  ·  [Tab] view'
+                      : '[/] search  ·  ← → period  ·  Enter txns  ·  [Tab] view  ·  [d] delta')
               : '[/] search'}
           </Text>
       }
@@ -387,7 +406,7 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
           {selectedAccount && <Text color={C_WARNING}>{selectedAccount.name}</Text>}
           {driftMode && <Text color={C_MANUAL} bold>delta</Text>}
           <Text dimColor>
-            {merchantDrill ? `merchants · ${merchantDrill.category}` : view === 'categories' ? 'categories' : view === 'flex' ? 'flex' : 'account'}
+            {merchantDrill ? `merchants · ${merchantDrill.category}` : view === 'categories' ? 'categories' : view === 'flex' ? 'flex' : view === 'account' ? 'account' : 'owner'}
           </Text>
         </Box>
       </Box>
@@ -463,6 +482,24 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
           {selectedAccount && (
             <Box marginTop={1}><Text dimColor>[c] clear filter</Text></Box>
           )}
+        </Box>
+      ) : view === 'owner' ? (
+        <Box flexDirection="column" marginTop={1}>
+          <Text bold dimColor>SPENDING BY OWNER</Text>
+          <Box flexDirection="column" marginTop={1}>
+            {ownerRows.map((row) => (
+              <Box key={row.owner} gap={2}>
+                <Text dimColor={row.owner === 'Unassigned'}>
+                  {(row.owner.length > dashCatNameW ? row.owner.slice(0, dashCatNameW - 1) + '…' : row.owner).padEnd(dashCatNameW)}
+                </Text>
+                <Text color={C_NEGATIVE} dimColor={row.spending === 0}>
+                  {(row.spending > 0 ? fmt(row.spending) : '—').padStart(10)}
+                </Text>
+                <Text color={C_MANUAL}>{bar(row.spending, maxOwnerSpend, dashBarW)}</Text>
+              </Box>
+            ))}
+          </Box>
+          <Box marginTop={1}><Text dimColor>Assign owners in [8] accounts → [o]</Text></Box>
         </Box>
       ) : displaySummary ? (
         <>


### PR DESCRIPTION
Add an optional owner per account and a gated Dashboard view that totals expenses side by side per owner, so spending can be split between partners.

- core/db.ts: idempotent owner column migration on accounts
- core/accounts.ts: updateAccountOwner mutation
- core/queries.ts: getOwnerRows (LEFT JOIN with predicates in ON, Unassigned bucket via COALESCE/NULLIF/TRIM); owner on LinkedAccount
- tui/Accounts.tsx: [o] owner edit flow (ModalPanel/TextInput, await-before-reload, inline error surfacing)
- tui/Dashboard.tsx: owner view in Tab cycle, gated on at least one account having an owner assigned
- tests: query coverage (sums, Unassigned bucketing, zero-spend rows, exclusions) and TUI coverage (gating, refresh race guard, error path)