### PR TITLE
feat: Phase 2 UX polish — unified edit forms, search improvements, e2e tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A terminal UI for personal finance. Syncs transactions from [Plaid](https://plai
 - **Category rules** — substring and regex rules that auto-categorize transactions, with optional amount filters
 - **Name rules** — rename how transactions display, with optional amount filters
 - **Spending flexibility** — tag categories as fixed / flexible / discretionary; view breakdown on Dashboard
-- **Manual edits** — pin a category or display name to a specific transaction; survives re-syncs
+- **Manual edits** — pin a category or display name to a specific transaction, or promote to a rule for all matches; survives re-syncs
 - **Ignore** — soft-hide transactions from totals (transfers, reimbursements, etc.)
 - **Hidden categories** — exclude categories like Transfer from all totals and charts
 - **Tags** — label transactions across accounts (trips, projects, events) and view summaries by tag
@@ -138,7 +138,7 @@ In **delta mode**, the bar chart is replaced by three delta columns — vs prev 
 | `/` | Search by name (regex); inherited from Dashboard if navigated with an active search |
 | `a` | Show all transactions |
 | `u` | Show uncategorized only |
-| `e` | Edit: rename display name or change category |
+| `Enter` | Edit selected transaction |
 | `g` | Tag panel: add/remove tags on selected transaction |
 | `G` | Tag all visible transactions at once (use `/` to filter first) |
 | `c` | Undo manual category override |
@@ -146,14 +146,18 @@ In **delta mode**, the bar chart is replaced by three delta columns — vs prev 
 | `x` | Delete selected transaction (CSV-imported only) |
 | `Esc` | Clear active filter (peels off one at a time) |
 
+The **edit panel** has four fields navigated with `↑ ↓`: **Name** (display name override), **Category** (cycle with `← →`), **Pattern**, and **Match type**. Leave Pattern empty and `Enter` saves the change to just this transaction. Fill in Pattern and `Enter` creates a category rule (and/or name rule) that applies to all matching transactions.
+
 ### Trends `[3]`
 
 | Key | Action |
 |-----|--------|
-| `Tab` | Cycle views: Expenses → Income → Net → [each category] |
+| `← →` | Cycle views: Expenses → Income → Net → Flexibility → Fixed → Flexible → Discretionary → [each category] |
 | `↑ ↓` | Navigate periods |
 | `r` | Cycle aggregation range (Week / Month / Quarter / Year) |
 | `Enter` | Drill into transactions for selected period |
+| `/` | Search transactions by name; hides view selector and shows net-style bars for matches |
+| `Esc` | Clear active search (or navigate back) |
 
 ### Net Worth `[4]`
 
@@ -208,20 +212,20 @@ Three sections, cycle with `Tab`: **Category Rules**, **Name Rules**, **Categori
 |-----|--------|
 | `/` | Search rules |
 | `a` | Add rule |
-| `e` / `Enter` | Edit selected rule |
+| `Enter` | Edit selected rule |
 | `x` | Delete selected rule |
 
-Category rules support substring and regex matching with optional min/max amount filters. Name rules support the same matching plus optional amount filters.
+The **rule form** is a single panel with fields navigated by `↑ ↓`: Pattern, Match type, Min $, Max $, Category (rules) or Replacement (name rules). `← →` cycles/toggles the active field. Category rules support substring and regex matching with optional min/max amount filters. Name rules support the same matching plus a replacement display name.
 
 **Categories:**
 
 | Key | Action |
 |-----|--------|
 | `a` | Add new category |
-| `n` | Rename category (cascades to all transactions, rules, and hidden settings) |
+| `Enter` | Edit selected category (Name, Flexibility, Hidden — navigated with `↑ ↓`) |
 | `x` | Delete category (resets affected transactions to Uncategorized) |
-| `v` | Toggle hidden (hidden categories are excluded from totals) |
-| `f` | Cycle flexibility tier: none → fixed → flexible → discretionary |
+| `v` | Toggle hidden from list |
+| `f` | Cycle flexibility tier from list: none → fixed → flexible → discretionary |
 
 ### Accounts `[8]`
 
@@ -229,8 +233,7 @@ Category rules support substring and regex matching with optional min/max amount
 |-----|--------|
 | `Tab` | Cycle views: Accounts → Add Data → Dupes |
 | `↑ ↓` | Select account |
-| `e` | Edit account type / subtype |
-| `n` | Set or clear a nickname (shown in place of the bank-assigned name) |
+| `Enter` | Edit selected account (nickname, type, subtype, APR — navigated with `↑ ↓`, `← →` to cycle) |
 | `v` | Update value (manual assets only) |
 | `r` | Repair Plaid link for selected account |
 | `s` | Force sync (bypasses 15-min cooldown) |

--- a/core/accounts.ts
+++ b/core/accounts.ts
@@ -11,6 +11,10 @@ export async function updateAccountNickname(id: string, nickname: string | null)
   await db.execute({ sql: 'UPDATE accounts SET nickname = ? WHERE id = ?', args: [nickname, id] });
 }
 
+export async function updateAccountApr(id: string, apr: number | null): Promise<void> {
+  await db.execute({ sql: 'UPDATE accounts SET apr = ? WHERE id = ?', args: [apr, id] });
+}
+
 export async function updateAccountValue(id: string, value: number): Promise<void> {
   const today = new Date().toISOString().slice(0, 10);
   await db.execute({

--- a/core/canvas-agent.ts
+++ b/core/canvas-agent.ts
@@ -1,5 +1,6 @@
 import { streamResponse } from './llm-provider.js';
 import { loadHealthData } from './health.js';
+import { loadProfile } from './profile.js';
 import { fmt, fmtPct, fmtPctSigned, fmtCompact, fmtCompactSigned, fmtMonths } from './fmt.js';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -116,7 +117,7 @@ Example: monthly mortgage payment with principal P, monthly rate r, n payments:
 7. Format dials and outputs consistently — if a dial is "dollar", its related output should be too
 8. Set \`signed: true\` on outputs that represent deltas or values that can be negative — e.g. net savings, surplus/deficit, change in portfolio. This shows an explicit +/- prefix so the sign is always unambiguous
 9. For any projection with a multi-year time horizon (retirement, investment growth, net worth, savings goals), show values in **real (inflation-adjusted) dollars** as the primary output — not nominal. Add an \`inflation\` dial (key: "inflation", default: 3, step: 0.5, min: 0, max: 8, format: "percent", hint: "annual inflation"). Convert nominal to real with: \`nominal / Math.pow(1 + inflation/100, years)\`. Label the output "Real value (today's $)" or similar. A nominal output may appear secondary.
-10. The live data does not include the user's age. If a canvas needs years-to-retirement or a birth-year assumption, add an \`age\` dial (default: 35, step: 1, min: 18, max: 80, format: "integer", hint: "your current age") so the user can set it accurately.
+10. If the live data includes household ages, use them to pre-fill age-related dials and personalize narrative (e.g. "years until retirement" = retirement_age - current_age). If age is not provided, add an \`age\` dial (default: 35, step: 1, min: 18, max: 80, format: "integer", hint: "your current age") so the user can set it accurately.
 
 ## Existing screen conventions (for consistency)
 
@@ -154,7 +155,29 @@ export type CanvasContext = {
 export async function loadCanvasContext(): Promise<CanvasContext> {
   const health = await loadHealthData();
   const taxableBrokerage = health.liquid - health.cash;
+  const profile = loadProfile();
+  const currentYear = new Date().getFullYear();
+
+  const householdLines: string[] = [];
+  if (profile?.self.birthYear) {
+    const age = currentYear - profile.self.birthYear;
+    const name = profile.self.name || 'You';
+    let line = `Household: ${name}, age ${age}`;
+    if (profile.spouse?.birthYear) {
+      const spouseAge = currentYear - profile.spouse.birthYear;
+      line += `; ${profile.spouse.name || 'Spouse'}, age ${spouseAge}`;
+    }
+    householdLines.push(line);
+    if (profile.children.length > 0) {
+      const childDesc = profile.children
+        .map((c) => c.birthYear > 0 ? `${c.name || 'Child'} (age ${currentYear - c.birthYear})` : (c.name || 'Child'))
+        .join(', ');
+      householdLines.push(`Children: ${childDesc}`);
+    }
+  }
+
   const financialContext = [
+    ...householdLines,
     `Monthly income:    ${fmt(health.monthlyIncome)} (12-month avg)`,
     `Monthly expenses:  ${fmt(health.avgMonthlyExpenses)} (12-month avg)`,
     `Monthly surplus:   ${fmt(health.monthlySavings)} (savings rate: ${Math.round(health.savingsRate)}%)`,

--- a/core/db.ts
+++ b/core/db.ts
@@ -112,6 +112,7 @@ export async function initDb() {
     'ALTER TABLE plaid_items ADD COLUMN last_synced_at INTEGER',
     'ALTER TABLE plaid_items ADD COLUMN days_requested INTEGER',
     'ALTER TABLE accounts ADD COLUMN nickname TEXT',
+    'ALTER TABLE accounts ADD COLUMN apr REAL',
   ];
   for (const sql of migrations) {
     try {

--- a/core/profile.ts
+++ b/core/profile.ts
@@ -1,0 +1,25 @@
+import path from 'node:path';
+import fs from 'node:fs';
+import { DATA_DIR } from './paths.js';
+
+const PROFILE_PATH = path.join(DATA_DIR, 'profile.json');
+
+export type HouseholdMember = { name: string; birthYear: number };
+
+export type Profile = {
+  self: HouseholdMember;
+  spouse?: HouseholdMember;
+  children: HouseholdMember[];
+};
+
+export function loadProfile(): Profile | null {
+  try {
+    return JSON.parse(fs.readFileSync(PROFILE_PATH, 'utf8')) as Profile;
+  } catch {
+    return null;
+  }
+}
+
+export function saveProfile(p: Profile): void {
+  fs.writeFileSync(PROFILE_PATH, JSON.stringify(p, null, 2), 'utf8');
+}

--- a/core/queries.ts
+++ b/core/queries.ts
@@ -361,17 +361,20 @@ export async function toggleHiddenCategory(category: string, hidden: Set<string>
   }
 }
 
-export type Tag = { id: number; name: string; count: number };
+export type Tag = { id: number; name: string; count: number; inflow: number; outflow: number };
 
 export async function getAllTags(): Promise<Tag[]> {
   const result = await db.execute(`
-    SELECT t.id, t.name, COUNT(tt.transaction_id) as count
+    SELECT t.id, t.name, COUNT(tt.transaction_id) as count,
+      COALESCE(SUM(CASE WHEN tx.amount < 0 THEN ABS(tx.amount) ELSE 0 END), 0) as inflow,
+      COALESCE(SUM(CASE WHEN tx.amount > 0 THEN tx.amount ELSE 0 END), 0) as outflow
     FROM tags t
     LEFT JOIN transaction_tags tt ON tt.tag_id = t.id
+    LEFT JOIN transactions tx ON tx.id = tt.transaction_id
     GROUP BY t.id ORDER BY t.name
   `);
-  return (result.rows as unknown as { id: number; name: string; count: number }[]).map((r) => ({
-    id: Number(r.id), name: r.name, count: Number(r.count),
+  return (result.rows as unknown as { id: number; name: string; count: number; inflow: number; outflow: number }[]).map((r) => ({
+    id: Number(r.id), name: r.name, count: Number(r.count), inflow: Number(r.inflow), outflow: Number(r.outflow),
   }));
 }
 
@@ -445,11 +448,11 @@ export async function countSearchMatches(
   return { count: matches.length, expenses: matches.filter((r) => Number(r.amount) > 0).reduce((s, r) => s + Number(r.amount), 0) };
 }
 
-export type LinkedAccount = { id: string; name: string; nickname: string | null; type: string; subtype: string | null; institution_name: string | null; mask: string | null; last_synced: string | null };
+export type LinkedAccount = { id: string; name: string; nickname: string | null; type: string; subtype: string | null; institution_name: string | null; mask: string | null; last_synced: string | null; apr: number | null };
 
 export async function getLinkedAccounts(): Promise<LinkedAccount[]> {
   const result = await db.execute(`
-    SELECT a.id, a.name, a.nickname, a.type, a.subtype, a.institution_name, a.mask,
+    SELECT a.id, a.name, a.nickname, a.type, a.subtype, a.institution_name, a.mask, a.apr,
       (SELECT MAX(date) FROM balance_history WHERE account_id = a.id) as last_synced
     FROM accounts a
     ORDER BY CASE a.type WHEN 'depository' THEN 0 WHEN 'investment' THEN 1 WHEN 'credit' THEN 2 ELSE 3 END, a.name

--- a/core/trends.ts
+++ b/core/trends.ts
@@ -1,5 +1,6 @@
 import { db } from './db.js';
 import { MONTHS, addDays, weekLabel, type TrendsRange } from './dateUtils.js';
+import { buildSearchRe } from './queries.js';
 
 const pad = (n: number) => String(n).padStart(2, '0');
 const Q_FROM = ['01', '04', '07', '10'];
@@ -207,4 +208,38 @@ export async function getPeriodTotals(view: View, range: TrendsRange): Promise<P
   const rawRows = rawResult.rows as unknown as any[];
   const actual = new Map<string, PeriodRow>(rawRows.map((r) => { const row = toActual(r); return [row.from, row]; }));
   return allPeriods.map((p) => actual.get(p.from) ?? zeroRow(p));
+}
+
+export async function getSearchMatchingPeriods(
+  search: string,
+  range: TrendsRange,
+): Promise<Set<string>> {
+  if (!search) return new Set();
+  const result = await db.execute(`
+    SELECT COALESCE(display_name, name) as display, merchant_name, date
+    FROM transactions WHERE pending = 0 AND ignored = 0
+  `);
+  const rows = result.rows as unknown as { display: string; merchant_name: string | null; date: string }[];
+  const re = buildSearchRe(search);
+  const periods = new Set<string>();
+  for (const row of rows) {
+    if (!re.test(row.display) && !(row.merchant_name ? re.test(row.merchant_name) : false)) continue;
+    const d = row.date;
+    if (range === 'month') {
+      periods.add(d.slice(0, 7) + '-01');
+    } else if (range === 'quarter') {
+      const m = parseInt(d.slice(5, 7));
+      periods.add(d.slice(0, 4) + '-' + Q_FROM[Math.floor((m - 1) / 3)] + '-01');
+    } else if (range === 'year') {
+      periods.add(d.slice(0, 4) + '-01-01');
+    } else {
+      // week: compute the Monday of this transaction's week
+      const dt = new Date(d + 'T12:00:00');
+      const dow = (dt.getDay() + 6) % 7;
+      const mon = new Date(dt);
+      mon.setDate(dt.getDate() - dow);
+      periods.add(mon.toISOString().slice(0, 10));
+    }
+  }
+  return periods;
 }

--- a/core/trends.ts
+++ b/core/trends.ts
@@ -213,8 +213,8 @@ export async function getPeriodTotals(view: View, range: TrendsRange): Promise<P
 export async function getSearchMatchingPeriods(
   search: string,
   range: TrendsRange,
-): Promise<Set<string>> {
-  if (!search) return new Set();
+): Promise<{ periods: Set<string>; count: number }> {
+  if (!search) return { periods: new Set(), count: 0 };
   const result = await db.execute(`
     SELECT COALESCE(display_name, name) as display, merchant_name, date
     FROM transactions WHERE pending = 0 AND ignored = 0
@@ -222,8 +222,10 @@ export async function getSearchMatchingPeriods(
   const rows = result.rows as unknown as { display: string; merchant_name: string | null; date: string }[];
   const re = buildSearchRe(search);
   const periods = new Set<string>();
+  let count = 0;
   for (const row of rows) {
     if (!re.test(row.display) && !(row.merchant_name ? re.test(row.merchant_name) : false)) continue;
+    count++;
     const d = row.date;
     if (range === 'month') {
       periods.add(d.slice(0, 7) + '-01');
@@ -241,5 +243,5 @@ export async function getSearchMatchingPeriods(
       periods.add(mon.toISOString().slice(0, 10));
     }
   }
-  return periods;
+  return { periods, count };
 }

--- a/core/trends.ts
+++ b/core/trends.ts
@@ -210,6 +210,46 @@ export async function getPeriodTotals(view: View, range: TrendsRange): Promise<P
   return allPeriods.map((p) => actual.get(p.from) ?? zeroRow(p));
 }
 
+function periodFrom(date: string, range: TrendsRange): string {
+  if (range === 'month') return date.slice(0, 7) + '-01';
+  if (range === 'quarter') {
+    const m = parseInt(date.slice(5, 7));
+    return date.slice(0, 4) + '-' + Q_FROM[Math.floor((m - 1) / 3)] + '-01';
+  }
+  if (range === 'year') return date.slice(0, 4) + '-01-01';
+  const dt = new Date(date + 'T12:00:00');
+  const dow = (dt.getDay() + 6) % 7;
+  const mon = new Date(dt);
+  mon.setDate(dt.getDate() - dow);
+  return mon.toISOString().slice(0, 10);
+}
+
+export async function getSearchPeriodTotals(search: string, range: TrendsRange): Promise<PeriodRow[]> {
+  if (!search) return [];
+  const result = await db.execute(`
+    SELECT COALESCE(display_name, name) as display, merchant_name, date, amount
+    FROM transactions WHERE pending = 0 AND ignored = 0
+  `);
+  const rows = result.rows as unknown as { display: string; merchant_name: string | null; date: string; amount: number }[];
+  const re = buildSearchRe(search);
+  const periodMap = new Map<string, { income: number; expenses: number }>();
+  for (const row of rows) {
+    if (!re.test(row.display) && !(row.merchant_name ? re.test(row.merchant_name) : false)) continue;
+    const from = periodFrom(row.date, range);
+    const existing = periodMap.get(from) ?? { income: 0, expenses: 0 };
+    const amt = Number(row.amount);
+    if (amt < 0) existing.income += Math.abs(amt); else existing.expenses += amt;
+    periodMap.set(from, existing);
+  }
+  const allPeriods = await generateAllPeriods(range);
+  return allPeriods
+    .filter((p) => periodMap.has(p.from))
+    .map((p) => {
+      const { income, expenses } = periodMap.get(p.from)!;
+      return { ...p, income, expenses, total: income - expenses };
+    });
+}
+
 export async function getSearchMatchingPeriods(
   search: string,
   range: TrendsRange,
@@ -226,22 +266,7 @@ export async function getSearchMatchingPeriods(
   for (const row of rows) {
     if (!re.test(row.display) && !(row.merchant_name ? re.test(row.merchant_name) : false)) continue;
     count++;
-    const d = row.date;
-    if (range === 'month') {
-      periods.add(d.slice(0, 7) + '-01');
-    } else if (range === 'quarter') {
-      const m = parseInt(d.slice(5, 7));
-      periods.add(d.slice(0, 4) + '-' + Q_FROM[Math.floor((m - 1) / 3)] + '-01');
-    } else if (range === 'year') {
-      periods.add(d.slice(0, 4) + '-01-01');
-    } else {
-      // week: compute the Monday of this transaction's week
-      const dt = new Date(d + 'T12:00:00');
-      const dow = (dt.getDay() + 6) % 7;
-      const mon = new Date(dt);
-      mon.setDate(dt.getDate() - dow);
-      periods.add(mon.toISOString().slice(0, 10));
-    }
+    periods.add(periodFrom(row.date, range));
   }
   return { periods, count };
 }

--- a/tests/helpers/makeTestDb.ts
+++ b/tests/helpers/makeTestDb.ts
@@ -8,7 +8,8 @@ const SCHEMA = `
     subtype TEXT,
     institution_name TEXT,
     mask TEXT,
-    nickname TEXT
+    nickname TEXT,
+    apr REAL
   );
 
   CREATE TABLE transactions (

--- a/tests/tui/screens.test.tsx
+++ b/tests/tui/screens.test.tsx
@@ -19,8 +19,14 @@ import { Rules } from '../../tui/Rules.js';
 import { Accounts } from '../../tui/Accounts.js';
 import * as accountsApi from '../../core/accounts.js';
 import { Health } from '../../tui/Health.js';
+import { Settings } from '../../tui/Settings.js';
 import { RefreshProvider } from '../../tui/RefreshContext.js';
 import { TypingContext } from '../../tui/TypingContext.js';
+
+vi.mock('../../core/profile.js', () => ({
+  loadProfile: () => null,
+  saveProfile: () => {},
+}));
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -393,7 +399,8 @@ describe('Trends', () => {
     );
     await waitFor(() => expect(frame(r)).toContain('Trends'));
     r.stdin.write('1');
-    expect(onNavigate).toHaveBeenCalledWith('dashboard');
+    // Trends passes search (undefined when empty) as second arg
+    expect(onNavigate).toHaveBeenCalledWith('dashboard', undefined);
   });
 
   it('right arrow cycles through the base views in order', async () => {
@@ -448,11 +455,172 @@ describe('Trends', () => {
     });
   });
 
+  it('search filter from initialFilter shows indicator in header', async () => {
+    const r = trends({ initialFilter: { search: 'Whole Foods' } });
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).toContain('Whole Foods');
+    });
+  });
 
+  it('search filters to only periods containing matching transactions', async () => {
+    // Amazon only appears in May — April should be hidden
+    const r = trends({ initialFilter: { search: 'Amazon' } });
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).toContain('May 2026');
+      expect(f).not.toContain('Apr 2026');
+    });
+  });
 
+  it('search that matches both periods shows both', async () => {
+    // Whole Foods appears in both April and May
+    const r = trends({ initialFilter: { search: 'Whole Foods' } });
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).toContain('Apr 2026');
+      expect(f).toContain('May 2026');
+    });
+  });
 
+  it('pressing 1 passes active search back to dashboard', async () => {
+    const onNavigate = vi.fn();
+    const r = render(
+      <W><Trends onNavigate={onNavigate} showHints={false} initialFilter={{ search: 'Amazon' }} /></W>,
+    );
+    await waitFor(() => expect(frame(r)).toContain('Trends'));
+    r.stdin.write('1');
+    await waitFor(() => {
+      expect(onNavigate).toHaveBeenCalledWith('dashboard', { search: 'Amazon' });
+    });
+  });
 
+  it('pressing 2 passes active search and period into Transactions', async () => {
+    const onNavigate = vi.fn();
+    const r = render(
+      <W><Trends onNavigate={onNavigate} showHints={false} initialFilter={{ search: 'Amazon' }} /></W>,
+    );
+    // Wait until filter is applied: Amazon-only May visible, April gone
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).toContain('May 2026');
+      expect(f).not.toContain('Apr 2026');
+    });
+    r.stdin.write('2');
+    await waitFor(() => {
+      expect(onNavigate).toHaveBeenCalledWith(
+        'transactions',
+        expect.objectContaining({ search: 'Amazon', from: '2026-05-01' }),
+      );
+    });
+  });
 
+  it('no-match search shows empty state message', async () => {
+    const r = trends({ initialFilter: { search: 'zzznomatch' } });
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).toContain('No periods match');
+    });
+  });
+});
+
+// ── Settings ──────────────────────────────────────────────────────────────────
+
+describe('Settings', () => {
+  function settings(overrides?: Partial<Parameters<typeof Settings>[0]>) {
+    return render(
+      <W>
+        <Settings onNavigate={noop} showHints={false} {...overrides} />
+      </W>,
+    );
+  }
+
+  it('renders Settings heading and section labels', () => {
+    const r = settings();
+    const f = frame(r);
+    expect(f).toContain('Settings');
+    expect(f).toContain('HOUSEHOLD');
+    expect(f).toContain('SPOUSE');
+    expect(f).toContain('CHILDREN');
+    expect(f).toContain('Your name');
+    expect(f).toContain('Birth year');
+  });
+
+  it('Enter on a field opens edit mode showing cursor', async () => {
+    const r = settings();
+    expect(frame(r)).not.toContain('▊');
+    r.stdin.write('\r'); // Enter on "Your name" (cursor starts at row 0)
+    await waitFor(() => expect(frame(r)).toContain('▊'));
+  });
+
+  it('typing in edit mode accumulates in the buffer', async () => {
+    const r = settings();
+    r.stdin.write('\r');       // open edit on "Your name"
+    await waitFor(() => expect(frame(r)).toContain('▊'));
+    r.stdin.write('Tom');
+    await waitFor(() => {
+      expect(frame(r)).toContain('Tom');
+      expect(frame(r)).toContain('▊');
+    });
+  });
+
+  it('Enter commits the edit and exits edit mode', async () => {
+    const r = settings();
+    r.stdin.write('\r');       // open
+    await waitFor(() => expect(frame(r)).toContain('▊'));
+    r.stdin.write('Alice');
+    await waitFor(() => expect(frame(r)).toContain('Alice')); // wait for buffer to render
+    r.stdin.write('\r');       // commit with fresh closure
+    await waitFor(() => {
+      expect(frame(r)).toContain('Alice');
+      expect(frame(r)).not.toContain('▊');
+    });
+  });
+
+  it('Esc cancels edit without committing', async () => {
+    const r = settings();
+    r.stdin.write('\r');
+    await waitFor(() => expect(frame(r)).toContain('▊'));
+    r.stdin.write('Alice');
+    r.stdin.write('\x1b');    // cancel
+    await waitFor(() => {
+      expect(frame(r)).not.toContain('Alice');
+      expect(frame(r)).not.toContain('▊');
+    });
+  });
+
+  it('[a] adds spouse fields when no spouse exists', async () => {
+    const r = settings();
+    expect(frame(r)).not.toContain('Spouse name');
+    r.stdin.write('a');       // [a] adds spouse from any cursor position
+    await waitFor(() => expect(frame(r)).toContain('Spouse name'));
+  });
+
+  it('[d] on spouse row removes spouse', async () => {
+    const r = settings();
+    r.stdin.write('a');                 // add spouse
+    await waitFor(() => expect(frame(r)).toContain('Spouse name'));
+    r.stdin.write('\x1B[B');            // ↓ to row 1 (self-year)
+    r.stdin.write('\x1B[B');            // ↓ to row 2 (spouse-name)
+    // Wait for re-render to commit cursor position before pressing 'd'
+    await waitFor(() => expect(frame(r)).toContain('[d] remove spouse'));
+    r.stdin.write('d');                 // remove spouse
+    await waitFor(() => expect(frame(r)).not.toContain('Spouse name'));
+  });
+
+  it('Esc navigates back to dashboard', async () => {
+    const onNavigate = vi.fn();
+    const r = render(<W><Settings onNavigate={onNavigate} showHints={false} /></W>);
+    r.stdin.write('\x1b');
+    await waitFor(() => expect(onNavigate).toHaveBeenCalledWith('dashboard'));
+  });
+
+  it('pressing a nav number calls onNavigate', () => {
+    const onNavigate = vi.fn();
+    const r = render(<W><Settings onNavigate={onNavigate} showHints={false} /></W>);
+    r.stdin.write('1');
+    expect(onNavigate).toHaveBeenCalledWith('dashboard');
+  });
 });
 
 // ── Net Worth ─────────────────────────────────────────────────────────────────
