### PR TITLE
security: bind servers to loopback by default; replace new Function in evalExpr

### DIFF
--- a/api/server.ts
+++ b/api/server.ts
@@ -76,8 +76,9 @@ export function startApiServer(port = DEFAULT_PORT, opts: { quiet?: boolean } = 
     }
   });
 
-  server.listen(port, () => {
-    if (!opts.quiet) console.log(`[fungible-api] Listening on http://localhost:${port}`);
+  const host = process.env.FUNGIBLE_BIND_HOST ?? '127.0.0.1';
+  server.listen(port, host, () => {
+    if (!opts.quiet) console.log(`[fungible-api] Listening on http://${host}:${port}`);
   });
 }
 

--- a/core/canvas-agent.ts
+++ b/core/canvas-agent.ts
@@ -38,13 +38,114 @@ export type CanvasSpec = {
 };
 
 // ─── Expression evaluator ─────────────────────────────────────────────────────
+// Safe recursive-descent parser — no new Function / eval. Supports the grammar
+// documented in the canvas system prompt: number/Infinity literals, dial keys,
+// parentheses, unary +/-, arithmetic, comparisons, ternary, Math.{pow,log,abs,
+// round,floor,ceil}. Unknown identifiers resolve to NaN; anything outside the
+// grammar throws and is caught as NaN.
+
+const MATH_FNS: Record<string, (...a: number[]) => number> = {
+  pow: Math.pow, log: Math.log, abs: Math.abs,
+  round: Math.round, floor: Math.floor, ceil: Math.ceil,
+};
+
+function lex(src: string): string[] {
+  const re = /(\d+\.?\d*|\.\d+|Infinity|Math\.[a-z]+|[A-Za-z_]\w*|<=|>=|==|!=|[-+*/()<>?:,])|(\s+)/y;
+  const out: string[] = [];
+  let i = 0;
+  while (i < src.length) {
+    re.lastIndex = i;
+    const m = re.exec(src);
+    if (!m) throw new Error(`invalid token near "${src.slice(i, i + 12)}"`);
+    i = re.lastIndex;
+    if (m[1] !== undefined) out.push(m[1]);
+  }
+  return out;
+}
+
+function parseEval(toks: string[], scope: Record<string, number>): number {
+  let p = 0;
+  const peek = () => toks[p];
+  const next = () => toks[p++];
+  const expect = (t: string) => { if (next() !== t) throw new Error(`expected ${t}`); };
+
+  function ternary(): number {
+    const cond = comparison();
+    if (peek() === '?') {
+      next();
+      const a = ternary();
+      expect(':');
+      const b = ternary();
+      return cond !== 0 ? a : b;
+    }
+    return cond;
+  }
+  function comparison(): number {
+    const l = additive();
+    const op = peek();
+    if (op === '<' || op === '<=' || op === '>' || op === '>=' || op === '==' || op === '!=') {
+      next();
+      const r = additive();
+      if (op === '<')  return l < r  ? 1 : 0;
+      if (op === '<=') return l <= r ? 1 : 0;
+      if (op === '>')  return l > r  ? 1 : 0;
+      if (op === '>=') return l >= r ? 1 : 0;
+      if (op === '==') return l === r ? 1 : 0;
+      if (op === '!=') return l !== r ? 1 : 0;
+    }
+    return l;
+  }
+  function additive(): number {
+    let v = multiplicative();
+    while (peek() === '+' || peek() === '-') {
+      const op = next();
+      v = op === '+' ? v + multiplicative() : v - multiplicative();
+    }
+    return v;
+  }
+  function multiplicative(): number {
+    let v = unary();
+    while (peek() === '*' || peek() === '/') {
+      const op = next();
+      v = op === '*' ? v * unary() : v / unary();
+    }
+    return v;
+  }
+  function unary(): number {
+    if (peek() === '-') { next(); return -unary(); }
+    if (peek() === '+') { next(); return unary(); }
+    return primary();
+  }
+  function primary(): number {
+    const t = next();
+    if (t === undefined) throw new Error('unexpected end');
+    if (t === '(') { const v = ternary(); expect(')'); return v; }
+    if (t === 'Infinity') return Infinity;
+    if (/^\d|^\./.test(t)) return parseFloat(t);
+    if (t.startsWith('Math.')) {
+      const fn = MATH_FNS[t.slice(5)];
+      if (!fn) throw new Error(`function not allowed: ${t}`);
+      expect('(');
+      const args: number[] = [];
+      if (peek() !== ')') {
+        args.push(ternary());
+        while (peek() === ',') { next(); args.push(ternary()); }
+      }
+      expect(')');
+      return fn(...args);
+    }
+    return Object.prototype.hasOwnProperty.call(scope, t) ? scope[t] : NaN;
+  }
+
+  const result = ternary();
+  if (p !== toks.length) throw new Error('trailing tokens');
+  return result;
+}
 
 export function evalExpr(expr: string, values: Record<string, number>): number {
+  if (expr.length > 500) return NaN;
   try {
-    const keys = Object.keys(values);
-    const vals = keys.map((k) => values[k]);
-    // eslint-disable-next-line @typescript-eslint/no-implied-eval
-    const result = new Function(...keys, `"use strict"; return (${expr});`)(...vals);
+    const result = parseEval(lex(expr), values);
     return typeof result === 'number' && !isNaN(result) && result !== -Infinity ? result : NaN;
   } catch {
     return NaN;

--- a/mcp/http.ts
+++ b/mcp/http.ts
@@ -25,5 +25,5 @@ export function startMcpHttpServer(port: number): void {
     }
   });
 
-  httpServer.listen(port);
+  httpServer.listen(port, process.env.FUNGIBLE_BIND_HOST ?? '127.0.0.1');
 }

