### PR TITLE
feat: filter transactions by income/expenses/flex when drilling from Trends

### DIFF
--- a/core/dedup.ts
+++ b/core/dedup.ts
@@ -25,6 +25,8 @@ const MATCH_SQL = `
       AND LOWER(SUBSTR(csv.name,   1, INSTR(plaid.name, '*') - 1))
         = LOWER(SUBSTR(plaid.name, 1, INSTR(plaid.name, '*') - 1))
     )
+    OR TRIM(REPLACE(LOWER(csv.name), '  ', ' ')) = TRIM(REPLACE(LOWER(plaid.name), '  ', ' '))
+    OR INSTR(LOWER(csv.name), LOWER(SUBSTR(plaid.name, 1, MAX(1, INSTR(plaid.name || ' ', ' ') - 1)))) > 0
   )
 `;
 

--- a/core/queries.ts
+++ b/core/queries.ts
@@ -403,8 +403,10 @@ export function buildSearchRe(search: string): RegExp {
 export async function getTransactions(filters: {
   category?: string | null; from?: string | null; to?: string | null;
   search?: string; tag?: string | null; account?: string | null; sort?: SortMode;
+  txType?: 'income' | 'expenses' | null;
+  flex?: 'fixed' | 'flexible' | 'discretionary' | null;
 }): Promise<TxRow[]> {
-  const { category, from, to, search, tag, account, sort = 'date-desc' } = filters;
+  const { category, from, to, search, tag, account, sort = 'date-desc', txType, flex } = filters;
   const conditions: string[] = [];
   const args: (string | number | null)[] = [];
 
@@ -415,6 +417,9 @@ export async function getTransactions(filters: {
     args.push(tag);
   }
   if (account) { conditions.push('t.account_id = ?'); args.push(account); }
+  if (txType === 'income') { conditions.push('t.amount < 0'); conditions.push('t.category NOT IN (SELECT category FROM hidden_categories)'); }
+  if (txType === 'expenses') { conditions.push('t.amount > 0'); conditions.push('t.category NOT IN (SELECT category FROM hidden_categories)'); }
+  if (flex) { conditions.push('EXISTS (SELECT 1 FROM categories c WHERE c.name = t.category AND c.flexibility = ?)'); args.push(flex); }
 
   const where = conditions.length ? 'WHERE ' + conditions.join(' AND ') : '';
   const result = await db.execute({

--- a/scripts/seed-demo.ts
+++ b/scripts/seed-demo.ts
@@ -1,9 +1,20 @@
 /**
  * Seed a demo database with realistic fake transactions.
  * Called automatically when running `fungible --demo` on a fresh data dir.
+ * Dates are relative to today so the data always appears recent.
  */
 import { db } from '../core/db.js';
 import { seedRules } from '../core/seed-rules.js';
+
+// d(monthsAgo, day) — e.g. d(0, 15) = 15th of this month
+function d(monthsAgo: number, day: number): string {
+  const now = new Date();
+  const year = now.getFullYear() + Math.floor((now.getMonth() - monthsAgo) / 12);
+  const month = ((now.getMonth() - monthsAgo) % 12 + 12) % 12;
+  const maxDay = new Date(year, month + 1, 0).getDate();
+  const dd = Math.min(day, maxDay);
+  return `${year}-${String(month + 1).padStart(2, '0')}-${String(dd).padStart(2, '0')}`;
+}
 
 export async function seedDemo() {
   const countResult = await db.execute('SELECT COUNT(*) as c FROM transactions');
@@ -29,77 +40,77 @@ await db.batch([
 
 const txns: [string, string, string, string, string | null, number, string][] = [
   // Income
-  ['demo-t001', 'demo-checking', '2026-05-01', 'Direct Deposit - Acme Corp',    null,              -4200.00, 'Income'],
-  ['demo-t002', 'demo-savings',  '2026-05-01', 'Interest Payment',               null,              -12.50,   'Income'],
-  ['demo-t003', 'demo-checking', '2026-04-01', 'Direct Deposit - Acme Corp',    null,              -4200.00, 'Income'],
-  ['demo-t004', 'demo-checking', '2026-03-01', 'Direct Deposit - Acme Corp',    null,              -4200.00, 'Income'],
+  ['demo-t001', 'demo-checking', d(0, 1),  'Direct Deposit - Acme Corp',    null,              -4200.00, 'Income'],
+  ['demo-t002', 'demo-savings',  d(0, 1),  'Interest Payment',               null,                -12.50, 'Income'],
+  ['demo-t003', 'demo-checking', d(1, 1),  'Direct Deposit - Acme Corp',    null,              -4200.00, 'Income'],
+  ['demo-t004', 'demo-checking', d(2, 1),  'Direct Deposit - Acme Corp',    null,              -4200.00, 'Income'],
 
   // Rent / Fixed
-  ['demo-t010', 'demo-checking', '2026-05-02', 'Rent Payment',                  null,               1850.00, 'Rent'],
-  ['demo-t011', 'demo-checking', '2026-04-02', 'Rent Payment',                  null,               1850.00, 'Rent'],
-  ['demo-t012', 'demo-checking', '2026-03-02', 'Rent Payment',                  null,               1850.00, 'Rent'],
+  ['demo-t010', 'demo-checking', d(0, 2),  'Rent Payment',                  null,               1850.00, 'Rent'],
+  ['demo-t011', 'demo-checking', d(1, 2),  'Rent Payment',                  null,               1850.00, 'Rent'],
+  ['demo-t012', 'demo-checking', d(2, 2),  'Rent Payment',                  null,               1850.00, 'Rent'],
 
   // Bills & Utilities
-  ['demo-t020', 'demo-credit',   '2026-05-03', 'Con Edison',                    'Con Edison',        92.40,  'Bills & Utilities'],
-  ['demo-t021', 'demo-credit',   '2026-05-04', 'Verizon Wireless',              'Verizon',           85.00,  'Bills & Utilities'],
-  ['demo-t022', 'demo-credit',   '2026-05-05', 'Spotify',                       'Spotify',           11.99,  'Bills & Utilities'],
-  ['demo-t023', 'demo-credit',   '2026-05-05', 'Netflix',                       'Netflix',           15.99,  'Entertainment'],
-  ['demo-t024', 'demo-credit',   '2026-04-03', 'Con Edison',                    'Con Edison',        88.10,  'Bills & Utilities'],
-  ['demo-t025', 'demo-credit',   '2026-04-04', 'Verizon Wireless',              'Verizon',           85.00,  'Bills & Utilities'],
+  ['demo-t020', 'demo-credit',   d(0, 3),  'Con Edison',                    'Con Edison',         92.40, 'Bills & Utilities'],
+  ['demo-t021', 'demo-credit',   d(0, 4),  'Verizon Wireless',              'Verizon',            85.00, 'Bills & Utilities'],
+  ['demo-t022', 'demo-credit',   d(0, 5),  'Spotify',                       'Spotify',            11.99, 'Bills & Utilities'],
+  ['demo-t023', 'demo-credit',   d(0, 5),  'Netflix',                       'Netflix',            15.99, 'Entertainment'],
+  ['demo-t024', 'demo-credit',   d(1, 3),  'Con Edison',                    'Con Edison',         88.10, 'Bills & Utilities'],
+  ['demo-t025', 'demo-credit',   d(1, 4),  'Verizon Wireless',              'Verizon',            85.00, 'Bills & Utilities'],
 
   // Groceries
-  ['demo-t030', 'demo-credit',   '2026-05-06', 'Whole Foods Market',            'Whole Foods',       87.43,  'Grocery'],
-  ['demo-t031', 'demo-credit',   '2026-05-10', "Trader Joe's",                  "Trader Joe's",      54.21,  'Grocery'],
-  ['demo-t032', 'demo-credit',   '2026-05-16', 'Whole Foods Market',            'Whole Foods',       63.80,  'Grocery'],
-  ['demo-t033', 'demo-credit',   '2026-04-07', 'Whole Foods Market',            'Whole Foods',       91.20,  'Grocery'],
-  ['demo-t034', 'demo-credit',   '2026-04-14', "Trader Joe's",                  "Trader Joe's",      48.60,  'Grocery'],
-  ['demo-t035', 'demo-credit',   '2026-03-09', 'Whole Foods Market',            'Whole Foods',       79.40,  'Grocery'],
-  ['demo-t036', 'demo-credit',   '2026-03-20', "Trader Joe's",                  "Trader Joe's",      61.30,  'Grocery'],
+  ['demo-t030', 'demo-credit',   d(0, 6),  'Whole Foods Market',            'Whole Foods',        87.43, 'Grocery'],
+  ['demo-t031', 'demo-credit',   d(0, 10), "Trader Joe's",                  "Trader Joe's",       54.21, 'Grocery'],
+  ['demo-t032', 'demo-credit',   d(0, 16), 'Whole Foods Market',            'Whole Foods',        63.80, 'Grocery'],
+  ['demo-t033', 'demo-credit',   d(1, 7),  'Whole Foods Market',            'Whole Foods',        91.20, 'Grocery'],
+  ['demo-t034', 'demo-credit',   d(1, 14), "Trader Joe's",                  "Trader Joe's",       48.60, 'Grocery'],
+  ['demo-t035', 'demo-credit',   d(2, 9),  'Whole Foods Market',            'Whole Foods',        79.40, 'Grocery'],
+  ['demo-t036', 'demo-credit',   d(2, 20), "Trader Joe's",                  "Trader Joe's",       61.30, 'Grocery'],
 
   // Dining
-  ['demo-t040', 'demo-credit',   '2026-05-07', 'Sweetgreen',                    'Sweetgreen',        16.50,  'Dining'],
-  ['demo-t041', 'demo-credit',   '2026-05-09', 'Tacos El Patron',               null,                24.00,  'Dining'],
-  ['demo-t042', 'demo-credit',   '2026-05-12', 'Blue Bottle Coffee',            'Blue Bottle',        6.75,  'Food & Drink'],
-  ['demo-t043', 'demo-credit',   '2026-05-14', 'The Dutch',                     null,                78.40,  'Dining'],
-  ['demo-t044', 'demo-credit',   '2026-05-19', 'Sweetgreen',                    'Sweetgreen',        15.75,  'Dining'],
-  ['demo-t045', 'demo-credit',   '2026-04-08', 'Tacos El Patron',               null,                21.50,  'Dining'],
-  ['demo-t046', 'demo-credit',   '2026-04-11', 'Ramen Nagi',                    null,                32.00,  'Dining'],
-  ['demo-t047', 'demo-credit',   '2026-04-18', 'Blue Bottle Coffee',            'Blue Bottle',        6.75,  'Food & Drink'],
-  ['demo-t048', 'demo-credit',   '2026-03-13', 'Sweetgreen',                    'Sweetgreen',        16.50,  'Dining'],
-  ['demo-t049', 'demo-credit',   '2026-03-22', 'The Dutch',                     null,                95.20,  'Dining'],
+  ['demo-t040', 'demo-credit',   d(0, 7),  'Sweetgreen',                    'Sweetgreen',         16.50, 'Dining'],
+  ['demo-t041', 'demo-credit',   d(0, 9),  'Tacos El Patron',               null,                 24.00, 'Dining'],
+  ['demo-t042', 'demo-credit',   d(0, 12), 'Blue Bottle Coffee',            'Blue Bottle',         6.75, 'Food & Drink'],
+  ['demo-t043', 'demo-credit',   d(0, 14), 'The Dutch',                     null,                 78.40, 'Dining'],
+  ['demo-t044', 'demo-credit',   d(0, 19), 'Sweetgreen',                    'Sweetgreen',         15.75, 'Dining'],
+  ['demo-t045', 'demo-credit',   d(1, 8),  'Tacos El Patron',               null,                 21.50, 'Dining'],
+  ['demo-t046', 'demo-credit',   d(1, 11), 'Ramen Nagi',                    null,                 32.00, 'Dining'],
+  ['demo-t047', 'demo-credit',   d(1, 18), 'Blue Bottle Coffee',            'Blue Bottle',         6.75, 'Food & Drink'],
+  ['demo-t048', 'demo-credit',   d(2, 13), 'Sweetgreen',                    'Sweetgreen',         16.50, 'Dining'],
+  ['demo-t049', 'demo-credit',   d(2, 22), 'The Dutch',                     null,                 95.20, 'Dining'],
 
   // Transportation
-  ['demo-t050', 'demo-credit',   '2026-05-08', 'Lyft',                          'Lyft',              14.20,  'Transportation'],
-  ['demo-t051', 'demo-credit',   '2026-05-13', 'Lyft',                          'Lyft',              11.80,  'Transportation'],
-  ['demo-t052', 'demo-credit',   '2026-05-17', 'MTA NYC Transit',               'MTA',               33.00,  'Transportation'],
-  ['demo-t053', 'demo-credit',   '2026-04-10', 'Lyft',                          'Lyft',              18.50,  'Transportation'],
-  ['demo-t054', 'demo-credit',   '2026-04-15', 'MTA NYC Transit',               'MTA',               33.00,  'Transportation'],
+  ['demo-t050', 'demo-credit',   d(0, 8),  'Lyft',                          'Lyft',               14.20, 'Transportation'],
+  ['demo-t051', 'demo-credit',   d(0, 13), 'Lyft',                          'Lyft',               11.80, 'Transportation'],
+  ['demo-t052', 'demo-credit',   d(0, 17), 'MTA NYC Transit',               'MTA',                33.00, 'Transportation'],
+  ['demo-t053', 'demo-credit',   d(1, 10), 'Lyft',                          'Lyft',               18.50, 'Transportation'],
+  ['demo-t054', 'demo-credit',   d(1, 15), 'MTA NYC Transit',               'MTA',                33.00, 'Transportation'],
 
   // Shopping
-  ['demo-t060', 'demo-credit',   '2026-05-11', 'Amazon',                        'Amazon',            43.99,  'Shopping'],
-  ['demo-t061', 'demo-credit',   '2026-05-15', 'Uniqlo',                        'Uniqlo',            89.00,  'Shopping'],
-  ['demo-t062', 'demo-credit',   '2026-04-20', 'Amazon',                        'Amazon',            27.50,  'Shopping'],
-  ['demo-t063', 'demo-credit',   '2026-03-17', 'Amazon',                        'Amazon',           112.34,  'Shopping'],
+  ['demo-t060', 'demo-credit',   d(0, 11), 'Amazon',                        'Amazon',             43.99, 'Shopping'],
+  ['demo-t061', 'demo-credit',   d(0, 15), 'Uniqlo',                        'Uniqlo',             89.00, 'Shopping'],
+  ['demo-t062', 'demo-credit',   d(1, 20), 'Amazon',                        'Amazon',             27.50, 'Shopping'],
+  ['demo-t063', 'demo-credit',   d(2, 17), 'Amazon',                        'Amazon',            112.34, 'Shopping'],
 
   // Health
-  ['demo-t070', 'demo-credit',   '2026-05-02', 'Equinox',                       'Equinox',          135.00,  'Personal Care'],
-  ['demo-t071', 'demo-credit',   '2026-05-18', 'CVS Pharmacy',                  'CVS',               22.40,  'Medical'],
-  ['demo-t072', 'demo-credit',   '2026-04-02', 'Equinox',                       'Equinox',          135.00,  'Personal Care'],
-  ['demo-t073', 'demo-credit',   '2026-03-02', 'Equinox',                       'Equinox',          135.00,  'Personal Care'],
+  ['demo-t070', 'demo-credit',   d(0, 2),  'Equinox',                       'Equinox',           135.00, 'Personal Care'],
+  ['demo-t071', 'demo-credit',   d(0, 18), 'CVS Pharmacy',                  'CVS',                22.40, 'Medical'],
+  ['demo-t072', 'demo-credit',   d(1, 2),  'Equinox',                       'Equinox',           135.00, 'Personal Care'],
+  ['demo-t073', 'demo-credit',   d(2, 2),  'Equinox',                       'Equinox',           135.00, 'Personal Care'],
 
   // Travel (Tokyo trip — for tag demo)
-  ['demo-t080', 'demo-credit',   '2026-04-22', 'Japan Airlines',                'JAL',              890.00,  'Travel'],
-  ['demo-t081', 'demo-credit',   '2026-04-23', 'APA Hotel Tokyo',               null,               420.00,  'Travel'],
-  ['demo-t082', 'demo-credit',   '2026-04-24', 'Ichiran Ramen',                 null,                18.00,  'Dining'],
-  ['demo-t083', 'demo-credit',   '2026-04-24', 'Tokyo Metro',                   null,                12.00,  'Transportation'],
-  ['demo-t084', 'demo-credit',   '2026-04-25', 'Tsukiji Market',                null,                34.00,  'Food & Drink'],
-  ['demo-t085', 'demo-credit',   '2026-04-26', 'Don Quijote',                   null,                67.00,  'Shopping'],
-  ['demo-t086', 'demo-credit',   '2026-04-27', 'APA Hotel Tokyo',               null,               420.00,  'Travel'],
-  ['demo-t087', 'demo-credit',   '2026-04-28', 'Japan Airlines',                'JAL',              890.00,  'Travel'],
+  ['demo-t080', 'demo-credit',   d(1, 22), 'Japan Airlines',                'JAL',               890.00, 'Travel'],
+  ['demo-t081', 'demo-credit',   d(1, 23), 'APA Hotel Tokyo',               null,                420.00, 'Travel'],
+  ['demo-t082', 'demo-credit',   d(1, 24), 'Ichiran Ramen',                 null,                 18.00, 'Dining'],
+  ['demo-t083', 'demo-credit',   d(1, 24), 'Tokyo Metro',                   null,                 12.00, 'Transportation'],
+  ['demo-t084', 'demo-credit',   d(1, 25), 'Tsukiji Market',                null,                 34.00, 'Food & Drink'],
+  ['demo-t085', 'demo-credit',   d(1, 26), 'Don Quijote',                   null,                 67.00, 'Shopping'],
+  ['demo-t086', 'demo-credit',   d(1, 27), 'APA Hotel Tokyo',               null,                420.00, 'Travel'],
+  ['demo-t087', 'demo-credit',   d(1, 28), 'Japan Airlines',                'JAL',               890.00, 'Travel'],
 
   // Credit card payment (transfer)
-  ['demo-t090', 'demo-checking', '2026-05-15', 'Chase Credit Card Payment',     null,             -1200.00,  'Transfer'],
-  ['demo-t091', 'demo-checking', '2026-04-15', 'Chase Credit Card Payment',     null,             -1100.00,  'Transfer'],
+  ['demo-t090', 'demo-checking', d(0, 15), 'Chase Credit Card Payment',     null,              -1200.00, 'Transfer'],
+  ['demo-t091', 'demo-checking', d(1, 15), 'Chase Credit Card Payment',     null,              -1100.00, 'Transfer'],
 ];
 
 await db.batch(
@@ -114,18 +125,18 @@ await db.batch(
 // ── Balance history ────────────────────────────────────────────────────────────
 
 const balances: [string, number, string][] = [
-  ['demo-checking',   8420.00, '2026-05-25'],
-  ['demo-checking',   6810.00, '2026-04-30'],
-  ['demo-checking',   5990.00, '2026-03-31'],
-  ['demo-savings',   18500.00, '2026-05-25'],
-  ['demo-savings',   18200.00, '2026-04-30'],
-  ['demo-savings',   17900.00, '2026-03-31'],
-  ['demo-credit',    -1340.00, '2026-05-25'],
-  ['demo-credit',     -980.00, '2026-04-30'],
-  ['demo-credit',    -1120.00, '2026-03-31'],
-  ['demo-brokerage', 34200.00, '2026-05-25'],
-  ['demo-brokerage', 32100.00, '2026-04-30'],
-  ['demo-brokerage', 30500.00, '2026-03-31'],
+  ['demo-checking',   8420.00, d(0, 25)],
+  ['demo-checking',   6810.00, d(1, 28)],
+  ['demo-checking',   5990.00, d(2, 28)],
+  ['demo-savings',   18500.00, d(0, 25)],
+  ['demo-savings',   18200.00, d(1, 28)],
+  ['demo-savings',   17900.00, d(2, 28)],
+  ['demo-credit',    -1340.00, d(0, 25)],
+  ['demo-credit',     -980.00, d(1, 28)],
+  ['demo-credit',    -1120.00, d(2, 28)],
+  ['demo-brokerage', 34200.00, d(0, 25)],
+  ['demo-brokerage', 32100.00, d(1, 28)],
+  ['demo-brokerage', 30500.00, d(2, 28)],
 ];
 
 await db.batch(

--- a/tests/queries.test.ts
+++ b/tests/queries.test.ts
@@ -13,6 +13,7 @@ import {
   getRecentTransactions,
   getMerchantSummary,
   hasAccounts,
+  getTransactions,
 } from '../core/queries.js';
 
 let txId = 0;
@@ -368,6 +369,76 @@ describe('getRecentTransactions', () => {
     const txs = await getRecentTransactions();
     expect(txs).toHaveLength(1);
     expect(txs[0].amount).toBe(200);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────
+describe('getTransactions — txType filter', () => {
+  it('income returns only negative-amount transactions', async () => {
+    await insertTx({ amount: -500, category: 'Income' });
+    await insertTx({ amount: 100,  category: 'Shopping' });
+    const rows = await getTransactions({ txType: 'income' });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].amount).toBe(-500);
+  });
+
+  it('income excludes hidden categories', async () => {
+    await db.execute({ sql: 'INSERT INTO hidden_categories VALUES (?)', args: ['Transfer'] });
+    await insertTx({ amount: -500, category: 'Income' });
+    await insertTx({ amount: -200, category: 'Transfer' });
+    const rows = await getTransactions({ txType: 'income' });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].category).toBe('Income');
+  });
+
+  it('expenses returns only positive-amount transactions', async () => {
+    await insertTx({ amount: 100,  category: 'Shopping' });
+    await insertTx({ amount: -500, category: 'Income' });
+    const rows = await getTransactions({ txType: 'expenses' });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].amount).toBe(100);
+  });
+
+  it('expenses excludes hidden categories', async () => {
+    await db.execute({ sql: 'INSERT INTO hidden_categories VALUES (?)', args: ['Transfer'] });
+    await insertTx({ amount: 100, category: 'Shopping' });
+    await insertTx({ amount: 200, category: 'Transfer' });
+    const rows = await getTransactions({ txType: 'expenses' });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].category).toBe('Shopping');
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────
+describe('getTransactions — flex filter', () => {
+  beforeEach(async () => {
+    await db.execute("INSERT INTO categories (name, flexibility) VALUES ('Rent', 'fixed')");
+    await db.execute("INSERT INTO categories (name, flexibility) VALUES ('Grocery', 'flexible')");
+    await db.execute("INSERT INTO categories (name, flexibility) VALUES ('Dining', 'discretionary')");
+  });
+
+  it('returns only transactions in categories with the given flex tier', async () => {
+    await insertTx({ amount: 1500, category: 'Rent' });
+    await insertTx({ amount: 200,  category: 'Grocery' });
+    await insertTx({ amount: 50,   category: 'Dining' });
+    await insertTx({ amount: 100,  category: 'Shopping' }); // no flex tier
+    const fixed = await getTransactions({ flex: 'fixed' });
+    expect(fixed).toHaveLength(1);
+    expect(fixed[0].category).toBe('Rent');
+  });
+
+  it('works for all three tiers', async () => {
+    await insertTx({ amount: 1500, category: 'Rent' });
+    await insertTx({ amount: 200,  category: 'Grocery' });
+    await insertTx({ amount: 50,   category: 'Dining' });
+    expect((await getTransactions({ flex: 'fixed' })).map((r) => r.category)).toEqual(['Rent']);
+    expect((await getTransactions({ flex: 'flexible' })).map((r) => r.category)).toEqual(['Grocery']);
+    expect((await getTransactions({ flex: 'discretionary' })).map((r) => r.category)).toEqual(['Dining']);
+  });
+
+  it('excludes categories with no flex tier', async () => {
+    await insertTx({ amount: 100, category: 'Shopping' });
+    expect(await getTransactions({ flex: 'fixed' })).toHaveLength(0);
   });
 });
 

--- a/tui/App.tsx
+++ b/tui/App.tsx
@@ -30,6 +30,8 @@ export type TxFilter = {
   range?: string;   // 'week' | 'month' | 'quarter' | 'year' | 'alltime'
   anchor?: string;  // YYYY-MM-DD — which specific period to land on
   canvasSpec?: string; // JSON-encoded CanvasSpec, used when navigating to 'canvas'
+  txType?: 'income' | 'expenses';
+  flex?: 'fixed' | 'flexible' | 'discretionary';
 };
 
 function AppInner() {

--- a/tui/Transactions.tsx
+++ b/tui/Transactions.tsx
@@ -55,6 +55,8 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
   const [tag, setTag] = useState<string | null>(initialFilter?.tag ?? null);
   const [account, setAccount] = useState<string | null>(initialFilter?.account ?? null);
   const [accountName, setAccountName] = useState<string | null>(initialFilter?.accountName ?? null);
+  const [txType] = useState<'income' | 'expenses' | null>(initialFilter?.txType ?? null);
+  const [flex] = useState<'fixed' | 'flexible' | 'discretionary' | null>(initialFilter?.flex ?? null);
   const [sort, setSort] = useState<SortMode>('date-desc');
   const [bounds, setBounds] = useState<{ minDate: string; maxDate: string }>({ minDate: '2000-01-01', maxDate: '2099-12-31' });
   const [search, setSearch] = useState(initialFilter?.search ?? '');
@@ -79,7 +81,7 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
   const [tagInput, setTagInput] = useState('');
 
   function load(s = search, keepCursor = false) {
-    void getTransactions({ category, from, to, search: s, tag, account, sort }).then((rows) => {
+    void getTransactions({ category, from, to, search: s, tag, account, sort, txType, flex }).then((rows) => {
       setTxs(rows);
       if (!keepCursor) setCursor(0);
       else setCursor((c) => Math.min(c, Math.max(0, rows.length - 1)));
@@ -87,7 +89,7 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
   }
 
   useEffect(() => { void getDataBounds().then(setBounds); void getAllCategories().then(setCategories); }, []);
-  useEffect(() => { load(); }, [category, from, to, search, tag, account, sort, refreshKey]);
+  useEffect(() => { load(); }, [category, from, to, search, tag, account, sort, txType, flex, refreshKey]);
 
   const setTyping = useSetTyping();
   useEffect(() => {
@@ -410,6 +412,8 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
     tag ? `#${tag}` : null,
     search ? `"${search}"` : null,
     category,
+    txType ? txType.charAt(0).toUpperCase() + txType.slice(1) : null,
+    flex ? flex.charAt(0).toUpperCase() + flex.slice(1) : null,
   ].filter(Boolean).join(' · ');
 
   // Category list window for edit panel

--- a/tui/Trends.tsx
+++ b/tui/Trends.tsx
@@ -118,6 +118,9 @@ export function Trends({
       onNavigate('transactions', {
         ...(row ? { from: row.from, to: row.to } : {}),
         ...(!search && view.category ? { category: view.category } : {}),
+        ...(!search && view.mode === 'income' ? { txType: 'income' as const } : {}),
+        ...(!search && view.mode === 'expenses' ? { txType: 'expenses' as const } : {}),
+        ...(!search && view.mode === 'flex' && view.flex ? { flex: view.flex } : {}),
         ...(search ? { search } : {}),
       });
       return;
@@ -137,6 +140,9 @@ export function Trends({
       const row = activeRows[clampedCursor];
       if (row) onNavigate('transactions', {
         ...(!search && view.category ? { category: view.category } : {}),
+        ...(!search && view.mode === 'income' ? { txType: 'income' as const } : {}),
+        ...(!search && view.mode === 'expenses' ? { txType: 'expenses' as const } : {}),
+        ...(!search && view.mode === 'flex' && view.flex ? { flex: view.flex } : {}),
         from: row.from, to: row.to,
         ...(search ? { search } : {}),
       });


### PR DESCRIPTION
## Summary
- Pressing Enter (or [2]) on Income, Expenses, Fixed, Flexible, or Discretionary Trends views now navigates to a filtered transaction list matching that view's criteria
- Income/Expenses filters exclude hidden categories (e.g. Transfer) to match Trends query behaviour
- Filter label in Transactions capitalises txType/flex names to match category style
- Demo data now uses relative dates so it always appears recent when first seeded
- Unit tests added for the new `txType` and `flex` filters in `getTransactions`
- Includes improved dedup match query with whitespace normalisation and first-word prefix matching

## Test plan
- [ ] Enter from Trends Income → transactions show only credits, no transfers
- [ ] Enter from Trends Expenses → transactions show only debits
- [ ] Enter from Trends Fixed/Flexible/Discretionary → transactions filtered to that flex tier
- [ ] Enter from Trends Net / Flexibility → date-range only, no extra filter
- [ ] Filter label shows "Income", "Fixed", etc. capitalised
- [ ] `npm run demo` on a fresh data dir shows current month transactions

🤖 Generated with [Claude Code](https://claude.ai/claude-code)