@@ -788,6 +956,39 @@ describe('Health', () => {
     r.stdin.write('1');
     expect(onNavigate).toHaveBeenCalledWith('dashboard');
   });
+
+  it('Enter opens dial edit mode showing cursor', async () => {
+    const r = health();
+    await waitFor(() => expect(frame(r)).toContain('ASSUMPTIONS'));
+    expect(frame(r)).not.toContain('▊');
+    r.stdin.write('\r');
+    await waitFor(() => expect(frame(r)).toContain('▊'));
+  });
+
+  it('Esc cancels dial edit mode', async () => {
+    const r = health();
+    await waitFor(() => expect(frame(r)).toContain('ASSUMPTIONS'));
+    r.stdin.write('\r');
+    await waitFor(() => expect(frame(r)).toContain('▊'));
+    r.stdin.write('\x1b');
+    await waitFor(() => expect(frame(r)).not.toContain('▊'));
+  });
+
+  it('typing and Enter commit a new dial value', async () => {
+    const r = health();
+    await waitFor(() => expect(frame(r)).toContain('ASSUMPTIONS'));
+    r.stdin.write('\r');         // open edit on spend dial (pre-fills current value)
+    await waitFor(() => expect(frame(r)).toContain('▊'));
+    // Write digits one at a time — Health's handler uses /^[\d.-]$/ (single-char regex)
+    for (const ch of '4000') r.stdin.write(ch);
+    await waitFor(() => expect(frame(r)).toContain('4000'));
+    r.stdin.write('\r');         // commit with fresh closure
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).toContain('4,000'); // formatted value appears in dial
+      expect(f).not.toContain('▊');
+    });
+  });
 });
 
 // ── App smoke test ────────────────────────────────────────────────────────────
@@ -826,5 +1027,12 @@ describe('App', () => {
     // hints off by default — pressing h shows them
     r.stdin.write('h');
     await waitFor(() => expect(frame(r)).toContain('[h]'));
+  });
+
+  it('pressing 0 switches to Settings screen', async () => {
+    const r = render(<App />);
+    await waitFor(() => expect(frame(r)).toContain('Dashboard'));
+    r.stdin.write('0');
+    await waitFor(() => expect(frame(r)).toContain('Settings'));
   });
 });

--- a/tests/tui/screens.test.tsx
+++ b/tests/tui/screens.test.tsx
@@ -351,6 +351,57 @@ describe('Transactions', () => {
     r.stdin.write('4'); // networth
     expect(onNavigate).toHaveBeenCalledWith('networth');
   });
+
+  it('Enter opens the edit panel for the selected transaction', async () => {
+    const r = txns();
+    await waitFor(() => expect(frame(r)).toContain('Trader Joes'));
+    r.stdin.write('\r');
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).toContain('Name');
+      expect(f).toContain('Category');
+    });
+  });
+
+  it('↓ in edit panel moves to Category, ← → cycles categories', async () => {
+    const r = txns();
+    await waitFor(() => expect(frame(r)).toContain('Trader Joes'));
+    r.stdin.write('\r');
+    await waitFor(() => expect(frame(r)).toContain('← Grocery')); // edit panel open (toggle arrows unique to panel)
+    r.stdin.write('\x1b[B'); // ↓ → move to category field
+    await waitFor(() => expect(frame(r)).toContain('(unchanged)')); // name inactive = category active
+    const before = frame(r);
+    r.stdin.write('\x1b[C'); // → cycle to next category
+    await waitFor(() => expect(frame(r)).not.toEqual(before));
+  });
+
+  it('Esc in edit panel cancels without saving', async () => {
+    const r = txns();
+    await waitFor(() => expect(frame(r)).toContain('Trader Joes'));
+    r.stdin.write('\r');
+    await waitFor(() => expect(frame(r)).toContain('Name'));
+    r.stdin.write('\x1b'); // Esc
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).not.toContain('Name\n'); // panel gone
+      expect(f).toContain('Trader Joes');
+    });
+  });
+
+  it('typing a name in edit panel and Enter saves the display name', async () => {
+    const r = txns();
+    await waitFor(() => expect(frame(r)).toContain('Trader Joes'));
+    r.stdin.write('\r');
+    await waitFor(() => expect(frame(r)).toContain('Name')); // panel open, Name field active
+    r.stdin.write('TJ');
+    await waitFor(() => expect(frame(r)).toContain('TJ'));
+    r.stdin.write('\r'); // save
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).toContain('TJ');
+      expect(f).not.toContain('Trader Joes');
+    });
+  });
 });
 
 // ── Trends ────────────────────────────────────────────────────────────────────
@@ -712,6 +763,48 @@ describe('Tags', () => {
     await waitFor(() => expect(frame(r)).toContain('New Tag'));
   });
 
+  it('[n] opens rename panel pre-filled with the tag name', async () => {
+    const r = tags();
+    await waitFor(() => expect(frame(r)).toContain('travel'));
+    r.stdin.write('n');
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).toContain('Rename Tag');
+      expect(f).toContain('travel');
+    });
+  });
+
+  it('typing a suffix and Enter in rename panel renames the tag', async () => {
+    const r = tags();
+    await waitFor(() => expect(frame(r)).toContain('travel'));
+    r.stdin.write('n');
+    await waitFor(() => expect(frame(r)).toContain('Rename Tag'));
+    for (const ch of '-edited') r.stdin.write(ch);
+    await waitFor(() => expect(frame(r)).toContain('travel-edited'));
+    r.stdin.write('\r');
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).not.toContain('Rename Tag');
+      expect(f).toContain('travel-edited');
+    });
+  });
+
+  it('Esc in rename panel cancels without saving', async () => {
+    const r = tags();
+    await waitFor(() => expect(frame(r)).toContain('travel'));
+    r.stdin.write('n');
+    await waitFor(() => expect(frame(r)).toContain('Rename Tag'));
+    for (const ch of 'xyz') r.stdin.write(ch);
+    await waitFor(() => expect(frame(r)).toContain('travelxyz'));
+    r.stdin.write('\x1b');
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).not.toContain('Rename Tag');
+      expect(f).not.toContain('travelxyz');
+      expect(f).toContain('travel');
+    });
+  });
+
   it('pressing nav number calls onNavigate', async () => {
     const onNavigate = vi.fn();
     const r = render(
@@ -771,6 +864,111 @@ describe('Rules', () => {
       const f = frame(r);
       expect(f).toContain('Grocery');
       expect(f).toContain('Dining');
+    });
+  });
+
+  it('[a] opens new category rule form', async () => {
+    const r = rules();
+    await waitFor(() => expect(frame(r)).toContain('Whole Foods')); // rules loaded
+    r.stdin.write('a');
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).toContain('New Category Rule');
+      expect(f).toContain('Pattern');
+    });
+  });
+
+  it('typing pattern and Enter in rule-form saves the rule', async () => {
+    const r = rules();
+    await waitFor(() => expect(frame(r)).toContain('Whole Foods'));
+    r.stdin.write('a');
+    await waitFor(() => expect(frame(r)).toContain('New Category Rule'));
+    for (const ch of 'Starbucks') r.stdin.write(ch);
+    await waitFor(() => expect(frame(r)).toContain('Starbucks'));
+    r.stdin.write('\r');
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).not.toContain('New Category Rule');
+      expect(f).toContain('Starbucks');
+    });
+  });
+
+  it('Enter on existing rule opens edit form pre-filled with its pattern', async () => {
+    const r = rules();
+    await waitFor(() => expect(frame(r)).toContain('Whole Foods'));
+    r.stdin.write('\r');
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).toContain('Edit Category Rule');
+      expect(f).toContain('Whole Foods');
+    });
+  });
+
+  it('[a] in Name Rules section opens new name rule form', async () => {
+    const r = rules();
+    await waitFor(() => expect(frame(r)).toContain('Category Rules'));
+    r.stdin.write('\t'); // switch to Name Rules
+    await waitFor(() => expect(frame(r)).toContain('No name rules'));
+    r.stdin.write('a');
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).toContain('New Name Rule');
+      expect(f).toContain('Pattern');
+      expect(f).toContain('Replace with');
+    });
+  });
+
+  it('typing pattern + replacement in name-rule-form and Enter saves the rule', async () => {
+    const r = rules();
+    await waitFor(() => expect(frame(r)).toContain('Category Rules'));
+    r.stdin.write('\t');
+    await waitFor(() => expect(frame(r)).toContain('No name rules'));
+    r.stdin.write('a');
+    await waitFor(() => expect(frame(r)).toContain('New Name Rule'));
+    for (const ch of 'amazon') r.stdin.write(ch);
+    await waitFor(() => expect(frame(r)).toContain('amazon'));
+    for (let i = 0; i < 4; i++) r.stdin.write('\x1b[B'); // navigate to replacement
+    // Wait for React to commit the field navigation before typing (avoids stale closure)
+    await waitFor(() => expect(frame(r)).toContain('display name'));
+    for (const ch of 'Amazon') r.stdin.write(ch);
+    await waitFor(() => expect(frame(r)).toContain('Amazon'));
+    r.stdin.write('\r');
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).not.toContain('New Name Rule');
+      expect(f).toContain('amazon');
+      expect(f).toContain('Amazon');
+    });
+  });
+
+  it('Enter in categories section opens the edit panel', async () => {
+    const r = rules();
+    await waitFor(() => expect(frame(r)).toContain('Category Rules'));
+    r.stdin.write('\t');
+    r.stdin.write('\t'); // categories section
+    await waitFor(() => expect(frame(r)).toContain('Bills & Utilities'));
+    r.stdin.write('\r');
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).toContain('Edit: Bills & Utilities');
+      expect(f).toContain('Name');
+      expect(f).toContain('Flexibility');
+    });
+  });
+
+  it('Esc in categories edit panel closes without navigating away', async () => {
+    const r = rules();
+    await waitFor(() => expect(frame(r)).toContain('Category Rules'));
+    r.stdin.write('\t');
+    r.stdin.write('\t');
+    await waitFor(() => expect(frame(r)).toContain('Bills & Utilities'));
+    r.stdin.write('\r');
+    await waitFor(() => expect(frame(r)).toContain('Edit: Bills & Utilities'));
+    r.stdin.write('\x1b');
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).not.toContain('Edit: Bills & Utilities');
+      expect(f).toContain('Bills & Utilities');
     });
   });
 

--- a/tests/tui/screens.test.tsx
+++ b/tests/tui/screens.test.tsx
@@ -402,6 +402,64 @@ describe('Transactions', () => {
       expect(f).not.toContain('Trader Joes');
     });
   });
+
+  it('edit panel shows Pattern and Match type fields', async () => {
+    const r = txns();
+    await waitFor(() => expect(frame(r)).toContain('Trader Joes'));
+    r.stdin.write('\r');
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).toContain('Pattern');
+      expect(f).toContain('Match type');
+    });
+  });
+
+  it('↓↓ navigates to Pattern field and typing shows match count', async () => {
+    const r = txns();
+    await waitFor(() => expect(frame(r)).toContain('Trader Joes'));
+    r.stdin.write('\r');
+    await waitFor(() => expect(frame(r)).toContain('← Grocery')); // panel open
+    r.stdin.write('\x1b[B'); // name → category
+    r.stdin.write('\x1b[B'); // category → pattern
+    await waitFor(() => expect(frame(r)).toContain('optional')); // Pattern field active (placeholder)
+    for (const ch of 'Trader') r.stdin.write(ch);
+    await waitFor(() => expect(frame(r)).toContain('transactions match'));
+  });
+
+  it('↓↓↓ navigates to Match type, ← → toggles to regex', async () => {
+    const r = txns();
+    await waitFor(() => expect(frame(r)).toContain('Trader Joes'));
+    r.stdin.write('\r');
+    await waitFor(() => expect(frame(r)).toContain('← Grocery')); // panel open
+    r.stdin.write('\x1b[B'); // name → category
+    r.stdin.write('\x1b[B'); // category → pattern
+    r.stdin.write('\x1b[B'); // pattern → type
+    await waitFor(() => expect(frame(r)).toContain('(unchanged)')); // name inactive = type field reached
+    r.stdin.write('\x1b[C'); // → toggle name → regex
+    await waitFor(() => expect(frame(r)).toContain('regex'));
+  });
+
+  it('Enter with pattern saves as a category rule', async () => {
+    const r = txns();
+    await waitFor(() => expect(frame(r)).toContain('Trader Joes'));
+    r.stdin.write('\r');
+    await waitFor(() => expect(frame(r)).toContain('← Grocery')); // panel open
+    // Change category to Income (→ cycles Grocery index 2 → Income index 3)
+    r.stdin.write('\x1b[B'); // name → category
+    await waitFor(() => expect(frame(r)).toContain('(unchanged)'));
+    r.stdin.write('\x1b[C'); // cycle Grocery → Income
+    // Navigate to Pattern and type a pattern
+    r.stdin.write('\x1b[B'); // category → pattern
+    await waitFor(() => expect(frame(r)).toContain('optional'));
+    for (const ch of 'Trader') r.stdin.write(ch);
+    await waitFor(() => expect(frame(r)).toContain('transactions match'));
+    r.stdin.write('\r'); // save as rule
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).not.toContain('optional'); // panel closed
+      expect(f).toContain('Saved:');
+    });
+  });
 });
 
 // ── Trends ────────────────────────────────────────────────────────────────────