--- a/scripts/link.ts
+++ b/scripts/link.ts
@@ -159,7 +159,7 @@ async function main() {
     res.end();
   });
 
-  server.listen(PORT, () => {
+  server.listen(PORT, '127.0.0.1', () => {
     const url = `http://localhost:${PORT}`;
     console.log(`Opening ${url} ...`);
     execFile('open', [url]);

--- a/tests/tui/canvas.test.tsx
+++ b/tests/tui/canvas.test.tsx
@@ -58,28 +58,165 @@ describe('generateCanvas', () => {
 // ─── evalExpr ─────────────────────────────────────────────────────────────────
 
 describe('evalExpr', () => {
+  // Basic arithmetic
   it('evaluates simple arithmetic', () => {
     expect(evalExpr('a + b', { a: 1, b: 2 })).toBe(3);
     expect(evalExpr('a * b', { a: 3, b: 4 })).toBe(12);
+    expect(evalExpr('a - b', { a: 10, b: 3 })).toBe(7);
+    expect(evalExpr('a / b', { a: 9, b: 3 })).toBe(3);
   });
 
-  it('evaluates mortgage payment formula', () => {
-    // $300k, 6% annual (0.5% monthly), 360 payments
+  it('respects operator precedence', () => {
+    expect(evalExpr('2 + 3 * 4', {})).toBe(14);
+    expect(evalExpr('(2 + 3) * 4', {})).toBe(20);
+    expect(evalExpr('10 - 2 - 3', {})).toBe(5);
+  });
+
+  it('handles unary minus and plus', () => {
+    expect(evalExpr('-a', { a: 5 })).toBe(-5);
+    expect(evalExpr('--a', { a: 5 })).toBe(5);
+    expect(evalExpr('+a', { a: 7 })).toBe(7);
+    expect(evalExpr('-a + b', { a: 3, b: 10 })).toBe(7);
+  });
+
+  it('handles number literals including decimals', () => {
+    expect(evalExpr('1.5 + 0.5', {})).toBe(2);
+    expect(evalExpr('100', {})).toBe(100);
+    expect(evalExpr('.25 * 4', {})).toBe(1);
+  });
+
+  it('handles the Infinity literal', () => {
+    expect(evalExpr('Infinity', {})).toBe(Infinity);
+    expect(evalExpr('a > 0 ? Infinity : 0', { a: 1 })).toBe(Infinity);
+  });
+
+  // Math functions
+  it('evaluates mortgage payment formula with Math.pow', () => {
     const P = 300_000, r = 0.005, n = 360;
     const result = evalExpr('P * r / (1 - Math.pow(1 + r, -n))', { P, r, n });
     expect(result).toBeCloseTo(1798.65, 0);
   });
 
-  it('returns NaN for bad expressions', () => {
-    expect(isNaN(evalExpr('not valid js!!!', {}))).toBe(true);
+  it('evaluates Math.log', () => {
+    expect(evalExpr('Math.log(1)', {})).toBe(0);
+    expect(evalExpr('Math.log(a)', { a: Math.E })).toBeCloseTo(1, 10);
   });
 
+  it('evaluates Math.abs', () => {
+    expect(evalExpr('Math.abs(a)', { a: -42 })).toBe(42);
+    expect(evalExpr('Math.abs(a)', { a: 42 })).toBe(42);
+  });
+
+  it('evaluates Math.round / Math.floor / Math.ceil', () => {
+    expect(evalExpr('Math.round(1.6)', {})).toBe(2);
+    expect(evalExpr('Math.round(1.4)', {})).toBe(1);
+    expect(evalExpr('Math.floor(1.9)', {})).toBe(1);
+    expect(evalExpr('Math.ceil(1.1)', {})).toBe(2);
+  });
+
+  it('evaluates Math.pow with two arguments', () => {
+    expect(evalExpr('Math.pow(2, 10)', {})).toBe(1024);
+  });
+
+  // Comparisons
+  it('evaluates comparison operators returning 0 or 1', () => {
+    expect(evalExpr('a < b', { a: 1, b: 2 })).toBe(1);
+    expect(evalExpr('a < b', { a: 2, b: 1 })).toBe(0);
+    expect(evalExpr('a <= b', { a: 2, b: 2 })).toBe(1);
+    expect(evalExpr('a > b', { a: 5, b: 3 })).toBe(1);
+    expect(evalExpr('a >= b', { a: 3, b: 3 })).toBe(1);
+    expect(evalExpr('a == b', { a: 4, b: 4 })).toBe(1);
+    expect(evalExpr('a == b', { a: 4, b: 5 })).toBe(0);
+    expect(evalExpr('a != b', { a: 4, b: 5 })).toBe(1);
+    expect(evalExpr('a != b', { a: 4, b: 4 })).toBe(0);
+  });
+
+  // Ternary
+  it('evaluates ternary operator', () => {
+    expect(evalExpr('a > 0 ? 1 : -1', { a: 5 })).toBe(1);
+    expect(evalExpr('a > 0 ? 1 : -1', { a: -5 })).toBe(-1);
+    expect(evalExpr('a > 0 ? b : c', { a: 1, b: 10, c: 20 })).toBe(10);
+    expect(evalExpr('a > 0 ? b : c', { a: -1, b: 10, c: 20 })).toBe(20);
+  });
+
+  it('evaluates nested ternary', () => {
+    expect(evalExpr('a > 2 ? 3 : a > 1 ? 2 : 1', { a: 3 })).toBe(3);
+    expect(evalExpr('a > 2 ? 3 : a > 1 ? 2 : 1', { a: 2 })).toBe(2);
+    expect(evalExpr('a > 2 ? 3 : a > 1 ? 2 : 1', { a: 0 })).toBe(1);
+  });
+
+  // Real canvas formulas
+  it('evaluates credit-card payoff formula', () => {
+    const balance = 20000, rate = 22, monthly = 500;
+    const result = evalExpr(
+      '-Math.log(1 - balance * rate/100/12 / monthly) / Math.log(1 + rate/100/12)',
+      { balance, rate, monthly },
+    );
+    expect(result).toBeCloseTo(72.75, 0);
+  });
+
+  it('evaluates retirement real-value formula', () => {
+    const savings = 100_000, growth = 7, years = 20, inflation = 3;
+    const result = evalExpr(
+      'savings * Math.pow(1 + growth/100, years) / Math.pow(1 + inflation/100, years)',
+      { savings, growth, years, inflation },
+    );
+    expect(result).toBeGreaterThan(savings);
+  });
+
+  // Sentinel values
   it('passes Infinity through (used for "never" payoff sentinel)', () => {
     expect(evalExpr('a / b', { a: 1, b: 0 })).toBe(Infinity);
   });
 
-  it('returns NaN for negative-infinity and invalid expressions', () => {
+  it('returns NaN for negative-infinity', () => {
     expect(isNaN(evalExpr('-a / b', { a: 1, b: 0 }))).toBe(true);
+  });
+
+  // Unknown identifiers
+  it('returns NaN for unknown identifiers', () => {
+    expect(isNaN(evalExpr('unknown', {}))).toBe(true);
+    expect(isNaN(evalExpr('a + unknown', { a: 5 }))).toBe(true);
+  });
+
+  // Error cases
+  it('returns NaN for expressions exceeding 500 chars', () => {
+    expect(isNaN(evalExpr('a +'.repeat(200), { a: 1 }))).toBe(true);
+  });
+
+  it('returns NaN for trailing tokens', () => {
+    expect(isNaN(evalExpr('a + b c', { a: 1, b: 2, c: 3 }))).toBe(true);
+  });
+
+  it('returns NaN for unmatched parentheses', () => {
+    expect(isNaN(evalExpr('(a + b', { a: 1, b: 2 }))).toBe(true);
+    expect(isNaN(evalExpr('a + b)', { a: 1, b: 2 }))).toBe(true);
+  });
+
+  it('returns NaN for empty input', () => {
+    expect(isNaN(evalExpr('', {}))).toBe(true);
+  });
+
+  // Security: tokens outside the grammar must not execute
+  it('returns NaN for process.env access attempts', () => {
+    expect(isNaN(evalExpr('process.env.HOME', {}))).toBe(true);
+  });
+
+  it('returns NaN for globalThis access attempts', () => {
+    expect(isNaN(evalExpr('globalThis.process', {}))).toBe(true);
+  });
+
+  it('returns NaN for arrow function syntax', () => {
+    expect(isNaN(evalExpr('(() => 42)()', {}))).toBe(true);
+  });
+
+  it('returns NaN for string literals (outside grammar)', () => {
+    expect(isNaN(evalExpr('"hello"', {}))).toBe(true);
+  });
+
+  it('returns NaN for disallowed Math methods', () => {
+    expect(isNaN(evalExpr('Math.random()', {}))).toBe(true);
+    expect(isNaN(evalExpr('Math.sqrt(4)', {}))).toBe(true);
   });
 });
 


### PR DESCRIPTION
Fixes #66. Two security issues reported by @sassyass.

## Changes

**1. HTTP servers now bind to `127.0.0.1` by default**

`api/server.ts`, `mcp/http.ts`, and `scripts/link.ts` were all calling `listen(port)` with no host argument, causing Node to bind to `0.0.0.0` / `::` — every interface. Any device on the same network or VPN could reach the REST API or MCP server unauthenticated.

Now defaults to `127.0.0.1`. Set `FUNGIBLE_BIND_HOST=<host>` to opt into LAN/tailnet access explicitly.

**2. `evalExpr` replaces `new Function` with a safe recursive-descent parser**

The canvas evaluator was feeding LLM-generated expressions directly into `new Function(...)`, which executes arbitrary JS with full access to `process`, `globalThis`, env vars, and the on-disk database. A prompt injection via a merchant name or CSV row could have exploited this.

The replacement parser enforces the documented grammar at the parse level — numbers, dial keys, `+ - * /`, comparisons, ternary `?:`, and six whitelisted `Math` methods. Anything outside that grammar returns `NaN`.

## Tests

`evalExpr` test coverage expanded from 5 to 27 cases, including explicit rejection of `process.env`, `globalThis`, arrow functions, string literals, and disallowed `Math` methods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)