--- a/tests/tui/screens.test.tsx
+++ b/tests/tui/screens.test.tsx
@@ -853,14 +853,14 @@ describe('Accounts', () => {
     const r = accounts();
     // Cursor starts on the first account (depository sorts first = Test Checking).
     await waitFor(() => expect(frame(r)).toContain('Test Checking'));
-    r.stdin.write('n');                 // open nickname editor
-    await waitFor(() => expect(frame(r)).toContain('Leave empty to clear nickname'));
-    r.stdin.write('Vacation Fund');     // type the nickname
+    r.stdin.write('\r');                // open unified edit panel
+    await waitFor(() => expect(frame(r)).toContain('Edit: Test Checking'));
+    r.stdin.write('Vacation Fund');     // type the nickname (cursor starts on Nickname field)
     await waitFor(() => expect(frame(r)).toContain('Vacation Fund'));
-    r.stdin.write('\r');                // save (separate chunk so it isn't merged with the text)
+    r.stdin.write('\r');                // save
     // The list row now shows the nickname in place of the account name. Asserting
     // the original name is gone proves the list reloaded with post-write data (the
-    // status toast that mentions the nickname never contains the original name).
+    // status toast shows the nickname, not the original name).
     await waitFor(() => {
       const f = frame(r);
       expect(f).toContain('Vacation Fund');
@@ -895,17 +895,17 @@ describe('Accounts', () => {
 
     const r = accounts();
     await waitFor(() => expect(frame(r)).toContain('Test Checking'));
-    r.stdin.write('n');
-    await waitFor(() => expect(frame(r)).toContain('Leave empty to clear nickname'));
+    r.stdin.write('\r');                 // open unified edit panel
+    await waitFor(() => expect(frame(r)).toContain('Edit: Test Checking'));
     r.stdin.write('Vacation Fund');
     await waitFor(() => expect(frame(r)).toContain('Vacation Fund'));
     r.stdin.write('\r');                 // save → write rejects
     // A failed write must show an error rather than a (false) success, and the
     // account must keep its original name.
-    await waitFor(() => expect(frame(r)).toContain('Failed to save nickname'));
+    await waitFor(() => expect(frame(r)).toContain('Failed to update'));
     const f = frame(r);
     expect(f).toContain('Test Checking');
-    expect(f).not.toContain('Nickname set to');
+    expect(f).not.toContain('Updated Vacation Fund');
   });
 });
 

--- a/tui/Accounts.tsx
+++ b/tui/Accounts.tsx
@@ -9,7 +9,7 @@ import { parseCSV, parseDate } from '../core/csv.js';
 import { getLinkedAccounts, getCsvAccounts, type LinkedAccount, type CsvAccount } from '../core/queries.js';
 import { getDefaultDaysRequested, MIN_DAYS_REQUESTED, MAX_DAYS_REQUESTED } from '../core/settings.js';
 import {
-  updateAccountTypeSubtype, updateAccountNickname, updateAccountValue,
+  updateAccountTypeSubtype, updateAccountNickname, updateAccountApr, updateAccountValue,
   createManualAccount, createCsvAccount, deleteAccount, importCsvTransactions, deleteDuplicate, deleteAllDuplicates,
 } from '../core/accounts.js';
 import type { Screen, TxFilter } from './App.js';
@@ -21,8 +21,8 @@ import { ModalPanel, TextInput, SelectableRow, useStatusMessage, PageHeader } fr
 // ─── Types ────────────────────────────────────────────────────────────────────
 
 type MainView = 'accounts' | 'add-data' | 'dupes';
-type AcctMode = 'list' | 'edit' | 'update-value' | 'nickname' | 'confirm-delete';
-type EditField = 'type' | 'subtype';
+type AcctMode = 'list' | 'edit' | 'update-value' | 'confirm-delete';
+type EditField = 'nickname' | 'type' | 'subtype' | 'apr';
 
 type AddStep =
   | 'landing'
@@ -129,8 +129,9 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
   const [updateValueInput, setUpdateValueInput] = useState('');
   const [updateValueError, setUpdateValueError] = useState('');
 
-  // Nickname mode state
-  const [nicknameInput, setNicknameInput] = useState('');
+  // Unified edit panel state
+  const [editNickname, setEditNickname] = useState('');
+  const [editApr, setEditApr] = useState('');
 
   // Dupes view state
   const [dupes, setDupes] = useState<DupePair[]>([]);
@@ -138,7 +139,7 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
 
   const setTyping = useSetTyping();
   const TEXT_INPUT_STEPS = new Set<AddStep>(['link-days', 'file', 'manual-name', 'manual-value', 'new-acct-name']);
-  const TEXT_INPUT_MODES = new Set<AcctMode>(['nickname', 'update-value']);
+  const TEXT_INPUT_MODES = new Set<AcctMode>(['edit', 'update-value']);
   useEffect(() => {
     setTyping(TEXT_INPUT_STEPS.has(addStep) || TEXT_INPUT_MODES.has(acctMode));
   }, [addStep, acctMode]);
@@ -160,22 +161,27 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
   function openEdit(acct: LinkedAccount) {
     const type = acct.type;
     const subtypes = SUBTYPES[type] ?? [];
-    // Snap to a known subtype if possible, otherwise first option
     const currentSub = acct.subtype ?? '';
     const snapped = subtypes.includes(currentSub) ? currentSub : (subtypes[0] ?? '');
     setEditType(type);
     setEditSubtype(snapped);
-    setEditField('type');
+    setEditNickname(acct.nickname ?? '');
+    setEditApr(acct.apr !== null && acct.apr !== undefined ? String(acct.apr) : '');
+    setEditField('nickname');
     setAcctMode('edit');
   }
 
   async function saveEdit() {
     const acct = linkedAccounts[acctCursor];
     if (!acct) return;
+    const isDebt = editType === 'credit' || editType === 'loan';
+    const aprVal = editApr.trim() ? parseFloat(editApr) : null;
     try {
       await updateAccountTypeSubtype(acct.id, editType, editSubtype.trim() || null);
+      await updateAccountNickname(acct.id, editNickname.trim() || null);
+      if (isDebt) await updateAccountApr(acct.id, aprVal !== null && !isNaN(aprVal) ? aprVal : null);
       setAcctMode('list');
-      showAcctMsg(`Updated ${acct.name}`);
+      showAcctMsg(`Updated ${editNickname.trim() || acct.name}`);
       loadAccounts();
     } catch {
       showAcctErr(`Failed to update ${acct.name}`);
@@ -232,20 +238,6 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
     } catch {
       setAcctMode('list');
       showAcctErr(`Failed to delete ${acct.nickname ?? acct.name}`);
-    }
-  }
-
-  async function saveNickname() {
-    const acct = linkedAccounts[acctCursor];
-    if (!acct) return;
-    const nickname = nicknameInput.trim() || null;
-    try {
-      await updateAccountNickname(acct.id, nickname);
-      setAcctMode('list');
-      showAcctMsg(nickname ? `Nickname set to "${nickname}"` : 'Nickname cleared');
-      loadAccounts();
-    } catch {
-      showAcctErr('Failed to save nickname');
     }
   }
 
@@ -358,29 +350,41 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
       if (acctMode === 'edit') {
         if (key.escape) { setAcctMode('list'); return; }
         if (key.return) { void saveEdit(); return; }
-        if (key.tab) {
-          setEditField((f) => f === 'type' ? 'subtype' : 'type');
+        const isDebt = editType === 'credit' || editType === 'loan';
+        const editFields: EditField[] = isDebt ? ['nickname', 'type', 'subtype', 'apr'] : ['nickname', 'type', 'subtype'];
+        if (key.upArrow) {
+          setEditField((f) => { const i = editFields.indexOf(f); return editFields[Math.max(0, i - 1)]; });
           return;
         }
-        if (editField === 'type') {
-          if (key.leftArrow || key.rightArrow) {
-            const idx = ACCOUNT_TYPES.indexOf(editType as typeof ACCOUNT_TYPES[number]);
-            const dir = key.leftArrow ? -1 : 1;
-            const nextType = ACCOUNT_TYPES[(idx + dir + ACCOUNT_TYPES.length) % ACCOUNT_TYPES.length];
-            setEditType(nextType);
-            setEditSubtype(SUBTYPES[nextType]?.[0] ?? '');
-          }
+        if (key.downArrow) {
+          setEditField((f) => { const i = editFields.indexOf(f); return editFields[Math.min(editFields.length - 1, i + 1)]; });
+          return;
+        }
+        if (editField === 'type' && (key.leftArrow || key.rightArrow)) {
+          const idx = ACCOUNT_TYPES.indexOf(editType as typeof ACCOUNT_TYPES[number]);
+          const dir = key.leftArrow ? -1 : 1;
+          const nextType = ACCOUNT_TYPES[(idx + dir + ACCOUNT_TYPES.length) % ACCOUNT_TYPES.length];
+          setEditType(nextType);
+          setEditSubtype(SUBTYPES[nextType]?.[0] ?? '');
           return;
         }
         if (editField === 'subtype') {
           const subtypes = SUBTYPES[editType] ?? [];
-          if (subtypes.length > 0) {
-            if (key.leftArrow || key.rightArrow) {
-              const idx = subtypes.indexOf(editSubtype);
-              const dir = key.leftArrow ? -1 : 1;
-              setEditSubtype(subtypes[(idx + dir + subtypes.length) % subtypes.length]);
-            }
+          if (subtypes.length > 0 && (key.leftArrow || key.rightArrow)) {
+            const idx = subtypes.indexOf(editSubtype);
+            const dir = key.leftArrow ? -1 : 1;
+            setEditSubtype(subtypes[(idx + dir + subtypes.length) % subtypes.length]);
           }
+          return;
+        }
+        if (editField === 'nickname') {
+          if (key.backspace || key.delete) { setEditNickname((v) => v.slice(0, -1)); return; }
+          if (input && !key.ctrl && !key.meta) { setEditNickname((v) => v + input); return; }
+          return;
+        }
+        if (editField === 'apr') {
+          if (key.backspace || key.delete) { setEditApr((v) => v.slice(0, -1)); return; }
+          if (input && /^[\d.]$/.test(input) && !key.ctrl && !key.meta) { setEditApr((v) => v + input); return; }
           return;
         }
         return;
@@ -391,14 +395,6 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
         if (key.return) { void saveUpdatedValue(); return; }
         if (key.backspace || key.delete) { setUpdateValueInput((v) => v.slice(0, -1)); setUpdateValueError(''); return; }
         if (input && !key.ctrl && !key.meta) { setUpdateValueInput((v) => v + input); setUpdateValueError(''); return; }
-        return;
-      }
-
-      if (acctMode === 'nickname') {
-        if (key.escape) { setAcctMode('list'); setNicknameInput(''); return; }
-        if (key.return) { void saveNickname(); return; }
-        if (key.backspace || key.delete) { setNicknameInput((v) => v.slice(0, -1)); return; }
-        if (input && !key.ctrl && !key.meta) { setNicknameInput((v) => v + input); return; }
         return;
       }
 
@@ -413,13 +409,8 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
       if (key.tab) { setMainView('add-data'); return; }
       if (key.upArrow)   { setAcctCursor((c) => Math.max(0, c - 1)); return; }
       if (key.downArrow) { setAcctCursor((c) => Math.min(linkedAccounts.length - 1, c + 1)); return; }
-      if (input === 'e' && linkedAccounts[acctCursor]) {
+      if ((input === 'e' || key.return) && linkedAccounts[acctCursor]) {
         openEdit(linkedAccounts[acctCursor]);
-        return;
-      }
-      if ((input === 'n' || key.return) && linkedAccounts[acctCursor]) {
-        setNicknameInput(linkedAccounts[acctCursor].nickname ?? '');
-        setAcctMode('nickname');
         return;
       }
       if (input === 'v' && linkedAccounts[acctCursor]?.id.startsWith('manual-')) {
@@ -634,9 +625,9 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
       {showHints && <Box justifyContent="flex-end">
         <Text dimColor>
           {mainView === 'accounts' && acctMode === 'list'
-            ? `↑↓ select  ·  [e] edit  ·  [n] nickname${selectedAcct?.id.startsWith('manual-') ? '  ·  [v] update value' : '  ·  [r] repair link'}  ·  [x] delete  ·  [s] sync`
+            ? `↑↓ select  ·  Enter/[e] edit${selectedAcct?.id.startsWith('manual-') ? '  ·  [v] update value' : '  ·  [r] repair link'}  ·  [x] delete  ·  [s] sync`
             : mainView === 'accounts' && acctMode === 'edit'
-            ? 'Tab field  ·  ← → value  ·  Enter save  ·  Esc cancel'
+            ? '↑↓ field  ·  ← → change  ·  Enter save  ·  Esc cancel'
             : mainView === 'dupes'
             ? '↑↓ select  ·  [x] delete CSV copy  ·  [X] delete all'
             : ''}
@@ -705,15 +696,6 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
             </ModalPanel>
           )}
 
-          {/* Nickname panel */}
-          {acctMode === 'nickname' && selectedAcct && (
-            <ModalPanel title={`Nickname: ${selectedAcct.name}`} borderColor={C_WARNING}>
-              <Text dimColor>Leave empty to clear nickname</Text>
-              <Box marginTop={1} gap={1}><Text>Nickname: </Text><TextInput value={nicknameInput} color={C_WARNING} /></Box>
-              <Box marginTop={1}><Text dimColor>Enter save · Esc cancel</Text></Box>
-            </ModalPanel>
-          )}
-
           {/* Update-value panel */}
           {acctMode === 'update-value' && selectedAcct && (
             <ModalPanel title={`Update value: ${selectedAcct.name}`} borderColor={C_WARNING}>
@@ -723,29 +705,47 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
             </ModalPanel>
           )}
 
-          {/* Edit panel */}
-          {acctMode === 'edit' && selectedAcct && (
-            <ModalPanel title={`Edit: ${selectedAcct.name}${selectedAcct.mask ? ` ···${selectedAcct.mask}` : ''}`}>
-              <Box marginTop={1} flexDirection="column" gap={1}>
-                <Box gap={2}>
-                  <Text color={editField === 'type' ? C_ACCENT : C_NEUTRAL}>
-                    {editField === 'type' ? '▶ ' : '  '}Type
-                  </Text>
-                  <Text color={editField === 'type' ? C_ACCENT : undefined}>
-                    {'← '}{editType}{'  →'}
-                  </Text>
+          {/* Unified edit panel */}
+          {acctMode === 'edit' && selectedAcct && (() => {
+            const isDebt = editType === 'credit' || editType === 'loan';
+            return (
+              <ModalPanel title={`Edit: ${selectedAcct.name}${selectedAcct.mask ? ` ···${selectedAcct.mask}` : ''}`}>
+                <Box marginTop={1} flexDirection="column" gap={1}>
+                  <Box gap={2}>
+                    <Text color={editField === 'nickname' ? C_ACCENT : C_NEUTRAL}>{'Nickname'.padEnd(10)}</Text>
+                    <Box>
+                      <Text color={editField === 'nickname' ? C_ACCENT : C_NEUTRAL}>{'[ '}</Text>
+                      {editField === 'nickname'
+                        ? <TextInput value={editNickname} color={C_WARNING} placeholder="none" />
+                        : <Text color={editNickname ? undefined : C_DIM}>{editNickname || 'none'}</Text>}
+                      <Text color={editField === 'nickname' ? C_ACCENT : C_NEUTRAL}>{' ]'}</Text>
+                    </Box>
+                  </Box>
+                  <Box gap={2}>
+                    <Text color={editField === 'type' ? C_ACCENT : C_NEUTRAL}>{'Type'.padEnd(10)}</Text>
+                    <Text color={editField === 'type' ? C_ACCENT : undefined}>{'← '}{editType}{'  →'}</Text>
+                  </Box>
+                  <Box gap={2}>
+                    <Text color={editField === 'subtype' ? C_ACCENT : C_NEUTRAL}>{'Subtype'.padEnd(10)}</Text>
+                    <Text color={editField === 'subtype' ? C_ACCENT : C_DIM}>{'← '}{editSubtype || '—'}{'  →'}</Text>
+                  </Box>
+                  {isDebt && (
+                    <Box gap={2}>
+                      <Text color={editField === 'apr' ? C_ACCENT : C_NEUTRAL}>{'APR %'.padEnd(10)}</Text>
+                      <Box>
+                        <Text color={editField === 'apr' ? C_ACCENT : C_NEUTRAL}>{'[ '}</Text>
+                        {editField === 'apr'
+                          ? <TextInput value={editApr} color={C_WARNING} placeholder="0.0" />
+                          : <Text color={editApr ? undefined : C_DIM}>{editApr || '—'}</Text>}
+                        <Text color={editField === 'apr' ? C_ACCENT : C_NEUTRAL}>{' ]'}</Text>
+                      </Box>
+                    </Box>
+                  )}
                 </Box>
-                <Box gap={2}>
-                  <Text color={editField === 'subtype' ? C_ACCENT : C_NEUTRAL}>
-                    {editField === 'subtype' ? '▶ ' : '  '}Subtype
-                  </Text>
-                  <Text color={editField === 'subtype' ? C_ACCENT : C_DIM}>
-                    {'← '}{editSubtype || '—'}{'  →'}
-                  </Text>
-                </Box>
-              </Box>
-            </ModalPanel>
-          )}
+                <Box marginTop={1}><Text dimColor>↑↓ field  ·  ← → change  ·  Enter save  ·  Esc cancel</Text></Box>
+              </ModalPanel>
+            );
+          })()}
         </>
       )}
 

--- a/tui/Accounts.tsx
+++ b/tui/Accounts.tsx
@@ -16,7 +16,7 @@ import type { Screen, TxFilter } from './App.js';
 import { truncate, Divider } from './fmt.js';
 import { handleNavKey } from './nav.js';
 import { useTerminalWidth, MONTHS, SUBTYPE_DISPLAY, C_POSITIVE, C_NEGATIVE, C_WARNING, C_NEUTRAL, C_ACCENT, C_MANUAL, C_DIM } from './ui.js';
-import { ModalPanel, TextInput, SelectableRow, useStatusMessage, PageHeader } from './components/index.js';
+import { ModalPanel, TextInput, SelectableRow, useStatusMessage, PageHeader, EditTextField, EditToggleField } from './components/index.js';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -711,36 +711,10 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
             return (
               <ModalPanel title={`Edit: ${selectedAcct.name}${selectedAcct.mask ? ` ···${selectedAcct.mask}` : ''}`}>
                 <Box marginTop={1} flexDirection="column" gap={1}>
-                  <Box gap={2}>
-                    <Text color={editField === 'nickname' ? C_ACCENT : C_NEUTRAL}>{'Nickname'.padEnd(10)}</Text>
-                    <Box>
-                      <Text color={editField === 'nickname' ? C_ACCENT : C_NEUTRAL}>{'[ '}</Text>
-                      {editField === 'nickname'
-                        ? <TextInput value={editNickname} color={C_WARNING} placeholder="none" />
-                        : <Text color={editNickname ? undefined : C_DIM}>{editNickname || 'none'}</Text>}
-                      <Text color={editField === 'nickname' ? C_ACCENT : C_NEUTRAL}>{' ]'}</Text>
-                    </Box>
-                  </Box>
-                  <Box gap={2}>
-                    <Text color={editField === 'type' ? C_ACCENT : C_NEUTRAL}>{'Type'.padEnd(10)}</Text>
-                    <Text color={editField === 'type' ? C_ACCENT : undefined}>{'← '}{editType}{'  →'}</Text>
-                  </Box>
-                  <Box gap={2}>
-                    <Text color={editField === 'subtype' ? C_ACCENT : C_NEUTRAL}>{'Subtype'.padEnd(10)}</Text>
-                    <Text color={editField === 'subtype' ? C_ACCENT : C_DIM}>{'← '}{editSubtype || '—'}{'  →'}</Text>
-                  </Box>
-                  {isDebt && (
-                    <Box gap={2}>
-                      <Text color={editField === 'apr' ? C_ACCENT : C_NEUTRAL}>{'APR %'.padEnd(10)}</Text>
-                      <Box>
-                        <Text color={editField === 'apr' ? C_ACCENT : C_NEUTRAL}>{'[ '}</Text>
-                        {editField === 'apr'
-                          ? <TextInput value={editApr} color={C_WARNING} placeholder="0.0" />
-                          : <Text color={editApr ? undefined : C_DIM}>{editApr || '—'}</Text>}
-                        <Text color={editField === 'apr' ? C_ACCENT : C_NEUTRAL}>{' ]'}</Text>
-                      </Box>
-                    </Box>
-                  )}
+                  <EditTextField label="Nickname" labelWidth={10} active={editField === 'nickname'} value={editNickname} color={C_WARNING} placeholder="none" emptyText="none" />
+                  <EditToggleField label="Type" labelWidth={10} active={editField === 'type'} value={editType} />
+                  <EditToggleField label="Subtype" labelWidth={10} active={editField === 'subtype'} value={editSubtype || '—'} valueColor={C_DIM} />
+                  {isDebt && <EditTextField label="APR %" labelWidth={10} active={editField === 'apr'} value={editApr} color={C_WARNING} placeholder="0.0" />}
                 </Box>
                 <Box marginTop={1}><Text dimColor>↑↓ field  ·  ← → change  ·  Enter save  ·  Esc cancel</Text></Box>
               </ModalPanel>

--- a/tui/Accounts.tsx
+++ b/tui/Accounts.tsx
@@ -417,7 +417,7 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
         openEdit(linkedAccounts[acctCursor]);
         return;
       }
-      if (input === 'n' && linkedAccounts[acctCursor]) {
+      if ((input === 'n' || key.return) && linkedAccounts[acctCursor]) {
         setNicknameInput(linkedAccounts[acctCursor].nickname ?? '');
         setAcctMode('nickname');
         return;

--- a/tui/Accounts.tsx
+++ b/tui/Accounts.tsx
@@ -409,7 +409,7 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
       if (key.tab) { setMainView('add-data'); return; }
       if (key.upArrow)   { setAcctCursor((c) => Math.max(0, c - 1)); return; }
       if (key.downArrow) { setAcctCursor((c) => Math.min(linkedAccounts.length - 1, c + 1)); return; }
-      if ((input === 'e' || key.return) && linkedAccounts[acctCursor]) {
+      if (key.return && linkedAccounts[acctCursor]) {
         openEdit(linkedAccounts[acctCursor]);
         return;
       }
@@ -625,7 +625,7 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
       {showHints && <Box justifyContent="flex-end">
         <Text dimColor>
           {mainView === 'accounts' && acctMode === 'list'
-            ? `↑↓ select  ·  Enter/[e] edit${selectedAcct?.id.startsWith('manual-') ? '  ·  [v] update value' : '  ·  [r] repair link'}  ·  [x] delete  ·  [s] sync`
+            ? `↑↓ select  ·  Enter edit${selectedAcct?.id.startsWith('manual-') ? '  ·  [v] update value' : '  ·  [r] repair link'}  ·  [x] delete  ·  [s] sync`
             : mainView === 'accounts' && acctMode === 'edit'
             ? '↑↓ field  ·  ← → change  ·  Enter save  ·  Esc cancel'
             : mainView === 'dupes'

--- a/tui/App.tsx
+++ b/tui/App.tsx
@@ -11,12 +11,13 @@ import { Rules } from './Rules.js';
 import { Accounts } from './Accounts.js';
 import { Health } from './Health.js';
 import { Canvas } from './Canvas.js';
+import { Settings } from './Settings.js';
 import { Chat } from './Chat.js';
 import { RefreshProvider, useRefreshKey } from './RefreshContext.js';
 import type { CanvasSpec } from '../core/canvas-agent.js';
 import { CANVAS_SPEC_PATH } from '../core/canvas-history.js';
 
-export type Screen = 'dashboard' | 'transactions' | 'trends' | 'networth' | 'tags' | 'rules' | 'accounts' | 'health' | 'canvas';
+export type Screen = 'dashboard' | 'transactions' | 'trends' | 'networth' | 'tags' | 'rules' | 'accounts' | 'health' | 'canvas' | 'settings';
 
 export type TxFilter = {
   category?: string;
@@ -91,6 +92,7 @@ function AppInner() {
       case 'accounts':     return <Accounts     onNavigate={navigate} isActive={screenIsActive} showHints={showHints} />;
       case 'health':       return <Health       onNavigate={navigate} isActive={screenIsActive} showHints={showHints} />;
       case 'canvas':       return <Canvas       onNavigate={navigate} onLoadSpec={loadSpec} isActive={screenIsActive} showHints={showHints} spec={canvasSpec} specKey={specKey} />;
+      case 'settings':     return <Settings     onNavigate={navigate} isActive={screenIsActive} showHints={showHints} />;
     }
   })();
 

--- a/tui/Canvas.tsx
+++ b/tui/Canvas.tsx
@@ -42,12 +42,41 @@ export function CanvasView({ spec, isActive }: { spec: CanvasSpec; isActive?: bo
     return d;
   });
   const [dialIdx, setDialIdx] = useState(0);
+  const [editMode, setEditMode] = useState(false);
+  const [editBuffer, setEditBuffer] = useState('');
 
   const currentKey = dials[dialIdx]?.key;
 
+  function applyEdit(buffer: string) {
+    if (currentKey) {
+      const n = parseFloat(buffer);
+      if (!isNaN(n)) {
+        const dial = dials[dialIdx];
+        let val = n;
+        if (dial.min !== undefined && val < dial.min) val = dial.min;
+        if (dial.max !== undefined && val > dial.max) val = dial.max;
+        setDialValues((v) => ({ ...v, [currentKey]: parseFloat(val.toFixed(10)) }));
+      }
+    }
+    setEditMode(false);
+    setEditBuffer('');
+  }
+
   useInput((_input, key) => {
+    if (editMode) {
+      if (key.escape) { setEditMode(false); setEditBuffer(''); return; }
+      if (key.return) { applyEdit(editBuffer); return; }
+      if (key.backspace || key.delete) { setEditBuffer((b) => b.slice(0, -1)); return; }
+      if (_input && /^[\d.\-]$/.test(_input) && !key.ctrl && !key.meta) setEditBuffer((b) => b + _input);
+      return;
+    }
     if (key.upArrow)   { setDialIdx((i) => (i - 1 + dials.length) % dials.length); return; }
     if (key.downArrow) { setDialIdx((i) => (i + 1) % dials.length); return; }
+    if (key.return && currentKey) {
+      setEditBuffer(String(dialValues[currentKey] ?? dials[dialIdx].default));
+      setEditMode(true);
+      return;
+    }
     if (key.rightArrow && currentKey) {
       setDialValues((v) => ({ ...v, [currentKey]: dialStep(dials[dialIdx], 1,  v[currentKey] ?? dials[dialIdx].default) }));
     }
@@ -74,6 +103,7 @@ export function CanvasView({ spec, isActive }: { spec: CanvasSpec; isActive?: bo
           const d = el.dial;
           const val = dialValues[d.key] ?? d.default;
           const isSelected = dials[dialIdx]?.key === d.key;
+          const isEditingThis = isSelected && editMode;
           const atDefault = val === d.default;
           return (
             <DialRow
@@ -83,9 +113,13 @@ export function CanvasView({ spec, isActive }: { spec: CanvasSpec; isActive?: bo
               selected={isSelected}
               labelWidth={LABEL_W}
               valueWidth={VALUE_W}
-              description={isSelected
-                ? `← → ±${fmtDialValue(d.step, d.format)}${!atDefault ? '  ·  [r] reset' : ''}`
-                : `${d.hint}${!atDefault ? ' (modified)' : ''}`}
+              editing={isEditingThis}
+              editBuffer={editBuffer}
+              description={isEditingThis
+                ? 'Enter confirm  ·  Esc cancel'
+                : isSelected
+                  ? `← → ±${fmtDialValue(d.step, d.format)}${!atDefault ? '  ·  [r] reset' : ''}`
+                  : `${d.hint}${!atDefault ? ' (modified)' : ''}`}
             />
           );
         }
@@ -174,7 +208,7 @@ export function Canvas({ onNavigate, onLoadSpec, isActive, showHints, spec, spec
           {mode === 'history'
             ? '↑↓ select  ·  type to filter  ·  Enter load  ·  ctrl + d delete  ·  Esc back'
             : spec
-              ? '↑↓ select  ·  ← → adjust  ·  [r] reset  ·  [/] history'
+              ? '↑↓ select  ·  ← → adjust  ·  Enter type  ·  [r] reset  ·  [/] history'
               : '[/] history  ·  or ask the agent (`)'}
         </Text>
       )}

--- a/tui/Dashboard.tsx
+++ b/tui/Dashboard.tsx
@@ -344,6 +344,8 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
       return;
     }
 
+    if (input === '3' && search) { onNavigate('trends', { search }); return; }
+
     handleNavKey(input, 'dashboard', onNavigate);
   }, { isActive: isActive !== false });
 

--- a/tui/Dashboard.tsx
+++ b/tui/Dashboard.tsx
@@ -394,8 +394,6 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
         </Box>
       </Box>
 
-      <Box marginTop={1}><Divider /></Box>
-
       {/* Search bar */}
       {(searchMode || search) && (
         <Box gap={2} marginTop={1}>
@@ -419,6 +417,8 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
           )}
         </Box>
       )}
+
+      <Box marginTop={1}><Divider /></Box>
 
       {view === 'account' ? (
         <Box flexDirection="column" marginTop={1}>

--- a/tui/Health.tsx
+++ b/tui/Health.tsx
@@ -48,6 +48,8 @@ export function Health({ onNavigate, isActive, showHints }: { onNavigate: (s: Sc
   const [dialIdx, setDialIdx]           = useState(0);
   const [monthlySpend, setMonthlySpend] = useState(SPEND_STEP);
   const [monthlySavings, setMonthlySavings] = useState(0);
+  const [editMode, setEditMode]         = useState(false);
+  const [editBuffer, setEditBuffer]     = useState('');
 
   useEffect(() => {
     void loadHealthData().then((d) => {
@@ -61,12 +63,46 @@ export function Health({ onNavigate, isActive, showHints }: { onNavigate: (s: Sc
 
   const currentDial: Dial = DIALS[dialIdx];
 
+  function currentDialValueStr(): string {
+    if (currentDial === 'spend')      return String(monthlySpend);
+    if (currentDial === 'savings')    return String(monthlySavings);
+    if (currentDial === 'withdrawal') return String(withdrawal);
+    if (currentDial === 'growth')     return String(growth);
+    return '';
+  }
+
+  function applyEdit(buffer: string) {
+    const n = parseFloat(buffer);
+    if (!isNaN(n)) {
+      if (currentDial === 'spend')      setMonthlySpend(Math.max(SPEND_STEP, Math.round(n / SPEND_STEP) * SPEND_STEP));
+      if (currentDial === 'savings')    setMonthlySavings(Math.round(n / SPEND_STEP) * SPEND_STEP);
+      if (currentDial === 'withdrawal') setWithdrawal(parseFloat(Math.min(10, Math.max(0.5, n)).toFixed(1)));
+      if (currentDial === 'growth')     setGrowth(parseFloat(Math.min(20, Math.max(0, n)).toFixed(1)));
+    }
+    setEditMode(false);
+    setEditBuffer('');
+  }
+
   useInput((input, key) => {
+    if (editMode) {
+      if (key.escape) { setEditMode(false); setEditBuffer(''); return; }
+      if (key.return) { applyEdit(editBuffer); return; }
+      if (key.backspace || key.delete) { setEditBuffer((b) => b.slice(0, -1)); return; }
+      if (input && /^[\d.\-]$/.test(input) && !key.ctrl && !key.meta) setEditBuffer((b) => b + input);
+      return;
+    }
+
     if (key.escape) { onNavigate('dashboard'); return; }
     handleNavKey(input, 'health', onNavigate);
 
     if (key.upArrow)   { setDialIdx((i) => (i - 1 + DIALS.length) % DIALS.length); return; }
     if (key.downArrow) { setDialIdx((i) => (i + 1) % DIALS.length); return; }
+
+    if (key.return) {
+      setEditBuffer(currentDialValueStr());
+      setEditMode(true);
+      return;
+    }
 
     if (key.rightArrow) {
       if (currentDial === 'spend')      setMonthlySpend((s) => s + SPEND_STEP);
@@ -124,7 +160,11 @@ export function Health({ onNavigate, isActive, showHints }: { onNavigate: (s: Sc
       <PageHeader current="health" showHints={showHints} />
 
       <Box marginTop={1}><Text bold>Financial Health</Text></Box>
-      {showHints && <Text dimColor>↑↓ select  ·  ← → adjust  ·  [r] reset</Text>}
+      {showHints && (
+        editMode
+          ? <Text dimColor>type value  ·  Enter confirm  ·  Esc cancel</Text>
+          : <Text dimColor>↑↓ select  ·  ← → adjust  ·  Enter type  ·  [r] reset</Text>
+      )}
       <Divider />
 
       {/* ── Snapshot ───────────────────────────────────────────────────────── */}
@@ -263,28 +303,40 @@ export function Health({ onNavigate, isActive, showHints }: { onNavigate: (s: Sc
       <Box flexDirection="column" marginTop={1}>
         <DialRow
           label="Monthly spending" value={fmt(monthlySpend)} selected={currentDial === 'spend'}
-          description={currentDial === 'spend'
-            ? (spendChanged ? `default ${fmt(defaultSpend)} · [r] reset` : `avg past 12 months  ← → ±${fmt(SPEND_STEP)}`)
-            : `avg past 12 months${spendChanged ? ' (modified)' : ''}`}
+          editing={editMode && currentDial === 'spend'} editBuffer={editBuffer}
+          description={editMode && currentDial === 'spend'
+            ? 'Enter confirm  ·  Esc cancel'
+            : currentDial === 'spend'
+              ? (spendChanged ? `default ${fmt(defaultSpend)} · [r] reset` : `avg past 12 months  ← → ±${fmt(SPEND_STEP)}`)
+              : `avg past 12 months${spendChanged ? ' (modified)' : ''}`}
         />
         <DialRow
           label="Monthly savings" value={fmtSigned(monthlySavings)} selected={currentDial === 'savings'}
           valueColor={monthlySavings < 0 ? C_NEGATIVE : C_NEUTRAL}
-          description={currentDial === 'savings'
-            ? (savingsChanged ? `default ${fmt(defaultSavings)} · [r] reset` : `avg surplus past 12 mo  ← → ±${fmt(SPEND_STEP)}`)
-            : `avg surplus past 12 mo${savingsChanged ? ' (modified)' : ''}`}
+          editing={editMode && currentDial === 'savings'} editBuffer={editBuffer}
+          description={editMode && currentDial === 'savings'
+            ? 'Enter confirm  ·  Esc cancel'
+            : currentDial === 'savings'
+              ? (savingsChanged ? `default ${fmt(defaultSavings)} · [r] reset` : `avg surplus past 12 mo  ← → ±${fmt(SPEND_STEP)}`)
+              : `avg surplus past 12 mo${savingsChanged ? ' (modified)' : ''}`}
         />
         <DialRow
           label="Withdrawal rate" value={fmtPct(withdrawal)} selected={currentDial === 'withdrawal'}
-          description={currentDial === 'withdrawal'
-            ? `← → ±${fmtPct(WITHDRAW_STEP)}${withdrawChanged ? ' · [r] reset' : ''}`
-            : `safe withdrawal rate${withdrawChanged ? ' (modified)' : ''}`}
+          editing={editMode && currentDial === 'withdrawal'} editBuffer={editBuffer}
+          description={editMode && currentDial === 'withdrawal'
+            ? 'Enter confirm  ·  Esc cancel'
+            : currentDial === 'withdrawal'
+              ? `← → ±${fmtPct(WITHDRAW_STEP)}${withdrawChanged ? ' · [r] reset' : ''}`
+              : `safe withdrawal rate${withdrawChanged ? ' (modified)' : ''}`}
         />
         <DialRow
           label="Growth rate" value={fmtPct(growth)} selected={currentDial === 'growth'}
-          description={currentDial === 'growth'
-            ? `← → ±${fmtPct(GROWTH_STEP)}${growthChanged ? ' · [r] reset' : ''}`
-            : `real annual return${growthChanged ? ' (modified)' : ''}`}
+          editing={editMode && currentDial === 'growth'} editBuffer={editBuffer}
+          description={editMode && currentDial === 'growth'
+            ? 'Enter confirm  ·  Esc cancel'
+            : currentDial === 'growth'
+              ? `← → ±${fmtPct(GROWTH_STEP)}${growthChanged ? ' · [r] reset' : ''}`
+              : `real annual return${growthChanged ? ' (modified)' : ''}`}
         />
       </Box>
     </Box>

--- a/tui/Rules.tsx
+++ b/tui/Rules.tsx
@@ -16,8 +16,12 @@ import { ModalPanel, TextInput, SelectableRow, usePagination, useStatusMessage, 
 
 type Flexibility = 'fixed' | 'flexible' | 'discretionary' | null;
 const FLEX_CYCLE: Flexibility[] = [null, 'fixed', 'flexible', 'discretionary'];
-type Mode = 'list' | 'search' | 'add-pattern' | 'add-type' | 'add-min-amount' | 'add-max-amount' | 'add-category' | 'add-name-pattern' | 'add-name-type' | 'add-name-min-amount' | 'add-name-max-amount' | 'add-name-replacement' | 'add-category-name' | 'rename-category' | 'edit-category';
+type Mode = 'list' | 'search' | 'rule-form' | 'name-rule-form' | 'add-category-name' | 'rename-category' | 'edit-category';
 type CatEditField = 'flexibility' | 'hidden';
+type RuleField = 'pattern' | 'type' | 'min' | 'max' | 'category';
+type NameRuleField = 'pattern' | 'type' | 'min' | 'max' | 'replacement';
+const RULE_FIELDS: RuleField[] = ['pattern', 'type', 'min', 'max', 'category'];
+const NAME_RULE_FIELDS: NameRuleField[] = ['pattern', 'type', 'min', 'max', 'replacement'];
 type Section = 'rules' | 'names' | 'categories';
 
 const SECTIONS: Section[] = ['rules', 'names', 'categories'];
@@ -60,11 +64,15 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
   // Category edit panel state
   const [catEditField, setCatEditField] = useState<CatEditField>('flexibility');
 
+  // Unified rule form field cursor
+  const [ruleField, setRuleField] = useState<RuleField>('pattern');
+  const [nameRuleField, setNameRuleField] = useState<NameRuleField>('pattern');
+
   // Search
   const [search, setSearch] = useState('');
 
   const setTyping = useSetTyping();
-  const TEXT_INPUT_MODES_RULES = new Set<Mode>(['search', 'add-pattern', 'add-min-amount', 'add-max-amount', 'add-name-pattern', 'add-name-min-amount', 'add-name-max-amount', 'add-name-replacement', 'add-category-name', 'rename-category']);
+  const TEXT_INPUT_MODES_RULES = new Set<Mode>(['search', 'rule-form', 'name-rule-form', 'add-category-name', 'rename-category']);
   useEffect(() => { setTyping(TEXT_INPUT_MODES_RULES.has(mode)); }, [mode]);
 
   const termW = useTerminalWidth();
@@ -169,7 +177,10 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
       if (section === 'rules') {
         if (key.upArrow) setCursor((c) => Math.max(0, c - 1));
         if (key.downArrow) setCursor((c) => Math.min(filteredRules.length - 1, c + 1));
-        if (input === 'a') { setEditingRuleId(null); setNewPattern(''); setNewType('name'); setNewMinAmount(''); setNewMaxAmount(''); setCatCursor(0); setMode('add-pattern'); }
+        if (input === 'a') {
+          setEditingRuleId(null); setNewPattern(''); setNewType('name'); setNewMinAmount(''); setNewMaxAmount(''); setCatCursor(0);
+          setRuleField('pattern'); setMode('rule-form');
+        }
         if (input === 'x' && filteredRules[cursor]) { handleDeleteRule(filteredRules[cursor].id); }
         if ((input === 'e' || key.return) && filteredRules[cursor]) {
           const r = filteredRules[cursor];
@@ -179,12 +190,15 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
           setNewMinAmount(r.min_amount !== null ? String(r.min_amount) : '');
           setNewMaxAmount(r.max_amount !== null ? String(r.max_amount) : '');
           setCatCursor(Math.max(0, categories.indexOf(r.category)));
-          setMode('add-pattern');
+          setRuleField('pattern'); setMode('rule-form');
         }
       } else if (section === 'names') {
         if (key.upArrow) setNameCursor((c) => Math.max(0, c - 1));
         if (key.downArrow) setNameCursor((c) => Math.min(filteredNameRules.length - 1, c + 1));
-        if (input === 'a') { setEditingNameRuleId(null); setNewNamePattern(''); setNewNameType('name'); setNewNameMinAmount(''); setNewNameMaxAmount(''); setNewReplacement(''); setMode('add-name-pattern'); }
+        if (input === 'a') {
+          setEditingNameRuleId(null); setNewNamePattern(''); setNewNameType('name'); setNewNameMinAmount(''); setNewNameMaxAmount(''); setNewReplacement('');
+          setNameRuleField('pattern'); setMode('name-rule-form');
+        }
         if (input === 'x' && filteredNameRules[nameCursor]) { handleDeleteNameRule(filteredNameRules[nameCursor].id); }
         if ((input === 'e' || key.return) && filteredNameRules[nameCursor]) {
           const r = filteredNameRules[nameCursor];
@@ -194,7 +208,7 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
           setNewNameMinAmount(r.min_amount !== null ? String(r.min_amount) : '');
           setNewNameMaxAmount(r.max_amount !== null ? String(r.max_amount) : '');
           setNewReplacement(r.replacement);
-          setMode('add-name-pattern');
+          setNameRuleField('pattern'); setMode('name-rule-form');
         }
       } else if (section === 'categories') {
         if (key.upArrow) setCatListCursor((c) => Math.max(0, c - 1));
@@ -259,54 +273,46 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
         }
         return;
       }
-    } else if (mode === 'add-pattern') {
-      if (key.return) { if (newPattern) setMode('add-type'); return; }
+    } else if (mode === 'rule-form') {
       if (key.escape) { setEditingRuleId(null); setMode('list'); return; }
-      if (key.backspace || key.delete) { setNewPattern((p) => p.slice(0, -1)); return; }
-      if (input && !key.ctrl && !key.meta) setNewPattern((p) => p + input);
-    } else if (mode === 'add-type') {
-      if (key.escape) { setMode('list'); return; }
-      if (input === 'n') { setNewType('name'); setNewMinAmount(''); setNewMaxAmount(''); setMode('add-min-amount'); }
-      if (input === 'r') { setNewType('regex'); setNewMinAmount(''); setNewMaxAmount(''); setMode('add-min-amount'); }
-    } else if (mode === 'add-min-amount') {
-      if (key.escape) { setMode('list'); return; }
-      if (key.return) { setMode('add-max-amount'); return; }
-      if (key.backspace || key.delete) { setNewMinAmount((p) => p.slice(0, -1)); return; }
-      if (input && !key.ctrl && !key.meta) setNewMinAmount((p) => p + input);
-    } else if (mode === 'add-max-amount') {
-      if (key.escape) { setMode('list'); return; }
-      if (key.return) { setMode('add-category'); return; }
-      if (key.backspace || key.delete) { setNewMaxAmount((p) => p.slice(0, -1)); return; }
-      if (input && !key.ctrl && !key.meta) setNewMaxAmount((p) => p + input);
-    } else if (mode === 'add-category') {
-      if (key.escape) { setMode('list'); return; }
-      if (key.upArrow) setCatCursor((c) => Math.max(0, c - 1));
-      if (key.downArrow) setCatCursor((c) => Math.min(categories.length - 1, c + 1));
-      if (key.return) saveRule();
-    } else if (mode === 'add-name-pattern') {
-      if (key.return) { if (newNamePattern) setMode('add-name-type'); return; }
+      if (key.return) { if (newPattern.trim()) saveRule(); return; }
+      if (key.upArrow) { setRuleField((f) => RULE_FIELDS[Math.max(0, RULE_FIELDS.indexOf(f) - 1)]); return; }
+      if (key.downArrow) { setRuleField((f) => RULE_FIELDS[Math.min(RULE_FIELDS.length - 1, RULE_FIELDS.indexOf(f) + 1)]); return; }
+      if (ruleField === 'pattern') {
+        if (key.backspace || key.delete) { setNewPattern((p) => p.slice(0, -1)); return; }
+        if (input && !key.ctrl && !key.meta) { setNewPattern((p) => p + input); return; }
+      } else if (ruleField === 'type') {
+        if (key.leftArrow || key.rightArrow) { setNewType((t) => t === 'name' ? 'regex' : 'name'); return; }
+      } else if (ruleField === 'min') {
+        if (key.backspace || key.delete) { setNewMinAmount((p) => p.slice(0, -1)); return; }
+        if (input && !key.ctrl && !key.meta) { setNewMinAmount((p) => p + input); return; }
+      } else if (ruleField === 'max') {
+        if (key.backspace || key.delete) { setNewMaxAmount((p) => p.slice(0, -1)); return; }
+        if (input && !key.ctrl && !key.meta) { setNewMaxAmount((p) => p + input); return; }
+      } else if (ruleField === 'category') {
+        if (key.leftArrow) { setCatCursor((c) => Math.max(0, c - 1)); return; }
+        if (key.rightArrow) { setCatCursor((c) => Math.min(categories.length - 1, c + 1)); return; }
+      }
+    } else if (mode === 'name-rule-form') {
       if (key.escape) { setEditingNameRuleId(null); setMode('list'); return; }
-      if (key.backspace || key.delete) { setNewNamePattern((p) => p.slice(0, -1)); return; }
-      if (input && !key.ctrl && !key.meta) setNewNamePattern((p) => p + input);
-    } else if (mode === 'add-name-type') {
-      if (key.escape) { setMode('list'); return; }
-      if (input === 'n') { setNewNameType('name'); setMode('add-name-min-amount'); }
-      if (input === 'r') { setNewNameType('regex'); setMode('add-name-min-amount'); }
-    } else if (mode === 'add-name-min-amount') {
-      if (key.escape) { setMode('list'); return; }
-      if (key.return) { setMode('add-name-max-amount'); return; }
-      if (key.backspace || key.delete) { setNewNameMinAmount((p) => p.slice(0, -1)); return; }
-      if (input && !key.ctrl && !key.meta) setNewNameMinAmount((p) => p + input);
-    } else if (mode === 'add-name-max-amount') {
-      if (key.escape) { setMode('list'); return; }
-      if (key.return) { setMode('add-name-replacement'); return; }
-      if (key.backspace || key.delete) { setNewNameMaxAmount((p) => p.slice(0, -1)); return; }
-      if (input && !key.ctrl && !key.meta) setNewNameMaxAmount((p) => p + input);
-    } else if (mode === 'add-name-replacement') {
-      if (key.return) { if (newReplacement) handleSaveNameRule(); return; }
-      if (key.escape) { setMode('list'); return; }
-      if (key.backspace || key.delete) { setNewReplacement((p) => p.slice(0, -1)); return; }
-      if (input && !key.ctrl && !key.meta) setNewReplacement((p) => p + input);
+      if (key.return) { if (newNamePattern.trim() && newReplacement.trim()) handleSaveNameRule(); return; }
+      if (key.upArrow) { setNameRuleField((f) => NAME_RULE_FIELDS[Math.max(0, NAME_RULE_FIELDS.indexOf(f) - 1)]); return; }
+      if (key.downArrow) { setNameRuleField((f) => NAME_RULE_FIELDS[Math.min(NAME_RULE_FIELDS.length - 1, NAME_RULE_FIELDS.indexOf(f) + 1)]); return; }
+      if (nameRuleField === 'pattern') {
+        if (key.backspace || key.delete) { setNewNamePattern((p) => p.slice(0, -1)); return; }
+        if (input && !key.ctrl && !key.meta) { setNewNamePattern((p) => p + input); return; }
+      } else if (nameRuleField === 'type') {
+        if (key.leftArrow || key.rightArrow) { setNewNameType((t) => t === 'name' ? 'regex' : 'name'); return; }
+      } else if (nameRuleField === 'min') {
+        if (key.backspace || key.delete) { setNewNameMinAmount((p) => p.slice(0, -1)); return; }
+        if (input && !key.ctrl && !key.meta) { setNewNameMinAmount((p) => p + input); return; }
+      } else if (nameRuleField === 'max') {
+        if (key.backspace || key.delete) { setNewNameMaxAmount((p) => p.slice(0, -1)); return; }
+        if (input && !key.ctrl && !key.meta) { setNewNameMaxAmount((p) => p + input); return; }
+      } else if (nameRuleField === 'replacement') {
+        if (key.backspace || key.delete) { setNewReplacement((p) => p.slice(0, -1)); return; }
+        if (input && !key.ctrl && !key.meta) { setNewReplacement((p) => p + input); return; }
+      }
     } else if (mode === 'add-category-name') {
       if (key.escape) { setMode('list'); return; }
       if (key.return && newCategoryName.trim()) {
@@ -511,64 +517,104 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
         );
       })()}
 
-      {mode === 'add-pattern' && (
-        <ModalPanel title={`${editingRuleId !== null ? 'Edit' : 'New'} Rule — Pattern`}>
-          <Text dimColor>Type pattern · Enter · Esc cancel</Text>
-          <Box marginTop={1} gap={1}><Text>Pattern: </Text><TextInput value={newPattern} color={C_WARNING} /></Box>
-        </ModalPanel>
-      )}
-      {mode === 'add-type' && (
-        <ModalPanel title={`${editingRuleId !== null ? 'Edit' : 'New'} Rule — Match Type`}>
-          <Text>Pattern: <Text color={C_WARNING}>"{newPattern}"</Text></Text>
-          <Box gap={4} marginTop={1}>
-            <Text color={C_ACCENT}>[n] name match</Text>
-            <Text color={C_ACCENT}>[r] regex match</Text>
+      {mode === 'rule-form' && (
+        <ModalPanel title={`${editingRuleId !== null ? 'Edit' : 'New'} Category Rule`}>
+          <Box marginTop={1} flexDirection="column" gap={1}>
+            <Box gap={2}>
+              <Text color={ruleField === 'pattern' ? C_ACCENT : C_NEUTRAL}>{'Pattern'.padEnd(12)}</Text>
+              <Box>
+                <Text color={ruleField === 'pattern' ? C_ACCENT : C_NEUTRAL}>{'[ '}</Text>
+                {ruleField === 'pattern'
+                  ? <TextInput value={newPattern} color={C_WARNING} placeholder="keyword or /regex/" />
+                  : <Text color={newPattern ? undefined : C_DIM}>{newPattern || 'empty'}</Text>}
+                <Text color={ruleField === 'pattern' ? C_ACCENT : C_NEUTRAL}>{' ]'}</Text>
+              </Box>
+            </Box>
+            <Box gap={2}>
+              <Text color={ruleField === 'type' ? C_ACCENT : C_NEUTRAL}>{'Match type'.padEnd(12)}</Text>
+              <Text color={ruleField === 'type' ? C_ACCENT : undefined}>{'← '}{newType}{'  →'}</Text>
+            </Box>
+            <Box gap={2}>
+              <Text color={ruleField === 'min' ? C_ACCENT : C_NEUTRAL}>{'Min $'.padEnd(12)}</Text>
+              <Box>
+                <Text color={ruleField === 'min' ? C_ACCENT : C_NEUTRAL}>{'[ '}</Text>
+                {ruleField === 'min'
+                  ? <TextInput value={newMinAmount} color={C_WARNING} placeholder="optional" />
+                  : <Text color={newMinAmount ? undefined : C_DIM}>{newMinAmount || '—'}</Text>}
+                <Text color={ruleField === 'min' ? C_ACCENT : C_NEUTRAL}>{' ]'}</Text>
+              </Box>
+            </Box>
+            <Box gap={2}>
+              <Text color={ruleField === 'max' ? C_ACCENT : C_NEUTRAL}>{'Max $'.padEnd(12)}</Text>
+              <Box>
+                <Text color={ruleField === 'max' ? C_ACCENT : C_NEUTRAL}>{'[ '}</Text>
+                {ruleField === 'max'
+                  ? <TextInput value={newMaxAmount} color={C_WARNING} placeholder="optional" />
+                  : <Text color={newMaxAmount ? undefined : C_DIM}>{newMaxAmount || '—'}</Text>}
+                <Text color={ruleField === 'max' ? C_ACCENT : C_NEUTRAL}>{' ]'}</Text>
+              </Box>
+            </Box>
+            <Box gap={2}>
+              <Text color={ruleField === 'category' ? C_ACCENT : C_NEUTRAL}>{'Category'.padEnd(12)}</Text>
+              <Text color={ruleField === 'category' ? C_ACCENT : C_NEUTRAL}>{'← '}{categories[catCursor] ?? '—'}{'  →'}</Text>
+            </Box>
           </Box>
-        </ModalPanel>
-      )}
-      {mode === 'add-min-amount' && (
-        <ModalPanel title={`${editingRuleId !== null ? 'Edit' : 'New'} Rule — Min Amount (optional)`}>
-          <Text>Pattern: <Text color={C_WARNING}>"{newPattern}"</Text>  Type: <Text color={C_WARNING}>{newType}</Text></Text>
-          <Text dimColor>Enter to skip · Esc cancel</Text>
-          <Box marginTop={1} gap={1}><Text>Min $: </Text><TextInput value={newMinAmount} color={C_WARNING} /></Box>
-        </ModalPanel>
-      )}
-      {mode === 'add-max-amount' && (
-        <ModalPanel title={`${editingRuleId !== null ? 'Edit' : 'New'} Rule — Max Amount (optional)`}>
-          <Text>Pattern: <Text color={C_WARNING}>"{newPattern}"</Text>  {newMinAmount && <Text>Min: <Text color={C_MANUAL}>${newMinAmount}</Text></Text>}</Text>
-          <Text dimColor>Enter to skip · Esc cancel</Text>
-          <Box marginTop={1} gap={1}><Text>Max $: </Text><TextInput value={newMaxAmount} color={C_WARNING} /></Box>
-        </ModalPanel>
-      )}
-      {mode === 'add-category' && (
-        <ModalPanel title={`${editingRuleId !== null ? 'Edit' : 'New'} Rule — Category`}>
-          <Text>Pattern: <Text color={C_WARNING}>"{newPattern}"</Text>  Type: <Text color={C_WARNING}>{newType}</Text></Text>
-          <Text dimColor>↑↓ select · Enter save · Esc cancel</Text>
-          <Box flexDirection="column" marginTop={1}>
-            {categories.map((cat, i) => (
-              <SelectableRow key={cat} selected={i === catCursor}>
-                <Text color={i === catCursor ? C_ACCENT : C_NEUTRAL} dimColor={i !== catCursor}>{cat}</Text>
-              </SelectableRow>
-            ))}
-          </Box>
+          <Box marginTop={1}><Text dimColor>↑↓ field  ·  ← → change  ·  Enter save  ·  Esc cancel</Text></Box>
         </ModalPanel>
       )}
 
-      {mode === 'add-name-pattern' && (
-        <ModalPanel title={`${editingNameRuleId !== null ? 'Edit' : 'New'} Name Rule — Pattern`} borderColor={C_POSITIVE}>
-          <Text dimColor>Matches against the raw transaction name</Text>
-          <Box marginTop={1} gap={1}><Text>Pattern: </Text><TextInput value={newNamePattern} color={C_WARNING} /></Box>
-        </ModalPanel>
-      )}
-      {mode === 'add-name-type' && (
-        <ModalPanel title={`${editingNameRuleId !== null ? 'Edit' : 'New'} Name Rule — Match Type`} borderColor={C_POSITIVE}>
-          <Text>Pattern: <Text color={C_WARNING}>"{newNamePattern}"</Text></Text>
-          <Box gap={4} marginTop={1}>
-            <Text color={C_POSITIVE}>[n] name match (replaces whole name)</Text>
-            <Text color={C_POSITIVE}>[r] regex (can use capture groups)</Text>
+      {mode === 'name-rule-form' && (
+        <ModalPanel title={`${editingNameRuleId !== null ? 'Edit' : 'New'} Name Rule`} borderColor={C_POSITIVE}>
+          <Box marginTop={1} flexDirection="column" gap={1}>
+            <Box gap={2}>
+              <Text color={nameRuleField === 'pattern' ? C_ACCENT : C_NEUTRAL}>{'Pattern'.padEnd(12)}</Text>
+              <Box>
+                <Text color={nameRuleField === 'pattern' ? C_ACCENT : C_NEUTRAL}>{'[ '}</Text>
+                {nameRuleField === 'pattern'
+                  ? <TextInput value={newNamePattern} color={C_WARNING} placeholder="keyword or /regex/" />
+                  : <Text color={newNamePattern ? undefined : C_DIM}>{newNamePattern || 'empty'}</Text>}
+                <Text color={nameRuleField === 'pattern' ? C_ACCENT : C_NEUTRAL}>{' ]'}</Text>
+              </Box>
+            </Box>
+            <Box gap={2}>
+              <Text color={nameRuleField === 'type' ? C_ACCENT : C_NEUTRAL}>{'Match type'.padEnd(12)}</Text>
+              <Text color={nameRuleField === 'type' ? C_ACCENT : undefined}>{'← '}{newNameType}{'  →'}</Text>
+            </Box>
+            <Box gap={2}>
+              <Text color={nameRuleField === 'min' ? C_ACCENT : C_NEUTRAL}>{'Min $'.padEnd(12)}</Text>
+              <Box>
+                <Text color={nameRuleField === 'min' ? C_ACCENT : C_NEUTRAL}>{'[ '}</Text>
+                {nameRuleField === 'min'
+                  ? <TextInput value={newNameMinAmount} color={C_WARNING} placeholder="optional" />
+                  : <Text color={newNameMinAmount ? undefined : C_DIM}>{newNameMinAmount || '—'}</Text>}
+                <Text color={nameRuleField === 'min' ? C_ACCENT : C_NEUTRAL}>{' ]'}</Text>
+              </Box>
+            </Box>
+            <Box gap={2}>
+              <Text color={nameRuleField === 'max' ? C_ACCENT : C_NEUTRAL}>{'Max $'.padEnd(12)}</Text>
+              <Box>
+                <Text color={nameRuleField === 'max' ? C_ACCENT : C_NEUTRAL}>{'[ '}</Text>
+                {nameRuleField === 'max'
+                  ? <TextInput value={newNameMaxAmount} color={C_WARNING} placeholder="optional" />
+                  : <Text color={newNameMaxAmount ? undefined : C_DIM}>{newNameMaxAmount || '—'}</Text>}
+                <Text color={nameRuleField === 'max' ? C_ACCENT : C_NEUTRAL}>{' ]'}</Text>
+              </Box>
+            </Box>
+            <Box gap={2}>
+              <Text color={nameRuleField === 'replacement' ? C_ACCENT : C_NEUTRAL}>{'Replace with'.padEnd(12)}</Text>
+              <Box>
+                <Text color={nameRuleField === 'replacement' ? C_ACCENT : C_NEUTRAL}>{'[ '}</Text>
+                {nameRuleField === 'replacement'
+                  ? <TextInput value={newReplacement} color={C_POSITIVE} placeholder="display name" />
+                  : <Text color={newReplacement ? C_POSITIVE : C_DIM}>{newReplacement || 'empty'}</Text>}
+                <Text color={nameRuleField === 'replacement' ? C_ACCENT : C_NEUTRAL}>{' ]'}</Text>
+              </Box>
+            </Box>
           </Box>
+          <Box marginTop={1}><Text dimColor>↑↓ field  ·  ← → change  ·  Enter save  ·  Esc cancel</Text></Box>
         </ModalPanel>
       )}
+
       {mode === 'add-category-name' && (
         <ModalPanel title="New Category" borderColor={C_WARNING}>
           <Text dimColor>Type a name · Enter save · Esc cancel</Text>
@@ -579,38 +625,6 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
         <ModalPanel title="Rename Category" borderColor={C_WARNING}>
           <Text dimColor>Updates all transactions, rules, and hidden settings · Enter save · Esc cancel</Text>
           <Box marginTop={1} gap={1}><Text>Name: </Text><TextInput value={renameCatInput} color={C_WARNING} /></Box>
-        </ModalPanel>
-      )}
-      {mode === 'add-name-min-amount' && (
-        <ModalPanel title={`${editingNameRuleId !== null ? 'Edit' : 'New'} Name Rule — Min Amount (optional)`} borderColor={C_POSITIVE}>
-          <Text>Pattern: <Text color={C_WARNING}>"{newNamePattern}"</Text>  Type: <Text color={C_WARNING}>{newNameType}</Text></Text>
-          <Text dimColor>Enter to skip · Esc cancel</Text>
-          <Box marginTop={1} gap={1}><Text>Min $: </Text><TextInput value={newNameMinAmount} color={C_WARNING} /></Box>
-        </ModalPanel>
-      )}
-      {mode === 'add-name-max-amount' && (
-        <ModalPanel title={`${editingNameRuleId !== null ? 'Edit' : 'New'} Name Rule — Max Amount (optional)`} borderColor={C_POSITIVE}>
-          <Text>Pattern: <Text color={C_WARNING}>"{newNamePattern}"</Text>  {newNameMinAmount && <Text>Min: <Text color={C_MANUAL}>${newNameMinAmount}</Text>  </Text>}</Text>
-          <Text dimColor>Enter to skip · Esc cancel</Text>
-          <Box marginTop={1} gap={1}><Text>Max $: </Text><TextInput value={newNameMaxAmount} color={C_WARNING} /></Box>
-        </ModalPanel>
-      )}
-      {mode === 'add-name-replacement' && (
-        <ModalPanel title={`${editingNameRuleId !== null ? 'Edit' : 'New'} Name Rule — Replacement`} borderColor={C_POSITIVE}>
-          <Text>
-            Pattern: <Text color={C_WARNING}>"{newNamePattern}"</Text>  Type: <Text color={C_WARNING}>{newNameType}</Text>
-            {(newNameMinAmount || newNameMaxAmount) && (
-              <Text>  Amount: <Text color={C_MANUAL}>
-                {newNameMinAmount && newNameMaxAmount && newNameMinAmount === newNameMaxAmount
-                  ? `$${newNameMinAmount}`
-                  : newNameMinAmount && newNameMaxAmount
-                  ? `$${newNameMinAmount}–$${newNameMaxAmount}`
-                  : newNameMinAmount ? `≥$${newNameMinAmount}` : `≤$${newNameMaxAmount}`}
-              </Text></Text>
-            )}
-          </Text>
-          <Text dimColor>The display name to show instead</Text>
-          <Box marginTop={1} gap={1}><Text>Replace with: </Text><TextInput value={newReplacement} color={C_POSITIVE} /></Box>
         </ModalPanel>
       )}
     </Box>

--- a/tui/Rules.tsx
+++ b/tui/Rules.tsx
@@ -112,11 +112,11 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
     load();
   }
 
-  function saveRule() {
+  async function saveRule() {
     const category = categories[catCursor];
     const minAmt = newMinAmount.trim() ? parseFloat(newMinAmount) : null;
     const maxAmt = newMaxAmount.trim() ? parseFloat(newMaxAmount) : null;
-    const count = saveCategoryRule({
+    const count = await saveCategoryRule({
       pattern: newPattern, matchType: newType, category,
       minAmount: minAmt, maxAmount: maxAmt,
       editingId: editingRuleId,
@@ -128,10 +128,10 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
     load();
   }
 
-  function handleSaveNameRule() {
+  async function handleSaveNameRule() {
     const minAmt = newNameMinAmount.trim() ? parseFloat(newNameMinAmount) : null;
     const maxAmt = newNameMaxAmount.trim() ? parseFloat(newNameMaxAmount) : null;
-    saveNameRule({
+    await saveNameRule({
       pattern: newNamePattern, matchType: newNameType, replacement: newReplacement,
       minAmount: minAmt, maxAmount: maxAmt,
       editingId: editingNameRuleId,
@@ -288,7 +288,7 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
       }
     } else if (mode === 'rule-form') {
       if (key.escape) { setEditingRuleId(null); setMode('list'); return; }
-      if (key.return) { if (newPattern.trim()) saveRule(); return; }
+      if (key.return) { if (newPattern.trim()) { void saveRule(); } return; }
       if (key.upArrow) { setRuleField((f) => RULE_FIELDS[Math.max(0, RULE_FIELDS.indexOf(f) - 1)]); return; }
       if (key.downArrow) { setRuleField((f) => RULE_FIELDS[Math.min(RULE_FIELDS.length - 1, RULE_FIELDS.indexOf(f) + 1)]); return; }
       if (ruleField === 'pattern') {
@@ -308,7 +308,7 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
       }
     } else if (mode === 'name-rule-form') {
       if (key.escape) { setEditingNameRuleId(null); setMode('list'); return; }
-      if (key.return) { if (newNamePattern.trim() && newReplacement.trim()) handleSaveNameRule(); return; }
+      if (key.return) { if (newNamePattern.trim() && newReplacement.trim()) { void handleSaveNameRule(); } return; }
       if (key.upArrow) { setNameRuleField((f) => NAME_RULE_FIELDS[Math.max(0, NAME_RULE_FIELDS.indexOf(f) - 1)]); return; }
       if (key.downArrow) { setNameRuleField((f) => NAME_RULE_FIELDS[Math.min(NAME_RULE_FIELDS.length - 1, NAME_RULE_FIELDS.indexOf(f) + 1)]); return; }
       if (nameRuleField === 'pattern') {

--- a/tui/Rules.tsx
+++ b/tui/Rules.tsx
@@ -12,12 +12,12 @@ import { handleNavKey } from './nav.js';
 import { useTerminalWidth, FLEX_COLORS, C_ACCENT, C_DIM, C_MANUAL, C_NEUTRAL, C_POSITIVE, C_WARNING } from './ui.js';
 import { useRefreshKey } from './RefreshContext.js';
 import { useSetTyping } from './TypingContext.js';
-import { ModalPanel, TextInput, SelectableRow, usePagination, useStatusMessage, ColumnHeader, PageHeader, SearchBar } from './components/index.js';
+import { ModalPanel, TextInput, SelectableRow, usePagination, useStatusMessage, ColumnHeader, PageHeader, SearchBar, EditTextField, EditToggleField } from './components/index.js';
 
 type Flexibility = 'fixed' | 'flexible' | 'discretionary' | null;
 const FLEX_CYCLE: Flexibility[] = [null, 'fixed', 'flexible', 'discretionary'];
-type Mode = 'list' | 'search' | 'rule-form' | 'name-rule-form' | 'add-category-name' | 'rename-category' | 'edit-category';
-type CatEditField = 'flexibility' | 'hidden';
+type Mode = 'list' | 'search' | 'rule-form' | 'name-rule-form' | 'add-category-name' | 'edit-category';
+type CatEditField = 'name' | 'flexibility' | 'hidden';
 type RuleField = 'pattern' | 'type' | 'min' | 'max' | 'category';
 type NameRuleField = 'pattern' | 'type' | 'min' | 'max' | 'replacement';
 const RULE_FIELDS: RuleField[] = ['pattern', 'type', 'min', 'max', 'category'];
@@ -72,7 +72,7 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
   const [search, setSearch] = useState('');
 
   const setTyping = useSetTyping();
-  const TEXT_INPUT_MODES_RULES = new Set<Mode>(['search', 'rule-form', 'name-rule-form', 'add-category-name', 'rename-category']);
+  const TEXT_INPUT_MODES_RULES = new Set<Mode>(['search', 'rule-form', 'name-rule-form', 'add-category-name', 'edit-category']);
   useEffect(() => { setTyping(TEXT_INPUT_MODES_RULES.has(mode)); }, [mode]);
 
   const termW = useTerminalWidth();
@@ -230,11 +230,6 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
           load();
           return;
         }
-        if (input === 'n' && categories[catListCursor]) {
-          setRenameCatInput(categories[catListCursor]);
-          setMode('rename-category');
-          return;
-        }
         if (input === 'x' && categories[catListCursor]) {
           const name = categories[catListCursor];
           deleteCategory(name);
@@ -242,16 +237,34 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
           load();
           setCatListCursor((c) => Math.max(0, c - 1));
         }
-        if (key.return && catDetails[catListCursor]) {
-          setCatEditField('flexibility');
+        if ((input === 'e' || key.return) && catDetails[catListCursor]) {
+          setRenameCatInput(categories[catListCursor] ?? '');
+          setCatEditField('name');
           setMode('edit-category');
           return;
         }
       }
     } else if (mode === 'edit-category') {
-      if (key.escape || key.return) { setMode('list'); return; }
-      if (key.upArrow || key.downArrow) {
-        setCatEditField((f) => f === 'flexibility' ? 'hidden' : 'flexibility');
+      const CAT_FIELDS: CatEditField[] = ['name', 'flexibility', 'hidden'];
+      if (key.escape) { setMode('list'); return; }
+      if (key.return) {
+        const cat = catDetails[catListCursor];
+        if (cat) {
+          const trimmed = renameCatInput.trim();
+          if (trimmed && trimmed !== cat.name) {
+            renameCategory(cat.name, trimmed);
+            showStatus(`Renamed to "${trimmed}"`);
+            load();
+          }
+        }
+        setMode('list');
+        return;
+      }
+      if (key.upArrow) { setCatEditField((f) => CAT_FIELDS[Math.max(0, CAT_FIELDS.indexOf(f) - 1)]); return; }
+      if (key.downArrow) { setCatEditField((f) => CAT_FIELDS[Math.min(CAT_FIELDS.length - 1, CAT_FIELDS.indexOf(f) + 1)]); return; }
+      if (catEditField === 'name') {
+        if (key.backspace || key.delete) { setRenameCatInput((p) => p.slice(0, -1)); return; }
+        if (input && !key.ctrl && !key.meta) { setRenameCatInput((p) => p + input); return; }
         return;
       }
       if (catEditField === 'flexibility' && (key.leftArrow || key.rightArrow)) {
@@ -325,21 +338,6 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
       }
       if (key.backspace || key.delete) { setNewCategoryName((p) => p.slice(0, -1)); return; }
       if (input && !key.ctrl && !key.meta) setNewCategoryName((p) => p + input);
-    } else if (mode === 'rename-category') {
-      if (key.escape) { setMode('list'); return; }
-      if (key.return && renameCatInput.trim()) {
-        const oldName = categories[catListCursor];
-        const newName = renameCatInput.trim();
-        if (oldName && newName !== oldName) {
-          renameCategory(oldName, newName);
-          showStatus(`Renamed to "${newName}"`);
-          load();
-        }
-        setMode('list');
-        return;
-      }
-      if (key.backspace || key.delete) { setRenameCatInput((p) => p.slice(0, -1)); return; }
-      if (input && !key.ctrl && !key.meta) setRenameCatInput((p) => p + input);
     }
   }, { isActive: isActive !== false });
 
@@ -368,7 +366,7 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
       </Box>
       <Text dimColor>
         {section === 'categories'
-          ? (showHints ? '[a] add  [n] rename  [x] delete  ·  Enter edit  ·  [Tab] switch' : '')
+          ? (showHints ? '[a] add  [x] delete  ·  Enter/[e] edit  ·  [Tab] switch' : '')
           : (showHints ? '[/] search  [a] add  [e] edit  [x] delete  ·  [Tab] switch' : '[/] search')}
       </Text>
 
@@ -499,12 +497,8 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
         return (
           <ModalPanel title={`Edit: ${cat.name}`}>
             <Box marginTop={1} flexDirection="column" gap={1}>
-              <Box gap={2}>
-                <Text color={catEditField === 'flexibility' ? C_ACCENT : C_NEUTRAL}>{'Flexibility'.padEnd(12)}</Text>
-                <Text color={catEditField === 'flexibility' ? C_ACCENT : (flexColor ?? C_DIM)}>
-                  {'← '}{cat.flexibility ?? '—'}{'  →'}
-                </Text>
-              </Box>
+              <EditTextField label="Name" active={catEditField === 'name'} value={renameCatInput} color={C_WARNING} emptyText="—" />
+              <EditToggleField label="Flexibility" active={catEditField === 'flexibility'} value={cat.flexibility ?? '—'} valueColor={flexColor ?? C_DIM} />
               <Box gap={2}>
                 <Text color={catEditField === 'hidden' ? C_ACCENT : C_NEUTRAL}>{'Hidden'.padEnd(12)}</Text>
                 <Text color={catEditField === 'hidden' ? C_ACCENT : (isHidden ? C_WARNING : C_DIM)}>
@@ -512,7 +506,7 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
                 </Text>
               </Box>
             </Box>
-            <Box marginTop={1}><Text dimColor>↑↓ field  ·  ← → change  ·  Enter/Esc close</Text></Box>
+            <Box marginTop={1}><Text dimColor>↑↓ field  ·  ← → change  ·  Enter save  ·  Esc cancel</Text></Box>
           </ModalPanel>
         );
       })()}
@@ -520,44 +514,11 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
       {mode === 'rule-form' && (
         <ModalPanel title={`${editingRuleId !== null ? 'Edit' : 'New'} Category Rule`}>
           <Box marginTop={1} flexDirection="column" gap={1}>
-            <Box gap={2}>
-              <Text color={ruleField === 'pattern' ? C_ACCENT : C_NEUTRAL}>{'Pattern'.padEnd(12)}</Text>
-              <Box>
-                <Text color={ruleField === 'pattern' ? C_ACCENT : C_NEUTRAL}>{'[ '}</Text>
-                {ruleField === 'pattern'
-                  ? <TextInput value={newPattern} color={C_WARNING} placeholder="keyword or /regex/" />
-                  : <Text color={newPattern ? undefined : C_DIM}>{newPattern || 'empty'}</Text>}
-                <Text color={ruleField === 'pattern' ? C_ACCENT : C_NEUTRAL}>{' ]'}</Text>
-              </Box>
-            </Box>
-            <Box gap={2}>
-              <Text color={ruleField === 'type' ? C_ACCENT : C_NEUTRAL}>{'Match type'.padEnd(12)}</Text>
-              <Text color={ruleField === 'type' ? C_ACCENT : undefined}>{'← '}{newType}{'  →'}</Text>
-            </Box>
-            <Box gap={2}>
-              <Text color={ruleField === 'min' ? C_ACCENT : C_NEUTRAL}>{'Min $'.padEnd(12)}</Text>
-              <Box>
-                <Text color={ruleField === 'min' ? C_ACCENT : C_NEUTRAL}>{'[ '}</Text>
-                {ruleField === 'min'
-                  ? <TextInput value={newMinAmount} color={C_WARNING} placeholder="optional" />
-                  : <Text color={newMinAmount ? undefined : C_DIM}>{newMinAmount || '—'}</Text>}
-                <Text color={ruleField === 'min' ? C_ACCENT : C_NEUTRAL}>{' ]'}</Text>
-              </Box>
-            </Box>
-            <Box gap={2}>
-              <Text color={ruleField === 'max' ? C_ACCENT : C_NEUTRAL}>{'Max $'.padEnd(12)}</Text>
-              <Box>
-                <Text color={ruleField === 'max' ? C_ACCENT : C_NEUTRAL}>{'[ '}</Text>
-                {ruleField === 'max'
-                  ? <TextInput value={newMaxAmount} color={C_WARNING} placeholder="optional" />
-                  : <Text color={newMaxAmount ? undefined : C_DIM}>{newMaxAmount || '—'}</Text>}
-                <Text color={ruleField === 'max' ? C_ACCENT : C_NEUTRAL}>{' ]'}</Text>
-              </Box>
-            </Box>
-            <Box gap={2}>
-              <Text color={ruleField === 'category' ? C_ACCENT : C_NEUTRAL}>{'Category'.padEnd(12)}</Text>
-              <Text color={ruleField === 'category' ? C_ACCENT : C_NEUTRAL}>{'← '}{categories[catCursor] ?? '—'}{'  →'}</Text>
-            </Box>
+            <EditTextField label="Pattern" active={ruleField === 'pattern'} value={newPattern} color={C_WARNING} placeholder="keyword or /regex/" emptyText="empty" />
+            <EditToggleField label="Match type" active={ruleField === 'type'} value={newType} />
+            <EditTextField label="Min $" active={ruleField === 'min'} value={newMinAmount} color={C_WARNING} placeholder="optional" />
+            <EditTextField label="Max $" active={ruleField === 'max'} value={newMaxAmount} color={C_WARNING} placeholder="optional" />
+            <EditToggleField label="Category" active={ruleField === 'category'} value={categories[catCursor] ?? '—'} />
           </Box>
           <Box marginTop={1}><Text dimColor>↑↓ field  ·  ← → change  ·  Enter save  ·  Esc cancel</Text></Box>
         </ModalPanel>
@@ -566,50 +527,11 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
       {mode === 'name-rule-form' && (
         <ModalPanel title={`${editingNameRuleId !== null ? 'Edit' : 'New'} Name Rule`} borderColor={C_POSITIVE}>
           <Box marginTop={1} flexDirection="column" gap={1}>
-            <Box gap={2}>
-              <Text color={nameRuleField === 'pattern' ? C_ACCENT : C_NEUTRAL}>{'Pattern'.padEnd(12)}</Text>
-              <Box>
-                <Text color={nameRuleField === 'pattern' ? C_ACCENT : C_NEUTRAL}>{'[ '}</Text>
-                {nameRuleField === 'pattern'
-                  ? <TextInput value={newNamePattern} color={C_WARNING} placeholder="keyword or /regex/" />
-                  : <Text color={newNamePattern ? undefined : C_DIM}>{newNamePattern || 'empty'}</Text>}
-                <Text color={nameRuleField === 'pattern' ? C_ACCENT : C_NEUTRAL}>{' ]'}</Text>
-              </Box>
-            </Box>
-            <Box gap={2}>
-              <Text color={nameRuleField === 'type' ? C_ACCENT : C_NEUTRAL}>{'Match type'.padEnd(12)}</Text>
-              <Text color={nameRuleField === 'type' ? C_ACCENT : undefined}>{'← '}{newNameType}{'  →'}</Text>
-            </Box>
-            <Box gap={2}>
-              <Text color={nameRuleField === 'min' ? C_ACCENT : C_NEUTRAL}>{'Min $'.padEnd(12)}</Text>
-              <Box>
-                <Text color={nameRuleField === 'min' ? C_ACCENT : C_NEUTRAL}>{'[ '}</Text>
-                {nameRuleField === 'min'
-                  ? <TextInput value={newNameMinAmount} color={C_WARNING} placeholder="optional" />
-                  : <Text color={newNameMinAmount ? undefined : C_DIM}>{newNameMinAmount || '—'}</Text>}
-                <Text color={nameRuleField === 'min' ? C_ACCENT : C_NEUTRAL}>{' ]'}</Text>
-              </Box>
-            </Box>
-            <Box gap={2}>
-              <Text color={nameRuleField === 'max' ? C_ACCENT : C_NEUTRAL}>{'Max $'.padEnd(12)}</Text>
-              <Box>
-                <Text color={nameRuleField === 'max' ? C_ACCENT : C_NEUTRAL}>{'[ '}</Text>
-                {nameRuleField === 'max'
-                  ? <TextInput value={newNameMaxAmount} color={C_WARNING} placeholder="optional" />
-                  : <Text color={newNameMaxAmount ? undefined : C_DIM}>{newNameMaxAmount || '—'}</Text>}
-                <Text color={nameRuleField === 'max' ? C_ACCENT : C_NEUTRAL}>{' ]'}</Text>
-              </Box>
-            </Box>
-            <Box gap={2}>
-              <Text color={nameRuleField === 'replacement' ? C_ACCENT : C_NEUTRAL}>{'Replace with'.padEnd(12)}</Text>
-              <Box>
-                <Text color={nameRuleField === 'replacement' ? C_ACCENT : C_NEUTRAL}>{'[ '}</Text>
-                {nameRuleField === 'replacement'
-                  ? <TextInput value={newReplacement} color={C_POSITIVE} placeholder="display name" />
-                  : <Text color={newReplacement ? C_POSITIVE : C_DIM}>{newReplacement || 'empty'}</Text>}
-                <Text color={nameRuleField === 'replacement' ? C_ACCENT : C_NEUTRAL}>{' ]'}</Text>
-              </Box>
-            </Box>
+            <EditTextField label="Pattern" active={nameRuleField === 'pattern'} value={newNamePattern} color={C_WARNING} placeholder="keyword or /regex/" emptyText="empty" />
+            <EditToggleField label="Match type" active={nameRuleField === 'type'} value={newNameType} />
+            <EditTextField label="Min $" active={nameRuleField === 'min'} value={newNameMinAmount} color={C_WARNING} placeholder="optional" />
+            <EditTextField label="Max $" active={nameRuleField === 'max'} value={newNameMaxAmount} color={C_WARNING} placeholder="optional" />
+            <EditTextField label="Replace with" active={nameRuleField === 'replacement'} value={newReplacement} color={C_POSITIVE} placeholder="display name" emptyText="empty" />
           </Box>
           <Box marginTop={1}><Text dimColor>↑↓ field  ·  ← → change  ·  Enter save  ·  Esc cancel</Text></Box>
         </ModalPanel>
@@ -619,12 +541,6 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
         <ModalPanel title="New Category" borderColor={C_WARNING}>
           <Text dimColor>Type a name · Enter save · Esc cancel</Text>
           <Box marginTop={1} gap={1}><Text>Name: </Text><TextInput value={newCategoryName} color={C_WARNING} /></Box>
-        </ModalPanel>
-      )}
-      {mode === 'rename-category' && (
-        <ModalPanel title="Rename Category" borderColor={C_WARNING}>
-          <Text dimColor>Updates all transactions, rules, and hidden settings · Enter save · Esc cancel</Text>
-          <Box marginTop={1} gap={1}><Text>Name: </Text><TextInput value={renameCatInput} color={C_WARNING} /></Box>
         </ModalPanel>
       )}
     </Box>

--- a/tui/Rules.tsx
+++ b/tui/Rules.tsx
@@ -9,14 +9,15 @@ import {
 import type { Screen, TxFilter } from './App.js';
 import { truncate, Divider } from './fmt.js';
 import { handleNavKey } from './nav.js';
-import { useTerminalWidth, FLEX_COLORS, C_ACCENT, C_MANUAL, C_NEUTRAL, C_POSITIVE, C_WARNING } from './ui.js';
+import { useTerminalWidth, FLEX_COLORS, C_ACCENT, C_DIM, C_MANUAL, C_NEUTRAL, C_POSITIVE, C_WARNING } from './ui.js';
 import { useRefreshKey } from './RefreshContext.js';
 import { useSetTyping } from './TypingContext.js';
 import { ModalPanel, TextInput, SelectableRow, usePagination, useStatusMessage, ColumnHeader, PageHeader, SearchBar } from './components/index.js';
 
 type Flexibility = 'fixed' | 'flexible' | 'discretionary' | null;
 const FLEX_CYCLE: Flexibility[] = [null, 'fixed', 'flexible', 'discretionary'];
-type Mode = 'list' | 'search' | 'add-pattern' | 'add-type' | 'add-min-amount' | 'add-max-amount' | 'add-category' | 'add-name-pattern' | 'add-name-type' | 'add-name-min-amount' | 'add-name-max-amount' | 'add-name-replacement' | 'add-category-name' | 'rename-category';
+type Mode = 'list' | 'search' | 'add-pattern' | 'add-type' | 'add-min-amount' | 'add-max-amount' | 'add-category' | 'add-name-pattern' | 'add-name-type' | 'add-name-min-amount' | 'add-name-max-amount' | 'add-name-replacement' | 'add-category-name' | 'rename-category' | 'edit-category';
+type CatEditField = 'flexibility' | 'hidden';
 type Section = 'rules' | 'names' | 'categories';
 
 const SECTIONS: Section[] = ['rules', 'names', 'categories'];
@@ -55,6 +56,9 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
   // Editing
   const [editingRuleId, setEditingRuleId] = useState<number | null>(null);
   const [editingNameRuleId, setEditingNameRuleId] = useState<number | null>(null);
+
+  // Category edit panel state
+  const [catEditField, setCatEditField] = useState<CatEditField>('flexibility');
 
   // Search
   const [search, setSearch] = useState('');
@@ -224,6 +228,36 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
           load();
           setCatListCursor((c) => Math.max(0, c - 1));
         }
+        if (key.return && catDetails[catListCursor]) {
+          setCatEditField('flexibility');
+          setMode('edit-category');
+          return;
+        }
+      }
+    } else if (mode === 'edit-category') {
+      if (key.escape || key.return) { setMode('list'); return; }
+      if (key.upArrow || key.downArrow) {
+        setCatEditField((f) => f === 'flexibility' ? 'hidden' : 'flexibility');
+        return;
+      }
+      if (catEditField === 'flexibility' && (key.leftArrow || key.rightArrow)) {
+        const cat = catDetails[catListCursor];
+        if (cat) {
+          const idx = FLEX_CYCLE.indexOf(cat.flexibility);
+          const dir = key.leftArrow ? -1 : 1;
+          const next = FLEX_CYCLE[(idx + dir + FLEX_CYCLE.length) % FLEX_CYCLE.length];
+          setCategoryFlexibility(cat.name, next);
+          load();
+        }
+        return;
+      }
+      if (catEditField === 'hidden' && (input === ' ' || key.leftArrow || key.rightArrow)) {
+        const cat = catDetails[catListCursor];
+        if (cat) {
+          toggleHiddenCategory(cat.name, hiddenSet);
+          void getHiddenCategorySet().then(setHiddenSet);
+        }
+        return;
       }
     } else if (mode === 'add-pattern') {
       if (key.return) { if (newPattern) setMode('add-type'); return; }
@@ -328,7 +362,7 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
       </Box>
       <Text dimColor>
         {section === 'categories'
-          ? (showHints ? '[a] add  [n] rename  [x] delete  [v] hidden  [f] flexibility  ·  [Tab] switch' : '')
+          ? (showHints ? '[a] add  [n] rename  [x] delete  ·  Enter edit  ·  [Tab] switch' : '')
           : (showHints ? '[/] search  [a] add  [e] edit  [x] delete  ·  [Tab] switch' : '[/] search')}
       </Text>
 
@@ -451,6 +485,31 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
       )}
 
       {statusMsg && <Text color={C_POSITIVE} bold>{statusMsg}</Text>}
+
+      {mode === 'edit-category' && catDetails[catListCursor] && (() => {
+        const cat = catDetails[catListCursor];
+        const isHidden = hiddenSet.has(cat.name);
+        const flexColor = cat.flexibility ? FLEX_COLORS[cat.flexibility] : undefined;
+        return (
+          <ModalPanel title={`Edit: ${cat.name}`}>
+            <Box marginTop={1} flexDirection="column" gap={1}>
+              <Box gap={2}>
+                <Text color={catEditField === 'flexibility' ? C_ACCENT : C_NEUTRAL}>{'Flexibility'.padEnd(12)}</Text>
+                <Text color={catEditField === 'flexibility' ? C_ACCENT : (flexColor ?? C_DIM)}>
+                  {'← '}{cat.flexibility ?? '—'}{'  →'}
+                </Text>
+              </Box>
+              <Box gap={2}>
+                <Text color={catEditField === 'hidden' ? C_ACCENT : C_NEUTRAL}>{'Hidden'.padEnd(12)}</Text>
+                <Text color={catEditField === 'hidden' ? C_ACCENT : (isHidden ? C_WARNING : C_DIM)}>
+                  {isHidden ? 'yes' : 'no'}{'  (space to toggle)'}
+                </Text>
+              </Box>
+            </Box>
+            <Box marginTop={1}><Text dimColor>↑↓ field  ·  ← → change  ·  Enter/Esc close</Text></Box>
+          </ModalPanel>
+        );
+      })()}
 
       {mode === 'add-pattern' && (
         <ModalPanel title={`${editingRuleId !== null ? 'Edit' : 'New'} Rule — Pattern`}>

--- a/tui/Rules.tsx
+++ b/tui/Rules.tsx
@@ -182,7 +182,7 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
           setRuleField('pattern'); setMode('rule-form');
         }
         if (input === 'x' && filteredRules[cursor]) { handleDeleteRule(filteredRules[cursor].id); }
-        if ((input === 'e' || key.return) && filteredRules[cursor]) {
+        if (key.return && filteredRules[cursor]) {
           const r = filteredRules[cursor];
           setEditingRuleId(r.id);
           setNewPattern(r.pattern);
@@ -200,7 +200,7 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
           setNameRuleField('pattern'); setMode('name-rule-form');
         }
         if (input === 'x' && filteredNameRules[nameCursor]) { handleDeleteNameRule(filteredNameRules[nameCursor].id); }
-        if ((input === 'e' || key.return) && filteredNameRules[nameCursor]) {
+        if (key.return && filteredNameRules[nameCursor]) {
           const r = filteredNameRules[nameCursor];
           setEditingNameRuleId(r.id);
           setNewNamePattern(r.pattern);
@@ -237,7 +237,7 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
           load();
           setCatListCursor((c) => Math.max(0, c - 1));
         }
-        if ((input === 'e' || key.return) && catDetails[catListCursor]) {
+        if (key.return && catDetails[catListCursor]) {
           setRenameCatInput(categories[catListCursor] ?? '');
           setCatEditField('name');
           setMode('edit-category');
@@ -366,8 +366,8 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
       </Box>
       <Text dimColor>
         {section === 'categories'
-          ? (showHints ? '[a] add  [x] delete  ·  Enter/[e] edit  ·  [Tab] switch' : '')
-          : (showHints ? '[/] search  [a] add  [e] edit  [x] delete  ·  [Tab] switch' : '[/] search')}
+          ? (showHints ? '[a] add  [x] delete  ·  Enter edit  ·  [Tab] switch' : '')
+          : (showHints ? '[/] search  [a] add  [x] delete  ·  Enter edit  ·  [Tab] switch' : '[/] search')}
       </Text>
 
       {mode === 'search' ? (

--- a/tui/Settings.tsx
+++ b/tui/Settings.tsx
@@ -1,0 +1,240 @@
+import React, { useState, useMemo, useEffect } from 'react';
+import { Box, Text, useInput } from 'ink';
+import type { Screen } from './App.js';
+import { handleNavKey } from './nav.js';
+import { loadProfile, saveProfile, type Profile } from '../core/profile.js';
+import { C_ACCENT, C_NEUTRAL, CURSOR } from './ui.js';
+import { PageHeader, SectionHeader, SelectableRow } from './components/index.js';
+import { Divider } from './fmt.js';
+import { useSetTyping } from './TypingContext.js';
+
+const LABEL_W = 16;
+const VALUE_W = 18;
+
+type FieldRow = { kind: 'field'; id: string; label: string; value: string; numeric?: boolean };
+type ActionRow = { kind: 'action'; id: string; label: string };
+type SettingsRow = FieldRow | ActionRow;
+
+function buildRows(profile: Profile): SettingsRow[] {
+  const r: SettingsRow[] = [
+    { kind: 'field', id: 'self-name', label: 'Your name', value: profile.self.name },
+    { kind: 'field', id: 'self-year', label: 'Birth year', value: profile.self.birthYear > 0 ? String(profile.self.birthYear) : '', numeric: true },
+  ];
+  if (profile.spouse) {
+    r.push(
+      { kind: 'field', id: 'spouse-name', label: 'Spouse name', value: profile.spouse.name },
+      { kind: 'field', id: 'spouse-year', label: 'Spouse year', value: profile.spouse.birthYear > 0 ? String(profile.spouse.birthYear) : '', numeric: true },
+    );
+  } else {
+    r.push({ kind: 'action', id: 'add-spouse', label: '[a] Add spouse' });
+  }
+  for (let i = 0; i < profile.children.length; i++) {
+    const child = profile.children[i];
+    r.push(
+      { kind: 'field', id: `child-${i}-name`, label: `Child ${i + 1}`, value: child.name },
+      { kind: 'field', id: `child-${i}-year`, label: `  birth year`, value: child.birthYear > 0 ? String(child.birthYear) : '', numeric: true },
+    );
+  }
+  r.push({ kind: 'action', id: 'add-child', label: '[a] Add child' });
+  return r;
+}
+
+export function Settings({ onNavigate, isActive, showHints }: {
+  onNavigate: (s: Screen) => void;
+  isActive?: boolean;
+  showHints: boolean;
+}) {
+  const setTyping = useSetTyping();
+  const [profile, setProfile] = useState<Profile>(
+    () => loadProfile() ?? { self: { name: '', birthYear: 0 }, children: [] }
+  );
+  const [cursor, setCursor] = useState(0);
+  const [editing, setEditing] = useState(false);
+  const [editBuffer, setEditBuffer] = useState('');
+
+  useEffect(() => { setTyping(editing); }, [editing, setTyping]);
+
+  const rows = useMemo(() => buildRows(profile), [profile]);
+  const clampedCursor = Math.min(cursor, rows.length - 1);
+  const currentRow = rows[clampedCursor] as SettingsRow | undefined;
+
+  function persist(next: Profile) {
+    setProfile(next);
+    saveProfile(next);
+  }
+
+  function commitEdit() {
+    if (!currentRow || currentRow.kind !== 'field') return;
+    const row = currentRow as FieldRow;
+    const value = editBuffer.trim();
+    const next: Profile = { ...profile, children: [...profile.children] };
+
+    if (row.id === 'self-name') {
+      next.self = { ...next.self, name: value };
+    } else if (row.id === 'self-year') {
+      const y = parseInt(value);
+      if (value && !isNaN(y) && y >= 1900 && y <= 2025) next.self = { ...next.self, birthYear: y };
+    } else if (row.id === 'spouse-name' && next.spouse) {
+      next.spouse = { ...next.spouse, name: value };
+    } else if (row.id === 'spouse-year' && next.spouse) {
+      const y = parseInt(value);
+      if (value && !isNaN(y) && y >= 1900 && y <= 2025) next.spouse = { ...next.spouse, birthYear: y };
+    } else {
+      const m = row.id.match(/^child-(\d+)-(name|year)$/);
+      if (m) {
+        const idx = parseInt(m[1]);
+        const field = m[2];
+        const child = { ...next.children[idx] };
+        if (field === 'name') {
+          child.name = value;
+        } else {
+          const y = parseInt(value);
+          if (value && !isNaN(y) && y >= 1900 && y <= 2025) child.birthYear = y;
+        }
+        next.children = [...next.children.slice(0, idx), child, ...next.children.slice(idx + 1)];
+      }
+    }
+    persist(next);
+    setEditing(false);
+    setEditBuffer('');
+  }
+
+  function getChildIdx(id: string): number | null {
+    const m = id.match(/^child-(\d+)/);
+    return m ? parseInt(m[1]) : null;
+  }
+
+  useInput((input, key) => {
+    if (editing) {
+      if (key.escape) { setEditing(false); setEditBuffer(''); return; }
+      if (key.return) { commitEdit(); return; }
+      if (key.backspace || key.delete) { setEditBuffer((b) => b.slice(0, -1)); return; }
+      if (!key.ctrl && !key.meta && input) {
+        if ((currentRow as FieldRow)?.numeric) {
+          const maxLen = 4;
+          if (/^\d$/.test(input) && editBuffer.length < maxLen) setEditBuffer((b) => b + input);
+        } else {
+          setEditBuffer((b) => b + input);
+        }
+      }
+      return;
+    }
+
+    if (key.escape) { onNavigate('dashboard'); return; }
+    if (handleNavKey(input, 'settings', onNavigate)) return;
+    if (key.upArrow)   { setCursor((c) => Math.max(0, c - 1)); return; }
+    if (key.downArrow) { setCursor((c) => Math.min(rows.length - 1, c + 1)); return; }
+
+    if (key.return) {
+      if (!currentRow) return;
+      if (currentRow.kind === 'field') {
+        setEditBuffer((currentRow as FieldRow).value);
+        setEditing(true);
+      } else if (currentRow.id === 'add-spouse') {
+        persist({ ...profile, spouse: { name: '', birthYear: 0 } });
+      } else if (currentRow.id === 'add-child') {
+        persist({ ...profile, children: [...profile.children, { name: '', birthYear: 0 }] });
+      }
+      return;
+    }
+
+    if (input === 'a') {
+      if (!profile.spouse) {
+        persist({ ...profile, spouse: { name: '', birthYear: 0 } });
+      } else {
+        persist({ ...profile, children: [...profile.children, { name: '', birthYear: 0 }] });
+      }
+      return;
+    }
+
+    if (input === 'd' && currentRow) {
+      if (currentRow.id === 'spouse-name' || currentRow.id === 'spouse-year') {
+        const { spouse: _, ...rest } = profile;
+        persist({ ...rest, children: [...profile.children] } as Profile);
+        return;
+      }
+      const idx = getChildIdx(currentRow.id);
+      if (idx !== null) {
+        persist({ ...profile, children: profile.children.filter((_, i) => i !== idx) });
+        setCursor((c) => Math.max(0, c - 1));
+        return;
+      }
+    }
+  }, { isActive: isActive !== false });
+
+  function renderField(row: SettingsRow, sectionCursor: number) {
+    const isSelected = sectionCursor === clampedCursor;
+    const isEditingThis = isSelected && editing;
+    const field = row as FieldRow;
+    const displayValue = isEditingThis ? editBuffer : field.value;
+    const hint = isEditingThis
+      ? 'Enter confirm  ·  Esc cancel'
+      : isSelected
+        ? field.id.includes('spouse') ? 'Enter to edit  ·  [d] remove spouse'
+          : field.id.includes('child') ? `Enter to edit  ·  [d] remove`
+          : 'Enter to edit'
+        : '';
+    return (
+      <SelectableRow key={row.id} selected={isSelected} gap={2}>
+        <Text color={isSelected ? C_ACCENT : undefined}>{field.label.padEnd(LABEL_W)}</Text>
+        <Box>
+          <Text color={isSelected ? C_ACCENT : C_NEUTRAL}>{displayValue.padStart(VALUE_W)}</Text>
+          {isEditingThis && <Text color={C_ACCENT}>{CURSOR}</Text>}
+        </Box>
+        <Text dimColor>{hint}</Text>
+      </SelectableRow>
+    );
+  }
+
+  function renderAction(row: SettingsRow, sectionCursor: number) {
+    const isSelected = sectionCursor === clampedCursor;
+    return (
+      <SelectableRow key={row.id} selected={isSelected} gap={2}>
+        <Text color={isSelected ? C_ACCENT : undefined} dimColor={!isSelected}>{(row as ActionRow).label}</Text>
+      </SelectableRow>
+    );
+  }
+
+  return (
+    <Box flexDirection="column" paddingX={2} paddingY={1}>
+      <PageHeader current="settings" showHints={showHints} />
+      <Box marginTop={1}><Text bold>Settings</Text></Box>
+      {showHints && <Text dimColor>↑↓ navigate  ·  Enter edit  ·  [a] add  ·  [d] remove  ·  Esc back</Text>}
+      <Divider />
+
+      {/* Household section */}
+      <Box flexDirection="column" marginTop={1}>
+        <SectionHeader>HOUSEHOLD</SectionHeader>
+        {rows[0] && renderField(rows[0], 0)}
+        {rows[1] && renderField(rows[1], 1)}
+      </Box>
+
+      {/* Spouse section */}
+      <Box flexDirection="column" marginTop={1}>
+        <SectionHeader>SPOUSE</SectionHeader>
+        {profile.spouse
+          ? (
+            <>
+              {rows[2] && rows[2].id === 'spouse-name' && renderField(rows[2], 2)}
+              {rows[3] && rows[3].id === 'spouse-year' && renderField(rows[3], 3)}
+            </>
+          ) : (
+            rows[2] && rows[2].id === 'add-spouse' && renderAction(rows[2], 2)
+          )
+        }
+      </Box>
+
+      {/* Children section */}
+      <Box flexDirection="column" marginTop={1}>
+        <SectionHeader>CHILDREN</SectionHeader>
+        {profile.children.length === 0 && <Box marginTop={1}><Text dimColor>No children added.</Text></Box>}
+        {rows.map((row, i) => {
+          if (row.id === 'add-child') return renderAction(row, i);
+          if (/^child-\d+-(name|year)$/.test(row.id)) return renderField(row, i);
+          return null;
+        })}
+      </Box>
+
+    </Box>
+  );
+}

--- a/tui/Tags.tsx
+++ b/tui/Tags.tsx
@@ -55,8 +55,8 @@ export function Tags({ onNavigate, isActive, showHints, initialFilter }: { onNav
 
   const termW = useTerminalWidth();
   const inner = Math.max(60, termW) - 4;
-  // [sel=2] gap [name] gap [count text~18] — 2 gaps of 2
-  const tagNameW = Math.max(10, inner - 24);
+  // [sel=2] gap [name] gap [count=6] gap [inflow=10] gap [outflow=10] — 4 gaps of 2
+  const tagNameW = Math.max(10, inner - 36);
 
   useInput((input, key) => {
     if (mode === 'search') {
@@ -230,7 +230,9 @@ export function Tags({ onNavigate, isActive, showHints, initialFilter }: { onNav
                     <Text color={isSelected ? C_ACCENT : undefined} dimColor={!isSelected}>
                       {t.name.length > tagNameW ? t.name.slice(0, tagNameW - 1) + '…' : t.name.padEnd(tagNameW)}
                     </Text>
-                    <Text dimColor>{t.count} transaction{t.count !== 1 ? 's' : ''}</Text>
+                    <Text dimColor>{(t.count + ' tx').padEnd(6)}</Text>
+                    <Text color={C_POSITIVE} dimColor={!isSelected}>{fmt(t.inflow).padStart(10)}</Text>
+                    <Text color={C_NEGATIVE} dimColor={!isSelected}>{fmt(t.outflow).padStart(10)}</Text>
                   </SelectableRow>
                 );
               })}

--- a/tui/Transactions.tsx
+++ b/tui/Transactions.tsx
@@ -350,7 +350,7 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
       if (key.downArrow) setCursor((c) => Math.min(txs.length - 1, c + 1));
       if (input === 'u') { setSearch(''); setSearchInput(''); setCategory('Uncategorized'); setFrom(null); setTo(null); setTag(null); setAccount(null); setAccountName(null); }
       if (input === 'a') { setSearch(''); setSearchInput(''); setCategory(null); setFrom(null); setTo(null); setTag(null); setAccount(null); setAccountName(null); }
-      if ((input === 'e' || key.return) && selected) openEdit();
+      if (key.return && selected) openEdit();
       if (input === 'E' && txs.length > 0) {
         void getAllCategories().then((cats) => {
           setCategories(cats);
@@ -446,7 +446,7 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
       </Box>
       <Text dimColor>
         {showHints
-          ? `[/] search  ·  ${from ? '← →  ·  ' : ''}[s] sort  ·  Enter/[e] edit  [g] tag  [i] ignore  [x] delete`
+          ? `[/] search  ·  ${from ? '← →  ·  ' : ''}[s] sort  ·  Enter edit  [g] tag  [i] ignore  [x] delete`
           : '[/] search'}
       </Text>
 

--- a/tui/Transactions.tsx
+++ b/tui/Transactions.tsx
@@ -18,7 +18,7 @@ import type { Screen, TxFilter } from './App.js';
 import { handleNavKey } from './nav.js';
 import { Divider } from './fmt.js';
 import { useTerminalWidth, MONTHS, C_POSITIVE, C_NEGATIVE, C_WARNING, C_NEUTRAL, C_MANUAL, C_ACCENT, C_DIM } from './ui.js';
-import { ModalPanel, usePagination, TextInput, SelectableRow, useStatusMessage, PageHeader, SearchBar, EditTextField } from './components/index.js';
+import { ModalPanel, usePagination, TextInput, SelectableRow, useStatusMessage, PageHeader, SearchBar, EditTextField, EditToggleField } from './components/index.js';
 import { useRefreshKey } from './RefreshContext.js';
 import { useSetTyping } from './TypingContext.js';
 
@@ -288,13 +288,10 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
         if (key.return) { saveToTransaction(); return; }
         if (input && !key.ctrl && !key.meta) { setEditName((n) => n + input); return; }
       } else {
-        if (key.upArrow) {
-          if (editCatCursor === 0) { setEditField('name'); return; }
-          setEditCatCursor((c) => c - 1);
-          return;
-        }
-        if (key.downArrow) { setEditCatCursor((c) => Math.min(categories.length - 1, c + 1)); return; }
-        if (input === 't' || key.return) { saveToTransaction(); return; }
+        if (key.upArrow) { setEditField('name'); return; }
+        if (key.leftArrow) { setEditCatCursor((c) => Math.max(0, c - 1)); return; }
+        if (key.rightArrow) { setEditCatCursor((c) => Math.min(categories.length - 1, c + 1)); return; }
+        if (key.return) { saveToTransaction(); return; }
         if (input === 'r') {
           setEditPattern(selected?.name ?? '');
           setEditMatchType('name');
@@ -583,28 +580,11 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
           <Box marginTop={1} flexDirection="column" gap={1}>
             <EditTextField label="Name" labelWidth={10} active={editField === 'name'} value={editName} color={C_WARNING} placeholder="type new name…" emptyText="(unchanged)" />
 
-            <Box gap={2}>
-              <Text color={editField === 'category' ? C_ACCENT : C_NEUTRAL}>{'Category'.padEnd(10)}</Text>
-              {editField === 'category' ? (
-                <Box flexDirection="column">
-                  {visibleCats.map((cat, i) => {
-                    const idx = catWinStart + i;
-                    const isSel = idx === editCatCursor;
-                    return (
-                      <SelectableRow key={cat} selected={isSel}>
-                        <Text color={isSel ? C_ACCENT : undefined} dimColor={!isSel}>{cat}</Text>
-                      </SelectableRow>
-                    );
-                  })}
-                </Box>
-              ) : (
-                <Text color={C_ACCENT}>{categories[editCatCursor]}</Text>
-              )}
-            </Box>
+            <EditToggleField label="Category" labelWidth={10} active={editField === 'category'} value={categories[editCatCursor] ?? '—'} />
           </Box>
 
           <Box marginTop={1}>
-            <Text dimColor>↑↓ navigate  ·  Enter save  ·  [r] make rule  ·  Esc cancel</Text>
+            <Text dimColor>↑↓ field  ·  ← → category  ·  Enter save  ·  [r] make rule  ·  Esc cancel</Text>
           </Box>
         </ModalPanel>
       )}

--- a/tui/Transactions.tsx
+++ b/tui/Transactions.tsx
@@ -25,8 +25,8 @@ import { useSetTyping } from './TypingContext.js';
 type Tx = TxRow;
 
 
-type Mode = 'list' | 'search' | 'edit' | 'edit-rule' | 'tag' | 'tag-all' | 'edit-all';
-type EditField = 'name' | 'category';
+type Mode = 'list' | 'search' | 'edit' | 'tag' | 'tag-all' | 'edit-all';
+type EditField = 'name' | 'category' | 'pattern' | 'type';
 
 const SORT_CYCLE: SortMode[] = ['date-desc', 'date-asc', 'name-asc', 'name-desc', 'amount-desc', 'amount-asc', 'category-asc', 'category-desc'];
 
@@ -91,8 +91,8 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
 
   const setTyping = useSetTyping();
   useEffect(() => {
-    const isTextInput = mode === 'search' || mode === 'edit-rule' || mode === 'tag' || mode === 'tag-all'
-      || (mode === 'edit' && editField === 'name');
+    const isTextInput = mode === 'search' || mode === 'tag' || mode === 'tag-all'
+      || (mode === 'edit' && (editField === 'name' || editField === 'pattern'));
     setTyping(isTextInput);
   }, [mode, editField]);
 
@@ -103,6 +103,8 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
     void getAllCategories().then((cats) => {
       setCategories(cats);
       setEditName('');
+      setEditPattern('');
+      setEditMatchType('name');
       setEditCatCursor(Math.max(0, cats.indexOf(selected.category)));
       setEditField('name');
       setMode('edit');
@@ -165,7 +167,7 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
     load(search, true);
   }
 
-  function saveAsRule() {
+  async function saveAsRule() {
     if (!selected) return;
     const newCat = categories[editCatCursor];
     const newDisplay = editName.trim();
@@ -175,12 +177,12 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
     const saved: string[] = [];
 
     if (catChanged) {
-      const count = upsertCategoryRule(editPattern, editMatchType, newCat);
+      const count = await upsertCategoryRule(editPattern, editMatchType, newCat);
       saved.push(`category rule (${count} updated)`);
     }
 
     if (nameChanged) {
-      upsertNameRule(editPattern, editMatchType, newDisplay);
+      await upsertNameRule(editPattern, editMatchType, newDisplay);
       saved.push('name rule');
     }
 
@@ -281,34 +283,26 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
     }
 
     if (mode === 'edit') {
+      const EDIT_FIELDS: EditField[] = ['name', 'category', 'pattern', 'type'];
       if (key.escape) { setMode('list'); return; }
+      if (key.return) {
+        if (editPattern.trim()) { void saveAsRule(); } else { saveToTransaction(); }
+        return;
+      }
+      if (key.upArrow) { setEditField((f) => EDIT_FIELDS[Math.max(0, EDIT_FIELDS.indexOf(f) - 1)]); return; }
+      if (key.downArrow) { setEditField((f) => EDIT_FIELDS[Math.min(EDIT_FIELDS.length - 1, EDIT_FIELDS.indexOf(f) + 1)]); return; }
       if (editField === 'name') {
-        if (key.downArrow) { setEditField('category'); return; }
         if (key.backspace || key.delete) { setEditName((n) => n.slice(0, -1)); return; }
-        if (key.return) { saveToTransaction(); return; }
         if (input && !key.ctrl && !key.meta) { setEditName((n) => n + input); return; }
-      } else {
-        if (key.upArrow) { setEditField('name'); return; }
+      } else if (editField === 'category') {
         if (key.leftArrow) { setEditCatCursor((c) => Math.max(0, c - 1)); return; }
         if (key.rightArrow) { setEditCatCursor((c) => Math.min(categories.length - 1, c + 1)); return; }
-        if (key.return) { saveToTransaction(); return; }
-        if (input === 'r') {
-          setEditPattern(selected?.name ?? '');
-          setEditMatchType('name');
-          setMode('edit-rule');
-          return;
-        }
+      } else if (editField === 'pattern') {
+        if (key.backspace || key.delete) { setEditPattern((p) => p.slice(0, -1)); return; }
+        if (input && !key.ctrl && !key.meta) { setEditPattern((p) => p + input); return; }
+      } else if (editField === 'type') {
+        if (key.leftArrow || key.rightArrow) { setEditMatchType((t) => t === 'name' ? 'regex' : 'name'); return; }
       }
-      return;
-    }
-
-    if (mode === 'edit-rule') {
-      if (key.escape) { setMode('edit'); return; }
-      if (input === 'n') { setEditMatchType('name'); return; }
-      if (input === 'x') { setEditMatchType('regex'); return; }
-      if (key.return) { saveAsRule(); return; }
-      if (key.backspace || key.delete) { setEditPattern((p) => p.slice(0, -1)); return; }
-      if (input && !key.ctrl && !key.meta) { setEditPattern((p) => p + input); return; }
       return;
     }
 
@@ -423,8 +417,15 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
   const catWinStart = Math.max(0, Math.min(editCatCursor - Math.floor(CAT_WIN / 2), categories.length - CAT_WIN));
   const visibleCats = categories.slice(catWinStart, catWinStart + CAT_WIN);
 
-  // Live match count for rule panel
-  const matchCount = mode === 'edit-rule' ? countPatternMatches(editPattern, editMatchType) : 0;
+  // Live match count when a rule pattern is typed
+  const [matchCount, setMatchCount] = useState(0);
+  useEffect(() => {
+    if (mode === 'edit' && editPattern.trim()) {
+      void countPatternMatches(editPattern, editMatchType).then(setMatchCount);
+    } else {
+      setMatchCount(0);
+    }
+  }, [mode, editPattern, editMatchType]);
 
   return (
     <Box flexDirection="column" paddingX={2} paddingY={1}>
@@ -574,41 +575,26 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
       )}
 
       {mode === 'edit' && selected && (
-        <ModalPanel>
+        <ModalPanel borderColor={editPattern.trim() ? C_MANUAL : undefined}>
           <Text bold>Edit  <Text dimColor>{selected.name}</Text></Text>
 
           <Box marginTop={1} flexDirection="column" gap={1}>
-            <EditTextField label="Name" labelWidth={10} active={editField === 'name'} value={editName} color={C_WARNING} placeholder="type new name…" emptyText="(unchanged)" />
-
-            <EditToggleField label="Category" labelWidth={10} active={editField === 'category'} value={categories[editCatCursor] ?? '—'} />
+            <EditTextField label="Name" labelWidth={12} active={editField === 'name'} value={editName} color={C_WARNING} placeholder="type new name…" emptyText="(unchanged)" />
+            <EditToggleField label="Category" labelWidth={12} active={editField === 'category'} value={categories[editCatCursor] ?? '—'} />
+            <EditTextField label="Pattern" labelWidth={12} active={editField === 'pattern'} value={editPattern} color={C_MANUAL} placeholder="optional — saves as rule" emptyText="—" />
+            <EditToggleField label="Match type" labelWidth={12} active={editField === 'type'} value={editMatchType} />
           </Box>
+
+          {editPattern.trim() ? (
+            <Box marginTop={1} gap={2}>
+              <Text color={C_WARNING}>{matchCount} transactions match</Text>
+              <Text dimColor>· Enter saves as rule</Text>
+            </Box>
+          ) : null}
 
           <Box marginTop={1}>
-            <Text dimColor>↑↓ field  ·  ← → category  ·  Enter save  ·  [r] make rule  ·  Esc cancel</Text>
+            <Text dimColor>↑↓ field  ·  ← → change  ·  Enter save  ·  Esc cancel</Text>
           </Box>
-        </ModalPanel>
-      )}
-
-      {mode === 'edit-rule' && selected && (
-        <ModalPanel borderColor={C_MANUAL}>
-          <Text bold>Make Rule</Text>
-          {categories[editCatCursor] !== selected.category && (
-            <Text dimColor>Category: <Text color={C_NEGATIVE}>{selected.category}</Text> → <Text color={C_ACCENT}>{categories[editCatCursor]}</Text></Text>
-          )}
-          {editName.trim().length > 0 && (
-            <Text dimColor>Name: <Text color={C_POSITIVE}>{editName}</Text></Text>
-          )}
-
-          <Box gap={2} marginTop={1}>
-            <Text>Pattern </Text>
-            <TextInput value={editPattern} color={C_MANUAL} />
-          </Box>
-          <Box gap={3} marginTop={1}>
-            <Text color={editMatchType === 'name' ? C_NEUTRAL : undefined} dimColor={editMatchType !== 'name'}>[n] name</Text>
-            <Text color={editMatchType === 'regex' ? C_NEUTRAL : undefined} dimColor={editMatchType !== 'regex'}>[x] regex</Text>
-            <Text color={C_WARNING}>{matchCount} transactions match</Text>
-          </Box>
-          <Box marginTop={1}><Text dimColor>Enter save  ·  Esc back</Text></Box>
         </ModalPanel>
       )}
     </Box>

--- a/tui/Transactions.tsx
+++ b/tui/Transactions.tsx
@@ -18,7 +18,7 @@ import type { Screen, TxFilter } from './App.js';
 import { handleNavKey } from './nav.js';
 import { Divider } from './fmt.js';
 import { useTerminalWidth, MONTHS, C_POSITIVE, C_NEGATIVE, C_WARNING, C_NEUTRAL, C_MANUAL, C_ACCENT, C_DIM } from './ui.js';
-import { ModalPanel, usePagination, TextInput, SelectableRow, useStatusMessage, PageHeader, SearchBar } from './components/index.js';
+import { ModalPanel, usePagination, TextInput, SelectableRow, useStatusMessage, PageHeader, SearchBar, EditTextField } from './components/index.js';
 import { useRefreshKey } from './RefreshContext.js';
 import { useSetTyping } from './TypingContext.js';
 
@@ -283,13 +283,16 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
     if (mode === 'edit') {
       if (key.escape) { setMode('list'); return; }
       if (editField === 'name') {
-        if (key.return || key.rightArrow) { setEditField('category'); return; }
-        if (key.leftArrow) { return; }
+        if (key.downArrow) { setEditField('category'); return; }
         if (key.backspace || key.delete) { setEditName((n) => n.slice(0, -1)); return; }
+        if (key.return) { saveToTransaction(); return; }
         if (input && !key.ctrl && !key.meta) { setEditName((n) => n + input); return; }
       } else {
-        if (key.leftArrow) { setEditField('name'); return; }
-        if (key.upArrow) { setEditCatCursor((c) => Math.max(0, c - 1)); return; }
+        if (key.upArrow) {
+          if (editCatCursor === 0) { setEditField('name'); return; }
+          setEditCatCursor((c) => c - 1);
+          return;
+        }
         if (key.downArrow) { setEditCatCursor((c) => Math.min(categories.length - 1, c + 1)); return; }
         if (input === 't' || key.return) { saveToTransaction(); return; }
         if (input === 'r') {
@@ -577,17 +580,11 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
         <ModalPanel>
           <Text bold>Edit  <Text dimColor>{selected.name}</Text></Text>
 
-          <Box marginTop={1} gap={3}>
-            <Box flexDirection="column">
-              <Text color={editField === 'name' ? C_ACCENT : C_DIM} bold>Name</Text>
-              {editField === 'name'
-                ? <TextInput value={editName} color={C_WARNING} placeholder="type new name…" />
-                : <Text dimColor>{editName || '(unchanged)'}</Text>
-              }
-            </Box>
+          <Box marginTop={1} flexDirection="column" gap={1}>
+            <EditTextField label="Name" labelWidth={10} active={editField === 'name'} value={editName} color={C_WARNING} placeholder="type new name…" emptyText="(unchanged)" />
 
-            <Box flexDirection="column">
-              <Text color={editField === 'category' ? C_ACCENT : C_DIM} bold>Category</Text>
+            <Box gap={2}>
+              <Text color={editField === 'category' ? C_ACCENT : C_NEUTRAL}>{'Category'.padEnd(10)}</Text>
               {editField === 'category' ? (
                 <Box flexDirection="column">
                   {visibleCats.map((cat, i) => {
@@ -606,11 +603,8 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
             </Box>
           </Box>
 
-          <Box marginTop={1} gap={3}>
-            {editField === 'name'
-              ? <Text dimColor>Enter / → to pick category  ·  Esc cancel</Text>
-              : <><Text color={C_ACCENT}>[t] / Enter  this transaction</Text><Text color={C_ACCENT}>[r] make rule</Text><Text dimColor>← name  ·  Esc cancel</Text></>
-            }
+          <Box marginTop={1}>
+            <Text dimColor>↑↓ navigate  ·  Enter save  ·  [r] make rule  ·  Esc cancel</Text>
           </Box>
         </ModalPanel>
       )}

--- a/tui/Transactions.tsx
+++ b/tui/Transactions.tsx
@@ -347,7 +347,7 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
       if (key.downArrow) setCursor((c) => Math.min(txs.length - 1, c + 1));
       if (input === 'u') { setSearch(''); setSearchInput(''); setCategory('Uncategorized'); setFrom(null); setTo(null); setTag(null); setAccount(null); setAccountName(null); }
       if (input === 'a') { setSearch(''); setSearchInput(''); setCategory(null); setFrom(null); setTo(null); setTag(null); setAccount(null); setAccountName(null); }
-      if (input === 'e' && selected) openEdit();
+      if ((input === 'e' || key.return) && selected) openEdit();
       if (input === 'E' && txs.length > 0) {
         void getAllCategories().then((cats) => {
           setCategories(cats);
@@ -443,7 +443,7 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
       </Box>
       <Text dimColor>
         {showHints
-          ? `[/] search  ·  ${from ? '← →  ·  ' : ''}[s] sort  ·  [e] edit  [g] tag  [i] ignore  [x] delete`
+          ? `[/] search  ·  ${from ? '← →  ·  ' : ''}[s] sort  ·  Enter/[e] edit  [g] tag  [i] ignore  [x] delete`
           : '[/] search'}
       </Text>
 

--- a/tui/Trends.tsx
+++ b/tui/Trends.tsx
@@ -1,12 +1,12 @@
 import React, { useState, useEffect } from 'react';
 import { Box, Text, useInput } from 'ink';
 import { type TrendsRange } from '../core/dateUtils.js';
-import { buildTrendViews, generateAllPeriods, getPeriodTotals, getSearchMatchingPeriods, type View, type PeriodRow } from '../core/trends.js';
+import { buildTrendViews, generateAllPeriods, getPeriodTotals, getSearchMatchingPeriods, getSearchPeriodTotals, type View, type PeriodRow } from '../core/trends.js';
 import type { Screen, TxFilter } from './App.js';
 import { fmt, fmtSigned, bar, Divider } from './fmt.js';
 import { handleNavKey } from './nav.js';
 import { useTerminalWidth, FLEX_COLORS, C_POSITIVE, C_NEGATIVE, C_NEUTRAL, C_ACCENT } from './ui.js';
-import { StatCard, usePagination, SelectableRow, PageHeader, SearchBar } from './components/index.js';
+import { StatCard, usePagination, SelectableRow, PageHeader, TextInput } from './components/index.js';
 import { useRefreshKey } from './RefreshContext.js';
 import { useSetTyping } from './TypingContext.js';
 
@@ -48,11 +48,11 @@ export function Trends({
     return (r && (TRENDS_RANGES as string[]).includes(r)) ? r as TrendsRange : 'month';
   });
   const [rows, setRows] = useState<PeriodRow[]>([]);
+  const [searchRows, setSearchRows] = useState<PeriodRow[]>([]);
   const [cursor, setCursor] = useState(0);
   const [search, setSearch] = useState(initialFilter?.search ?? '');
   const [searchInput, setSearchInput] = useState(initialFilter?.search ?? '');
   const [searchMode, setSearchMode] = useState(false);
-  const [matchingPeriods, setMatchingPeriods] = useState<Set<string> | null>(null);
   const [matchCount, setMatchCount] = useState<number | null>(null);
   const setTyping = useSetTyping();
   useEffect(() => { setTyping(searchMode); }, [searchMode, setTyping]);
@@ -80,16 +80,23 @@ export function Trends({
     });
   }, [viewIdx, range, views, refreshKey]);
 
+  // Live match count while typing; committed search rows
+  const liveSearch = searchMode ? searchInput : search;
   useEffect(() => {
-    if (!search) { setMatchingPeriods(null); setMatchCount(null); return; }
-    void getSearchMatchingPeriods(search, range).then(({ periods, count }) => {
-      setMatchingPeriods(periods);
-      setMatchCount(count);
+    if (!liveSearch) { setMatchCount(null); return; }
+    void getSearchMatchingPeriods(liveSearch, range).then(({ count }) => setMatchCount(count));
+  }, [liveSearch, range]);
+
+  useEffect(() => {
+    if (!search) { setSearchRows([]); return; }
+    void getSearchPeriodTotals(search, range).then((data) => {
+      setSearchRows(data);
+      setCursor(Math.max(0, data.length - 1));
     });
   }, [search, range]);
 
-  const displayRows = matchingPeriods ? rows.filter((r) => matchingPeriods.has(r.from)) : rows;
-  const clampedCursor = displayRows.length > 0 ? Math.min(cursor, displayRows.length - 1) : 0;
+  const activeRows = search ? searchRows : rows;
+  const clampedCursor = activeRows.length > 0 ? Math.min(cursor, activeRows.length - 1) : 0;
 
   useInput((input, key) => {
     if (searchMode) {
@@ -107,47 +114,61 @@ export function Trends({
     }
     if (input === '1') { onNavigate('dashboard', search ? { search } : undefined); return; }
     if (input === '2') {
-      const row = displayRows[clampedCursor];
+      const row = activeRows[clampedCursor];
       onNavigate('transactions', {
         ...(row ? { from: row.from, to: row.to } : {}),
-        ...(view.category ? { category: view.category } : {}),
+        ...(!search && view.category ? { category: view.category } : {}),
         ...(search ? { search } : {}),
       });
       return;
     }
     if (handleNavKey(input, 'trends', onNavigate)) return;
-    if (key.leftArrow)  { setViewIdx((i) => (i - 1 + views.length) % views.length); return; }
-    if (key.rightArrow) { setViewIdx((i) => (i + 1) % views.length); return; }
+    if (!search) {
+      if (key.leftArrow)  { setViewIdx((i) => (i - 1 + views.length) % views.length); return; }
+      if (key.rightArrow) { setViewIdx((i) => (i + 1) % views.length); return; }
+    }
     if (key.upArrow)   { setCursor((c) => Math.max(0, c - 1)); return; }
-    if (key.downArrow) { setCursor((c) => Math.min(displayRows.length - 1, c + 1)); return; }
+    if (key.downArrow) { setCursor((c) => Math.min(activeRows.length - 1, c + 1)); return; }
     if (input === 'r') {
       setRange((r) => TRENDS_RANGES[(TRENDS_RANGES.indexOf(r) + 1) % TRENDS_RANGES.length]);
       return;
     }
     if (key.return) {
-      const row = displayRows[clampedCursor];
-      if (row) onNavigate('transactions', { category: view.category ?? undefined, from: row.from, to: row.to, ...(search ? { search } : {}) });
+      const row = activeRows[clampedCursor];
+      if (row) onNavigate('transactions', {
+        ...(!search && view.category ? { category: view.category } : {}),
+        from: row.from, to: row.to,
+        ...(search ? { search } : {}),
+      });
     }
   }, { isActive: isActive !== false });
 
   const PAGE = 30;
-  const { visible, pageStart } = usePagination(displayRows, clampedCursor, PAGE);
+  const { visible, pageStart } = usePagination(activeRows, clampedCursor, PAGE);
+
+  // Search view: net-style with only matching transaction amounts
+  const searchIncome   = search ? searchRows.reduce((s, r) => s + (r.income   ?? 0), 0) : 0;
+  const searchExpenses = search ? searchRows.reduce((s, r) => s + (r.expenses ?? 0), 0) : 0;
+  const searchHasBoth  = searchIncome > 0 && searchExpenses > 0;
+  const searchIncomeOnly = searchIncome > 0 && searchExpenses === 0;
 
   // Scale maxes
-  const maxIncome   = isNet ? Math.max(...displayRows.map((r) => r.income   ?? 0), 1) : 1;
-  const maxExpenses = isNet ? Math.max(...displayRows.map((r) => r.expenses ?? 0), 1) : 1;
+  const maxIncome   = (isNet || search) ? Math.max(...activeRows.map((r) => r.income   ?? 0), 1) : 1;
+  const maxExpenses = (isNet || search) ? Math.max(...activeRows.map((r) => r.expenses ?? 0), 1) : 1;
   const netMax = Math.max(maxIncome, maxExpenses);
 
-  const flexMax = isFlexBreakdown
-    ? Math.max(...displayRows.flatMap((r) => [r.fixed ?? 0, r.flexible ?? 0, r.discretionary ?? 0]), 1)
+  const isFlexView = isFlexBreakdown && !search;
+  const flexMax = isFlexView
+    ? Math.max(...activeRows.flatMap((r) => [r.fixed ?? 0, r.flexible ?? 0, r.discretionary ?? 0]), 1)
     : 1;
 
-  const absMax = isNet          ? netMax
-               : isFlexBreakdown ? flexMax
-               : Math.max(...displayRows.map((r) => Math.abs(r.total)), 1);
+  const isNetView = (isNet || search) && !isFlexView;
+  const absMax = isNetView        ? netMax
+               : isFlexView       ? flexMax
+               : Math.max(...activeRows.map((r) => Math.abs(r.total)), 1);
 
-  const avg  = displayRows.length ? displayRows.reduce((s, r) => s + r.total, 0) / displayRows.length : 0;
-  const peak = displayRows.reduce((best, r) => Math.abs(r.total) > Math.abs(best?.total ?? 0) ? r : best, displayRows[0]);
+  const avg  = activeRows.length ? activeRows.reduce((s, r) => s + r.total, 0) / activeRows.length : 0;
+  const peak = activeRows.reduce((best, r) => Math.abs(r.total) > Math.abs(best?.total ?? 0) ? r : best, activeRows[0]);
 
   const labelWidth = range === 'week' ? 22 : range === 'month' ? 10 : range === 'quarter' ? 8 : 6;
   const color = viewColor(view);
@@ -155,12 +176,9 @@ export function Trends({
 
   const termW = useTerminalWidth();
   const inner = Math.max(70, termW) - 4;
-  const rowBase = 2 + labelWidth; // selector + label
-  // Regular: [rowBase] gap [total=13] gap [bar] — 2 gaps of 2
+  const rowBase = 2 + labelWidth;
   const BAR_WIDTH = Math.max(8, inner - rowBase - 13 - 4);
-  // Net: [rowBase] gap [net=13] gap [leftBar] gap [|=1] gap [rightBar] — 4 gaps of 1, |=1
   const HALF_BAR = Math.max(6, Math.floor((inner - rowBase - 13 - 4 - 1) / 2));
-  // Flex: [rowBase] gap [total=13] gap [bar1] gap [bar2] gap [bar3] — 4 gaps of 2
   const FLEX_BAR = Math.max(5, Math.floor((inner - rowBase - 13 - 8) / 3));
 
   return (
@@ -169,7 +187,10 @@ export function Trends({
 
       <Box justifyContent="space-between" marginTop={1}>
         <Text bold>Trends</Text>
-        <Text dimColor>{showHints ? (searchMode ? 'type · Enter apply · Esc cancel' : '←→ view  ·  ↑↓ navigate  ·  [r] range  ·  [/] search  ·  Enter txns') : '[/] search'}</Text>
+        <Text dimColor>{showHints
+          ? (searchMode ? '' : search ? '↑↓ navigate  ·  [r] range  ·  [/] search  ·  Enter txns' : '←→ view  ·  ↑↓ navigate  ·  [r] range  ·  [/] search  ·  Enter txns')
+          : '[/] search'}
+        </Text>
       </Box>
 
       <Box justifyContent="space-between" marginTop={1}>
@@ -181,25 +202,35 @@ export function Trends({
           ))}
           {showHints && <Text dimColor>[r]</Text>}
         </Box>
-        <Text><Text dimColor>← </Text><Text bold>{view.label}</Text><Text dimColor> →  {posLabel}</Text></Text>
+        {!search && (
+          <Text><Text dimColor>← </Text><Text bold>{view.label}</Text><Text dimColor> →  {posLabel}</Text></Text>
+        )}
       </Box>
 
-      {searchMode && <SearchBar value={searchInput} hint="Enter apply · Esc cancel" />}
-      {!searchMode && search && (
+      {(searchMode || search) && (
         <Box gap={2} marginTop={1}>
-          <Text color={C_ACCENT}>/{search}</Text>
-          {matchCount !== null && <Text dimColor>{matchCount} {matchCount === 1 ? 'txn' : 'txns'}  ·  {displayRows.length} of {rows.length} periods</Text>}
-          {showHints && <Text dimColor>[ESC] clear  [/] edit</Text>}
+          <Text color={C_ACCENT}>/</Text>
+          {searchMode
+            ? <TextInput value={searchInput} />
+            : <Text color={C_ACCENT}>{search}</Text>}
+          {matchCount !== null && (
+            <Text dimColor>
+              {matchCount} {matchCount === 1 ? 'txn' : 'txns'}
+              {!searchMode && searchRows.length > 0 && `  ·  ${searchRows.length} periods`}
+            </Text>
+          )}
+          {!searchMode && search && showHints && <Text dimColor>[ESC] clear  [/] edit</Text>}
+          {searchMode && showHints && <Text dimColor>[Enter] apply  [ESC] cancel</Text>}
         </Box>
       )}
       <Divider />
 
-      {displayRows.length === 0 ? (
+      {activeRows.length === 0 ? (
         <Box marginTop={1}><Text dimColor>{rows.length === 0 ? 'No data.' : 'No periods match the search.'}</Text></Box>
       ) : (
         <>
           <Box flexDirection="column" marginTop={1}>
-            {isNet && (
+            {(isNetView && (isNet || searchHasBoth || (!searchIncomeOnly && search))) && (
               <Box marginBottom={1}>
                 <Text>{'  '}</Text>
                 <Box gap={1}>
@@ -211,7 +242,7 @@ export function Trends({
                 </Box>
               </Box>
             )}
-            {isFlexBreakdown && (
+            {isFlexView && (
               <Box marginBottom={1}>
                 <Text>{'  '}</Text>
                 <Box gap={2}>
@@ -224,9 +255,10 @@ export function Trends({
               </Box>
             )}
             {visible.map((row, i) => {
-              const isSelected = displayRows[pageStart + i] === displayRows[clampedCursor];
+              const isSelected = activeRows[pageStart + i] === activeRows[clampedCursor];
 
-              if (isNet && row.income !== undefined && row.expenses !== undefined) {
+              // Net view or search view with both sides
+              if (isNetView && row.income !== undefined && row.expenses !== undefined && (isNet || searchHasBoth || (!searchIncomeOnly && search))) {
                 const expFilled = Math.min(HALF_BAR, Math.max(0, Math.round((row.expenses / netMax) * HALF_BAR)));
                 const incFilled = Math.min(HALF_BAR, Math.max(0, Math.round((row.income  / netMax) * HALF_BAR)));
                 const leftBar  = '░'.repeat(HALF_BAR - expFilled) + '█'.repeat(expFilled);
@@ -245,7 +277,23 @@ export function Trends({
                 );
               }
 
-              if (isFlexBreakdown) {
+              // Search view — income only or expenses only
+              if (search && !isFlexView) {
+                const searchColor = searchIncomeOnly ? C_POSITIVE : C_NEGATIVE;
+                return (
+                  <SelectableRow key={row.from} selected={isSelected}>
+                    <Text color={isSelected ? C_ACCENT : undefined}>{row.label.padEnd(labelWidth)}</Text>
+                    <Text color={isSelected ? C_NEUTRAL : undefined} dimColor={!isSelected}>
+                      {fmt(Math.abs(row.total)).padStart(13)}
+                    </Text>
+                    <Text color={searchColor} dimColor={!isSelected}>
+                      {bar(Math.abs(row.total), absMax, BAR_WIDTH)}
+                    </Text>
+                  </SelectableRow>
+                );
+              }
+
+              if (isFlexView) {
                 const fixedF = Math.min(FLEX_BAR, Math.max(0, Math.round(((row.fixed ?? 0) / flexMax) * FLEX_BAR)));
                 const flexF  = Math.min(FLEX_BAR, Math.max(0, Math.round(((row.flexible ?? 0) / flexMax) * FLEX_BAR)));
                 const discrF = Math.min(FLEX_BAR, Math.max(0, Math.round(((row.discretionary ?? 0) / flexMax) * FLEX_BAR)));
@@ -278,16 +326,16 @@ export function Trends({
 
           <Box marginTop={1}><Divider /></Box>
           <Box gap={6} marginTop={1}>
-            <StatCard label="periods" value={String(displayRows.length)} />
+            <StatCard label="periods" value={String(activeRows.length)} />
             <StatCard
               label={`avg/${RANGE_LABELS[range].toLowerCase()}`}
-              value={isNet ? fmtSigned(avg) : fmt(avg)}
-              color={isNet ? (avg >= 0 ? C_POSITIVE : C_NEGATIVE) : undefined}
+              value={isNetView ? fmtSigned(avg) : fmt(avg)}
+              color={isNetView ? (avg >= 0 ? C_POSITIVE : C_NEGATIVE) : undefined}
             />
             {peak && peak.total > 0 && (
               <StatCard
                 label="peak"
-                value={<>{peak.label}{' '}<Text dimColor>{isNet ? fmtSigned(peak.total) : fmt(peak.total)}</Text></>}
+                value={<>{peak.label}{' '}<Text dimColor>{isNetView ? fmtSigned(peak.total) : fmt(peak.total)}</Text></>}
               />
             )}
           </Box>

--- a/tui/Trends.tsx
+++ b/tui/Trends.tsx
@@ -50,8 +50,10 @@ export function Trends({
   const [rows, setRows] = useState<PeriodRow[]>([]);
   const [cursor, setCursor] = useState(0);
   const [search, setSearch] = useState(initialFilter?.search ?? '');
+  const [searchInput, setSearchInput] = useState(initialFilter?.search ?? '');
   const [searchMode, setSearchMode] = useState(false);
   const [matchingPeriods, setMatchingPeriods] = useState<Set<string> | null>(null);
+  const [matchCount, setMatchCount] = useState<number | null>(null);
   const setTyping = useSetTyping();
   useEffect(() => { setTyping(searchMode); }, [searchMode, setTyping]);
 
@@ -79,8 +81,11 @@ export function Trends({
   }, [viewIdx, range, views, refreshKey]);
 
   useEffect(() => {
-    if (!search) { setMatchingPeriods(null); return; }
-    void getSearchMatchingPeriods(search, range).then(setMatchingPeriods);
+    if (!search) { setMatchingPeriods(null); setMatchCount(null); return; }
+    void getSearchMatchingPeriods(search, range).then(({ periods, count }) => {
+      setMatchingPeriods(periods);
+      setMatchCount(count);
+    });
   }, [search, range]);
 
   const displayRows = matchingPeriods ? rows.filter((r) => matchingPeriods.has(r.from)) : rows;
@@ -88,13 +93,18 @@ export function Trends({
 
   useInput((input, key) => {
     if (searchMode) {
-      if (key.escape || key.return) { setSearchMode(false); return; }
-      if (key.backspace || key.delete) { setSearch((s) => s.slice(0, -1)); return; }
-      if (input && !key.ctrl && !key.meta) { setSearch((s) => s + input); return; }
+      if (key.escape) { setSearchInput(search); setSearchMode(false); return; }
+      if (key.return) { setSearch(searchInput); setSearchMode(false); return; }
+      if (key.backspace || key.delete) { setSearchInput((s) => s.slice(0, -1)); return; }
+      if (input && !key.ctrl && !key.meta) { setSearchInput((s) => s + input); return; }
       return;
     }
-    if (input === '/') { setSearchMode(true); return; }
-    if (key.escape) { onNavigate('dashboard', search ? { search } : undefined); return; }
+    if (input === '/') { setSearchInput(search); setSearchMode(true); return; }
+    if (key.escape) {
+      if (search) { setSearch(''); setSearchInput(''); return; }
+      onNavigate('dashboard');
+      return;
+    }
     if (input === '1') { onNavigate('dashboard', search ? { search } : undefined); return; }
     if (input === '2') {
       const row = displayRows[clampedCursor];
@@ -159,7 +169,7 @@ export function Trends({
 
       <Box justifyContent="space-between" marginTop={1}>
         <Text bold>Trends</Text>
-        {showHints && <Text dimColor>{searchMode ? 'type · Enter/Esc done' : '←→ view  ·  ↑↓ navigate  ·  [r] range  ·  [/] search  ·  Enter txns'}</Text>}
+        <Text dimColor>{showHints ? (searchMode ? 'type · Enter apply · Esc cancel' : '←→ view  ·  ↑↓ navigate  ·  [r] range  ·  [/] search  ·  Enter txns') : '[/] search'}</Text>
       </Box>
 
       <Box justifyContent="space-between" marginTop={1}>
@@ -173,12 +183,13 @@ export function Trends({
         </Box>
         <Text><Text dimColor>← </Text><Text bold>{view.label}</Text><Text dimColor> →  {posLabel}</Text></Text>
       </Box>
-      {searchMode && <SearchBar value={search} hint="Enter/Esc done" />}
+
+      {searchMode && <SearchBar value={searchInput} hint="Enter apply · Esc cancel" />}
       {!searchMode && search && (
-        <Box gap={1} marginTop={1}>
-          <Text color={C_ACCENT}>/</Text>
-          <Text color={C_NEUTRAL}>{search}</Text>
-          {matchingPeriods && <Text dimColor>  {displayRows.length} of {rows.length} periods</Text>}
+        <Box gap={2} marginTop={1}>
+          <Text color={C_ACCENT}>/{search}</Text>
+          {matchCount !== null && <Text dimColor>{matchCount} {matchCount === 1 ? 'txn' : 'txns'}  ·  {displayRows.length} of {rows.length} periods</Text>}
+          {showHints && <Text dimColor>[ESC] clear  [/] edit</Text>}
         </Box>
       )}
       <Divider />

--- a/tui/Trends.tsx
+++ b/tui/Trends.tsx
@@ -5,8 +5,8 @@ import { buildTrendViews, generateAllPeriods, getPeriodTotals, getSearchMatching
 import type { Screen, TxFilter } from './App.js';
 import { fmt, fmtSigned, bar, Divider } from './fmt.js';
 import { handleNavKey } from './nav.js';
-import { useTerminalWidth, FLEX_COLORS, C_POSITIVE, C_NEGATIVE, C_NEUTRAL, C_ACCENT, CURSOR } from './ui.js';
-import { StatCard, usePagination, SelectableRow, PageHeader } from './components/index.js';
+import { useTerminalWidth, FLEX_COLORS, C_POSITIVE, C_NEGATIVE, C_NEUTRAL, C_ACCENT } from './ui.js';
+import { StatCard, usePagination, SelectableRow, PageHeader, SearchBar } from './components/index.js';
 import { useRefreshKey } from './RefreshContext.js';
 import { useSetTyping } from './TypingContext.js';
 
@@ -158,15 +158,7 @@ export function Trends({
       <PageHeader current="trends" showHints={showHints} />
 
       <Box justifyContent="space-between" marginTop={1}>
-        <Box gap={2}>
-          <Text bold>Trends</Text>
-          {searchMode
-            ? <Text color={C_ACCENT}>/ {search}{CURSOR}</Text>
-            : search
-              ? <Text color={C_ACCENT}>/ {search}{matchingPeriods ? ` (${displayRows.length} of ${rows.length})` : ''}</Text>
-              : null
-          }
-        </Box>
+        <Text bold>Trends</Text>
         {showHints && <Text dimColor>{searchMode ? 'type · Enter/Esc done' : '←→ view  ·  ↑↓ navigate  ·  [r] range  ·  [/] search  ·  Enter txns'}</Text>}
       </Box>
 
@@ -181,6 +173,14 @@ export function Trends({
         </Box>
         <Text><Text dimColor>← </Text><Text bold>{view.label}</Text><Text dimColor> →  {posLabel}</Text></Text>
       </Box>
+      {searchMode && <SearchBar value={search} hint="Enter/Esc done" />}
+      {!searchMode && search && (
+        <Box gap={1} marginTop={1}>
+          <Text color={C_ACCENT}>/</Text>
+          <Text color={C_NEUTRAL}>{search}</Text>
+          {matchingPeriods && <Text dimColor>  {displayRows.length} of {rows.length} periods</Text>}
+        </Box>
+      )}
       <Divider />
 
       {displayRows.length === 0 ? (

--- a/tui/Trends.tsx
+++ b/tui/Trends.tsx
@@ -185,13 +185,11 @@ export function Trends({
     <Box flexDirection="column" paddingX={2} paddingY={1}>
       <PageHeader current="trends" showHints={showHints} />
 
-      <Box justifyContent="space-between" marginTop={1}>
-        <Text bold>Trends</Text>
-        <Text dimColor>{showHints
-          ? (searchMode ? '' : search ? '↑↓ navigate  ·  [r] range  ·  [/] search  ·  Enter txns' : '←→ view  ·  ↑↓ navigate  ·  [r] range  ·  [/] search  ·  Enter txns')
-          : '[/] search'}
-        </Text>
-      </Box>
+      <Box marginTop={1}><Text bold>Trends</Text></Box>
+      <Text dimColor>{showHints
+        ? (searchMode ? '' : search ? '↑↓ navigate  ·  [r] range  ·  [/] search  ·  Enter txns' : '←→ view  ·  ↑↓ navigate  ·  [r] range  ·  [/] search  ·  Enter txns')
+        : '[/] search'}
+      </Text>
 
       <Box justifyContent="space-between" marginTop={1}>
         <Box gap={2}>

--- a/tui/Trends.tsx
+++ b/tui/Trends.tsx
@@ -1,13 +1,14 @@
 import React, { useState, useEffect } from 'react';
 import { Box, Text, useInput } from 'ink';
 import { type TrendsRange } from '../core/dateUtils.js';
-import { buildTrendViews, generateAllPeriods, getPeriodTotals, type View, type PeriodRow } from '../core/trends.js';
+import { buildTrendViews, generateAllPeriods, getPeriodTotals, getSearchMatchingPeriods, type View, type PeriodRow } from '../core/trends.js';
 import type { Screen, TxFilter } from './App.js';
 import { fmt, fmtSigned, bar, Divider } from './fmt.js';
 import { handleNavKey } from './nav.js';
-import { useTerminalWidth, FLEX_COLORS, C_POSITIVE, C_NEGATIVE, C_NEUTRAL, C_ACCENT } from './ui.js';
+import { useTerminalWidth, FLEX_COLORS, C_POSITIVE, C_NEGATIVE, C_NEUTRAL, C_ACCENT, CURSOR } from './ui.js';
 import { StatCard, usePagination, SelectableRow, PageHeader } from './components/index.js';
 import { useRefreshKey } from './RefreshContext.js';
+import { useSetTyping } from './TypingContext.js';
 
 const TRENDS_RANGES: TrendsRange[] = ['week', 'month', 'quarter', 'year'];
 const RANGE_LABELS: Record<TrendsRange, string> = { week: 'Week', month: 'Month', quarter: 'Quarter', year: 'Year' };
@@ -48,6 +49,11 @@ export function Trends({
   });
   const [rows, setRows] = useState<PeriodRow[]>([]);
   const [cursor, setCursor] = useState(0);
+  const [search, setSearch] = useState(initialFilter?.search ?? '');
+  const [searchMode, setSearchMode] = useState(false);
+  const [matchingPeriods, setMatchingPeriods] = useState<Set<string> | null>(null);
+  const setTyping = useSetTyping();
+  useEffect(() => { setTyping(searchMode); }, [searchMode, setTyping]);
 
   useEffect(() => {
     void buildTrendViews().then((loaded) => {
@@ -72,13 +78,30 @@ export function Trends({
     });
   }, [viewIdx, range, views, refreshKey]);
 
+  useEffect(() => {
+    if (!search) { setMatchingPeriods(null); return; }
+    void getSearchMatchingPeriods(search, range).then(setMatchingPeriods);
+  }, [search, range]);
+
+  const displayRows = matchingPeriods ? rows.filter((r) => matchingPeriods.has(r.from)) : rows;
+  const clampedCursor = displayRows.length > 0 ? Math.min(cursor, displayRows.length - 1) : 0;
+
   useInput((input, key) => {
-    if (key.escape) { onNavigate('dashboard'); return; }
+    if (searchMode) {
+      if (key.escape || key.return) { setSearchMode(false); return; }
+      if (key.backspace || key.delete) { setSearch((s) => s.slice(0, -1)); return; }
+      if (input && !key.ctrl && !key.meta) { setSearch((s) => s + input); return; }
+      return;
+    }
+    if (input === '/') { setSearchMode(true); return; }
+    if (key.escape) { onNavigate('dashboard', search ? { search } : undefined); return; }
+    if (input === '1') { onNavigate('dashboard', search ? { search } : undefined); return; }
     if (input === '2') {
-      const row = rows[cursor];
+      const row = displayRows[clampedCursor];
       onNavigate('transactions', {
         ...(row ? { from: row.from, to: row.to } : {}),
         ...(view.category ? { category: view.category } : {}),
+        ...(search ? { search } : {}),
       });
       return;
     }
@@ -86,35 +109,35 @@ export function Trends({
     if (key.leftArrow)  { setViewIdx((i) => (i - 1 + views.length) % views.length); return; }
     if (key.rightArrow) { setViewIdx((i) => (i + 1) % views.length); return; }
     if (key.upArrow)   { setCursor((c) => Math.max(0, c - 1)); return; }
-    if (key.downArrow) { setCursor((c) => Math.min(rows.length - 1, c + 1)); return; }
+    if (key.downArrow) { setCursor((c) => Math.min(displayRows.length - 1, c + 1)); return; }
     if (input === 'r') {
       setRange((r) => TRENDS_RANGES[(TRENDS_RANGES.indexOf(r) + 1) % TRENDS_RANGES.length]);
       return;
     }
     if (key.return) {
-      const row = rows[cursor];
-      if (row) onNavigate('transactions', { category: view.category ?? undefined, from: row.from, to: row.to });
+      const row = displayRows[clampedCursor];
+      if (row) onNavigate('transactions', { category: view.category ?? undefined, from: row.from, to: row.to, ...(search ? { search } : {}) });
     }
   }, { isActive: isActive !== false });
 
   const PAGE = 30;
-  const { visible, pageStart } = usePagination(rows, cursor, PAGE);
+  const { visible, pageStart } = usePagination(displayRows, clampedCursor, PAGE);
 
   // Scale maxes
-  const maxIncome   = isNet ? Math.max(...rows.map((r) => r.income   ?? 0), 1) : 1;
-  const maxExpenses = isNet ? Math.max(...rows.map((r) => r.expenses ?? 0), 1) : 1;
+  const maxIncome   = isNet ? Math.max(...displayRows.map((r) => r.income   ?? 0), 1) : 1;
+  const maxExpenses = isNet ? Math.max(...displayRows.map((r) => r.expenses ?? 0), 1) : 1;
   const netMax = Math.max(maxIncome, maxExpenses);
 
   const flexMax = isFlexBreakdown
-    ? Math.max(...rows.flatMap((r) => [r.fixed ?? 0, r.flexible ?? 0, r.discretionary ?? 0]), 1)
+    ? Math.max(...displayRows.flatMap((r) => [r.fixed ?? 0, r.flexible ?? 0, r.discretionary ?? 0]), 1)
     : 1;
 
   const absMax = isNet          ? netMax
                : isFlexBreakdown ? flexMax
-               : Math.max(...rows.map((r) => Math.abs(r.total)), 1);
+               : Math.max(...displayRows.map((r) => Math.abs(r.total)), 1);
 
-  const avg  = rows.length ? rows.reduce((s, r) => s + r.total, 0) / rows.length : 0;
-  const peak = rows.reduce((best, r) => Math.abs(r.total) > Math.abs(best?.total ?? 0) ? r : best, rows[0]);
+  const avg  = displayRows.length ? displayRows.reduce((s, r) => s + r.total, 0) / displayRows.length : 0;
+  const peak = displayRows.reduce((best, r) => Math.abs(r.total) > Math.abs(best?.total ?? 0) ? r : best, displayRows[0]);
 
   const labelWidth = range === 'week' ? 22 : range === 'month' ? 10 : range === 'quarter' ? 8 : 6;
   const color = viewColor(view);
@@ -135,8 +158,16 @@ export function Trends({
       <PageHeader current="trends" showHints={showHints} />
 
       <Box justifyContent="space-between" marginTop={1}>
-        <Text bold>Trends</Text>
-        {showHints && <Text dimColor>←→ view  ·  ↑↓ navigate  ·  [r] range  ·  Enter txns</Text>}
+        <Box gap={2}>
+          <Text bold>Trends</Text>
+          {searchMode
+            ? <Text color={C_ACCENT}>/ {search}{CURSOR}</Text>
+            : search
+              ? <Text color={C_ACCENT}>/ {search}{matchingPeriods ? ` (${displayRows.length} of ${rows.length})` : ''}</Text>
+              : null
+          }
+        </Box>
+        {showHints && <Text dimColor>{searchMode ? 'type · Enter/Esc done' : '←→ view  ·  ↑↓ navigate  ·  [r] range  ·  [/] search  ·  Enter txns'}</Text>}
       </Box>
 
       <Box justifyContent="space-between" marginTop={1}>
@@ -152,8 +183,8 @@ export function Trends({
       </Box>
       <Divider />
 
-      {rows.length === 0 ? (
-        <Box marginTop={1}><Text dimColor>No data.</Text></Box>
+      {displayRows.length === 0 ? (
+        <Box marginTop={1}><Text dimColor>{rows.length === 0 ? 'No data.' : 'No periods match the search.'}</Text></Box>
       ) : (
         <>
           <Box flexDirection="column" marginTop={1}>
@@ -182,7 +213,7 @@ export function Trends({
               </Box>
             )}
             {visible.map((row, i) => {
-              const isSelected = rows[pageStart + i] === rows[cursor];
+              const isSelected = displayRows[pageStart + i] === displayRows[clampedCursor];
 
               if (isNet && row.income !== undefined && row.expenses !== undefined) {
                 const expFilled = Math.min(HALF_BAR, Math.max(0, Math.round((row.expenses / netMax) * HALF_BAR)));
@@ -236,7 +267,7 @@ export function Trends({
 
           <Box marginTop={1}><Divider /></Box>
           <Box gap={6} marginTop={1}>
-            <StatCard label="periods" value={String(rows.length)} />
+            <StatCard label="periods" value={String(displayRows.length)} />
             <StatCard
               label={`avg/${RANGE_LABELS[range].toLowerCase()}`}
               value={isNet ? fmtSigned(avg) : fmt(avg)}

--- a/tui/components/DialRow.tsx
+++ b/tui/components/DialRow.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { Text } from 'ink';
+import { Box, Text } from 'ink';
 import { SelectableRow } from './SelectableRow.js';
-import { C_ACCENT, C_NEUTRAL } from '../ui.js';
+import { C_ACCENT, C_NEUTRAL, CURSOR } from '../ui.js';
 
 export function DialRow({
   label,
@@ -11,6 +11,8 @@ export function DialRow({
   labelWidth = 16,
   valueWidth = 12,
   valueColor,
+  editing,
+  editBuffer,
 }: {
   label: string;
   value: string;
@@ -19,11 +21,18 @@ export function DialRow({
   labelWidth?: number;
   valueWidth?: number;
   valueColor?: string;
+  editing?: boolean;
+  editBuffer?: string;
 }) {
+  const displayValue = editing ? (editBuffer ?? '') : value;
   return (
     <SelectableRow selected={selected} gap={2}>
       <Text color={selected ? C_ACCENT : undefined}>{label.padEnd(labelWidth)}</Text>
-      <Text color={selected ? C_ACCENT : (valueColor ?? C_NEUTRAL)}>{'[ '}{value.padStart(valueWidth)}{' ]'}</Text>
+      <Box>
+        <Text color={selected ? C_ACCENT : (valueColor ?? C_NEUTRAL)}>{'[ '}{displayValue.padStart(valueWidth)}</Text>
+        {editing && <Text color={C_ACCENT}>{CURSOR}</Text>}
+        <Text color={selected ? C_ACCENT : (valueColor ?? C_NEUTRAL)}>{' ]'}</Text>
+      </Box>
       <Text dimColor>{description}</Text>
     </SelectableRow>
   );

--- a/tui/components/EditField.tsx
+++ b/tui/components/EditField.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Box, Text } from 'ink';
+import { C_ACCENT, C_DIM, C_NEUTRAL } from '../ui.js';
+import { TextInput } from './TextInput.js';
+
+/** A text-input field row: `Label  [ value/cursor ]` */
+export function EditTextField({
+  label, labelWidth = 12, active, value, placeholder, color, emptyText = '—',
+}: {
+  label: string; labelWidth?: number; active: boolean;
+  value: string; placeholder?: string; color?: string; emptyText?: string;
+}) {
+  return (
+    <Box gap={2}>
+      <Text color={active ? C_ACCENT : C_NEUTRAL}>{label.padEnd(labelWidth)}</Text>
+      <Box>
+        <Text color={active ? C_ACCENT : C_NEUTRAL}>{'[ '}</Text>
+        {active
+          ? <TextInput value={value} color={color} placeholder={placeholder} />
+          : <Text color={value ? undefined : C_DIM}>{value || emptyText}</Text>}
+        <Text color={active ? C_ACCENT : C_NEUTRAL}>{' ]'}</Text>
+      </Box>
+    </Box>
+  );
+}
+
+/** A toggle/cycle field row: `Label  ← value →` */
+export function EditToggleField({
+  label, labelWidth = 12, active, value, valueColor,
+}: {
+  label: string; labelWidth?: number; active: boolean;
+  value: string; valueColor?: string;
+}) {
+  return (
+    <Box gap={2}>
+      <Text color={active ? C_ACCENT : C_NEUTRAL}>{label.padEnd(labelWidth)}</Text>
+      <Text color={active ? C_ACCENT : valueColor}>{'← '}{value}{'  →'}</Text>
+    </Box>
+  );
+}

--- a/tui/components/index.ts
+++ b/tui/components/index.ts
@@ -9,3 +9,4 @@ export { ColumnHeader } from './ColumnHeader.js';
 export { PageHeader } from './PageHeader.js';
 export { SearchBar } from './SearchBar.js';
 export { DialRow } from './DialRow.js';
+export { EditTextField, EditToggleField } from './EditField.js';

--- a/tui/nav.tsx
+++ b/tui/nav.tsx
@@ -3,6 +3,7 @@ import { Box, Text } from 'ink';
 import type { Screen } from './App.js';
 
 const SCREEN_KEYS: Record<string, Screen> = {
+  '0': 'settings',
   '1': 'dashboard',
   '2': 'transactions',
   '3': 'trends',
@@ -15,13 +16,13 @@ const SCREEN_KEYS: Record<string, Screen> = {
 };
 
 const LABELS: Record<Screen, string> = {
-  dashboard: 'dash', transactions: 'txns', trends: 'trends',
+  settings: 'settings', dashboard: 'dash', transactions: 'txns', trends: 'trends',
   networth: 'worth', tags: 'tags', health: 'health', rules: 'rules', accounts: 'accounts',
   canvas: 'canvas',
 };
 
 // Split into two rows so each row stays short enough for narrow terminals
-const ROW1: Screen[] = ['dashboard', 'transactions', 'trends', 'networth'];
+const ROW1: Screen[] = ['settings', 'dashboard', 'transactions', 'trends', 'networth'];
 const ROW2: Screen[] = ['tags', 'health', 'rules', 'accounts', 'canvas'];
 
 const keyOf = (s: Screen) => Object.entries(SCREEN_KEYS).find(([, v]) => v === s)![0];


### PR DESCRIPTION
## Summary

- **Unified edit panels**: Replaced multi-step modal wizards in Rules with single-page forms (`rule-form`, `name-rule-form`). All fields visible at once with ↑↓ to navigate, ← → to toggle/cycle.
- **Category rename folded into edit panel**: Name is now the first field in the category edit panel; removed the separate `[n]` rename mode.
- **`EditTextField` / `EditToggleField` components**: Extracted the `label + [ value ]` and `label + ← value →` patterns into shared components used by Rules, Transactions, and Accounts.
- **Transactions edit panel**: Switched to vertical field layout (↑↓ to switch fields, ← → to cycle categories) matching the Rules style.
- **One key per action**: Removed the `[e]` alias everywhere — Enter is the single way to open edit panels.
- **Search improvements**: Dashboard search bar moved above the divider; Trends gets a delayed search (Enter to commit) that shows matching transaction count; Trends search bar matches Dashboard's style and placement.
- **Trends search view**: Live search hides the ← view → selector and renders net-style bars (two-sided if both income and expenses match, single-sided otherwise). Esc to exit search view.
- **Bug fix**: `saveRule()` and `handleSaveNameRule()` were calling async DB functions without `await`, causing `load()` to run before the write completed (new rules missing from list, status showed `[object Promise]`).
- **14 new e2e tests**: Rules category rule form, Rules name rule form, Rules categories edit panel, Tags rename flow.

## Test plan

- [ ] All 433 tests pass (`npx vitest run`)
- [ ] Rules: `[a]` opens single-page form; Enter saves; Enter on existing rule pre-fills; Esc cancels
- [ ] Rules categories: Enter opens edit panel with Name/Flexibility/Hidden fields; ← → cycles flexibility; Esc cancels
- [ ] Transactions: edit panel uses ↑↓ for fields, ← → for category cycling
- [ ] Dashboard: search bar appears above the divider
- [ ] Trends: search shows matching tx count; bars adapt to income-only/expense-only/both; Esc clears
- [ ] Tags: `[n]` opens rename panel pre-filled; Enter renames; Esc cancels

🤖 Generated with [Claude Code](https://claude.com/claude-code)