### PR TITLE
fix: household members in DB + owner view edge cases

### DIFF
--- a/core/canvas-agent.ts
+++ b/core/canvas-agent.ts
@@ -256,7 +256,7 @@ export type CanvasContext = {
 export async function loadCanvasContext(): Promise<CanvasContext> {
   const health = await loadHealthData();
   const taxableBrokerage = health.liquid - health.cash;
-  const profile = loadProfile();
+  const profile = await loadProfile();
   const currentYear = new Date().getFullYear();
 
   const householdLines: string[] = [];

--- a/core/db.ts
+++ b/core/db.ts
@@ -97,6 +97,12 @@ export async function initDb() {
     )`,
     `CREATE UNIQUE INDEX IF NOT EXISTS idx_balance_history_acct_date
       ON balance_history(account_id, date)`,
+    `CREATE TABLE IF NOT EXISTS household_members (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL DEFAULT '',
+      birth_year INTEGER NOT NULL DEFAULT 0,
+      sort_order INTEGER NOT NULL DEFAULT 0
+    )`,
   ], 'write');
 
   // Idempotent column migrations (each may fail if column exists — that's fine)
@@ -164,6 +170,24 @@ export async function initDb() {
     })),
     'write',
   );
+
+  // One-time migration: seed household_members from profile.json if table is empty
+  const hmCount = await db.execute('SELECT COUNT(*) as n FROM household_members');
+  if (Number(hmCount.rows[0].n) === 0) {
+    type ProfileJson = { self: { name: string; birthYear: number }; spouse?: { name: string; birthYear: number }; children: { name: string; birthYear: number }[] };
+    let p: ProfileJson | null = null;
+    try { p = JSON.parse(fs.readFileSync(path.join(DATA_DIR, 'profile.json'), 'utf8')) as ProfileJson; } catch {}
+    const self = p?.self ?? { name: '', birthYear: 0 };
+    const rows: { sql: string; args: (string | number)[] }[] = [
+      { sql: 'INSERT INTO household_members (id, name, birth_year, sort_order) VALUES (?,?,?,0)', args: ['self', self.name, self.birthYear] },
+    ];
+    if (p?.spouse) rows.push({ sql: 'INSERT INTO household_members (id, name, birth_year, sort_order) VALUES (?,?,?,1)', args: ['spouse', p.spouse.name, p.spouse.birthYear] });
+    for (let i = 0; i < (p?.children ?? []).length; i++) {
+      const c = p!.children[i];
+      rows.push({ sql: 'INSERT INTO household_members (id, name, birth_year, sort_order) VALUES (?,?,?,?)', args: [`child-${i}`, c.name, c.birthYear, i + 2] });
+    }
+    await db.batch(rows, 'write');
+  }
 
   // Seed default categories
   const defaultCategories = [

--- a/core/profile.ts
+++ b/core/profile.ts
@@ -1,8 +1,4 @@
-import path from 'node:path';
-import fs from 'node:fs';
-import { DATA_DIR } from './paths.js';
-
-const PROFILE_PATH = path.join(DATA_DIR, 'profile.json');
+import { db } from './db.js';
 
 export type HouseholdMember = { name: string; birthYear: number };
 
@@ -12,29 +8,49 @@ export type Profile = {
   children: HouseholdMember[];
 };
 
-export function loadProfile(): Profile | null {
-  try {
-    return JSON.parse(fs.readFileSync(PROFILE_PATH, 'utf8')) as Profile;
-  } catch {
-    return null;
+type MemberRow = { id: unknown; name: unknown; birth_year: unknown };
+
+function toMember(r: MemberRow): HouseholdMember {
+  return { name: String(r.name ?? ''), birthYear: Number(r.birth_year ?? 0) };
+}
+
+export async function loadProfile(): Promise<Profile | null> {
+  const { rows } = await db.execute('SELECT id, name, birth_year FROM household_members ORDER BY sort_order');
+  if (rows.length === 0) return null;
+  const all = rows as unknown as MemberRow[];
+  const selfRow = all.find((r) => r.id === 'self');
+  if (!selfRow) return null;
+  const spouseRow = all.find((r) => r.id === 'spouse');
+  const childRows = all.filter((r) => String(r.id).startsWith('child-'));
+  return {
+    self: toMember(selfRow),
+    spouse: spouseRow ? toMember(spouseRow) : undefined,
+    children: childRows.map(toMember),
+  };
+}
+
+export async function saveProfile(p: Profile): Promise<void> {
+  const rows: { sql: string; args: (string | number)[] }[] = [
+    { sql: 'INSERT OR REPLACE INTO household_members (id, name, birth_year, sort_order) VALUES (?,?,?,0)', args: ['self', p.self.name, p.self.birthYear] },
+  ];
+  if (p.spouse) {
+    rows.push({ sql: 'INSERT OR REPLACE INTO household_members (id, name, birth_year, sort_order) VALUES (?,?,?,1)', args: ['spouse', p.spouse.name, p.spouse.birthYear] });
+  } else {
+    rows.push({ sql: 'DELETE FROM household_members WHERE id = ?', args: ['spouse'] });
   }
+  rows.push({ sql: "DELETE FROM household_members WHERE id LIKE 'child-%'", args: [] });
+  for (let i = 0; i < p.children.length; i++) {
+    rows.push({ sql: 'INSERT INTO household_members (id, name, birth_year, sort_order) VALUES (?,?,?,?)', args: [`child-${i}`, p.children[i].name, p.children[i].birthYear, i + 2] });
+  }
+  await db.batch(rows, 'write');
 }
 
-export function saveProfile(p: Profile): void {
-  fs.writeFileSync(PROFILE_PATH, JSON.stringify(p, null, 2), 'utf8');
-}
-
-/**
- * The named household members an account can be assigned to as its owner —
- * self, spouse, then each child, in that order. Used to populate the owner
- * picker so the stored owner name comes from a known set rather than free text.
- * Members without a name are omitted.
- */
+// Returns ordered member names for the account owner picker. Members with no name are omitted.
 export function householdMembers(p: Profile | null): string[] {
   if (!p) return [];
   const names: string[] = [];
   if (p.self.name.trim()) names.push(p.self.name.trim());
-  if (p.spouse && p.spouse.name.trim()) names.push(p.spouse.name.trim());
+  if (p.spouse?.name.trim()) names.push(p.spouse.name.trim());
   for (const c of p.children) {
     if (c.name.trim()) names.push(c.name.trim());
   }

--- a/tests/helpers/makeTestDb.ts
+++ b/tests/helpers/makeTestDb.ts
@@ -83,6 +83,13 @@ const SCHEMA = `
     date TEXT NOT NULL,
     PRIMARY KEY (account_id, date)
   );
+
+  CREATE TABLE household_members (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL DEFAULT '',
+    birth_year INTEGER NOT NULL DEFAULT 0,
+    sort_order INTEGER NOT NULL DEFAULT 0
+  );
 `;
 
 export async function makeTestDb() {

--- a/tests/tui/canvas.test.tsx
+++ b/tests/tui/canvas.test.tsx
@@ -25,6 +25,7 @@ const MOCK_SPEC: CanvasSpec = {
 };
 
 vi.mock('../../core/health.js', () => ({ loadHealthData: async () => MOCK_HEALTH }));
+vi.mock('../../core/profile.js', () => ({ loadProfile: async () => null, householdMembers: () => [] }));
 vi.mock('../../core/llm-provider.js', () => ({
   streamResponse: vi.fn(async function* () {
     yield { type: 'tool_use', id: 'test-id', name: 'render_canvas', input: MOCK_SPEC };

--- a/tests/tui/screens.test.tsx
+++ b/tests/tui/screens.test.tsx
@@ -22,7 +22,7 @@ import { Health } from '../../tui/Health.js';
 import { Settings } from '../../tui/Settings.js';
 import { RefreshProvider } from '../../tui/RefreshContext.js';
 import { TypingContext } from '../../tui/TypingContext.js';
-import { loadProfile } from '../../core/profile.js';
+import { loadProfile, saveProfile } from '../../core/profile.js';
 
 // Keep householdMembers real (a pure helper used by the owner picker) but stub
 // the DB-backed loadProfile/saveProfile. loadProfile is a vi.fn so a test can
@@ -762,6 +762,80 @@ describe('Settings', () => {
     const r = render(<W><Settings onNavigate={onNavigate} showHints={false} /></W>);
     r.stdin.write('1');
     expect(onNavigate).toHaveBeenCalledWith('dashboard');
+  });
+
+  it('loaded profile values appear after async init', async () => {
+    vi.mocked(loadProfile).mockResolvedValue({ self: { name: 'Thomas', birthYear: 1990 }, children: [] });
+    const r = settings();
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).toContain('Thomas');
+      expect(f).toContain('1990');
+    });
+  });
+
+  it('committing a name edit calls saveProfile with the updated value', async () => {
+    vi.mocked(saveProfile).mockClear();
+    const r = settings();
+    r.stdin.write('\r');
+    await waitFor(() => expect(frame(r)).toContain('▊'));
+    r.stdin.write('Alice');
+    await waitFor(() => expect(frame(r)).toContain('Alice'));
+    r.stdin.write('\r');
+    await waitFor(() => expect(frame(r)).not.toContain('▊'));
+    expect(vi.mocked(saveProfile)).toHaveBeenCalledWith(
+      expect.objectContaining({ self: expect.objectContaining({ name: 'Alice' }) }),
+    );
+  });
+
+  it('[a] when spouse exists adds a child row', async () => {
+    const r = settings();
+    r.stdin.write('a');           // add spouse (no spouse yet)
+    await waitFor(() => expect(frame(r)).toContain('Spouse name'));
+    r.stdin.write('a');           // add child (spouse now exists)
+    await waitFor(() => expect(frame(r)).toContain('Child 1'));
+  });
+
+  it('[d] on a child row removes it', async () => {
+    const r = settings();
+    r.stdin.write('a');           // add spouse
+    await waitFor(() => expect(frame(r)).toContain('Spouse name'));
+    r.stdin.write('a');           // add child → rows: self-name(0) self-year(1) spouse-name(2) spouse-year(3) child-0-name(4)
+    await waitFor(() => expect(frame(r)).toContain('Child 1'));
+    r.stdin.write('\x1B[B');      // ↓ → row 1
+    r.stdin.write('\x1B[B');      // ↓ → row 2
+    r.stdin.write('\x1B[B');      // ↓ → row 3
+    r.stdin.write('\x1B[B');      // ↓ → row 4 (Child 1 name)
+    await waitFor(() => expect(frame(r)).toContain('[d] remove'));
+    r.stdin.write('d');
+    await waitFor(() => expect(frame(r)).not.toContain('Child 1'));
+  });
+
+  it('birth year field rejects out-of-range years', async () => {
+    const r = settings();
+    r.stdin.write('\x1B[B');      // ↓ to self-year (row 1)
+    r.stdin.write('\r');          // open edit
+    await waitFor(() => expect(frame(r)).toContain('▊'));
+    // Write digits individually — numeric fields check /^\d$/ per keypress
+    for (const d of '1800') r.stdin.write(d);
+    await waitFor(() => expect(frame(r)).toContain('1800')); // buffer visible while editing
+    r.stdin.write('\r');          // commit — rejected because 1800 < 1900
+    await waitFor(() => expect(frame(r)).not.toContain('▊'));
+    expect(frame(r)).not.toContain('1800');
+  });
+
+  it('birth year field accepts years in range', async () => {
+    const r = settings();
+    r.stdin.write('\x1B[B');      // ↓ to self-year (row 1)
+    r.stdin.write('\r');
+    await waitFor(() => expect(frame(r)).toContain('▊'));
+    for (const d of '1990') r.stdin.write(d);
+    await waitFor(() => expect(frame(r)).toContain('1990')); // buffer visible while editing
+    r.stdin.write('\r');
+    await waitFor(() => {
+      expect(frame(r)).toContain('1990');
+      expect(frame(r)).not.toContain('▊');
+    });
   });
 });
 

--- a/tests/tui/screens.test.tsx
+++ b/tests/tui/screens.test.tsx
@@ -25,11 +25,11 @@ import { TypingContext } from '../../tui/TypingContext.js';
 import { loadProfile } from '../../core/profile.js';
 
 // Keep householdMembers real (a pure helper used by the owner picker) but stub
-// the fs-backed loadProfile/saveProfile. loadProfile is a vi.fn so a test can
+// the DB-backed loadProfile/saveProfile. loadProfile is a vi.fn so a test can
 // supply a profile whose members populate the cycle.
 vi.mock('../../core/profile.js', async (importActual) => {
   const actual = await importActual<typeof import('../../core/profile.js')>();
-  return { ...actual, loadProfile: vi.fn(() => null), saveProfile: vi.fn() };
+  return { ...actual, loadProfile: vi.fn(() => Promise.resolve(null)), saveProfile: vi.fn(() => Promise.resolve()) };
 });
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -67,7 +67,7 @@ const noop = () => {};
 // ── Setup ─────────────────────────────────────────────────────────────────────
 
 beforeEach(async () => {
-  vi.mocked(loadProfile).mockReturnValue(null); // no household members unless a test sets one
+  vi.mocked(loadProfile).mockResolvedValue(null); // no household members unless a test sets one
   for (const tbl of ['transactions', 'accounts', 'categories', 'tags', 'transaction_tags',
                      'category_rules', 'name_rules', 'hidden_categories', 'balance_history']) {
     await db.execute(`DELETE FROM ${tbl}`);
@@ -1199,7 +1199,7 @@ describe('Accounts', () => {
 
   it('setting an owner refreshes the list to show the owner on the account row', async () => {
     // The owner editor cycles over household members, so a profile must supply one.
-    vi.mocked(loadProfile).mockReturnValue({ self: { name: 'Alex Stark', birthYear: 0 }, children: [] });
+    vi.mocked(loadProfile).mockResolvedValue({ self: { name: 'Alex Stark', birthYear: 0 }, children: [] });
     const real = accountsApi.updateAccountOwner;
     vi.spyOn(accountsApi, 'updateAccountOwner').mockImplementation(delayWrite(real));
 
@@ -1223,7 +1223,7 @@ describe('Accounts', () => {
   });
 
   it('surfaces an error and does not apply the owner when the write fails', async () => {
-    vi.mocked(loadProfile).mockReturnValue({ self: { name: 'Alex Stark', birthYear: 0 }, children: [] });
+    vi.mocked(loadProfile).mockResolvedValue({ self: { name: 'Alex Stark', birthYear: 0 }, children: [] });
     vi.spyOn(accountsApi, 'updateAccountOwner').mockRejectedValue(new Error('db down'));
 
     const r = accounts();

--- a/tui/Accounts.tsx
+++ b/tui/Accounts.tsx
@@ -162,14 +162,15 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
     void getCsvPlaidDupeCandidates().then(setDupes);
   }
   useEffect(() => { loadAccounts(); }, [refreshKey]);
+  useEffect(() => {
+    void loadProfile().then((p) => setOwnerMembers(householdMembers(p)));
+  }, [isActive]);
 
   function openEdit(acct: LinkedAccount) {
     const type = acct.type;
     const subtypes = SUBTYPES[type] ?? [];
     const currentSub = acct.subtype ?? '';
     const snapped = subtypes.includes(currentSub) ? currentSub : (subtypes[0] ?? '');
-    // Re-read the profile each time so owner choices reflect the latest household.
-    setOwnerMembers(householdMembers(loadProfile()));
     setEditType(type);
     setEditSubtype(snapped);
     setEditNickname(acct.nickname ?? '');

--- a/tui/Dashboard.tsx
+++ b/tui/Dashboard.tsx
@@ -177,7 +177,7 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
 
   // Don't strand the user on the owner view if the last owner gets unassigned elsewhere.
   useEffect(() => {
-    if (view === 'owner' && ownerRows.length > 0 && !ownerRows.some((r) => r.owner !== 'Unassigned')) {
+    if (view === 'owner' && !ownerRows.some((r) => r.owner !== 'Unassigned')) {
       setView('categories');
     }
   }, [view, ownerRows]);
@@ -195,7 +195,7 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
   // Every owned account yields an OwnerRow (LEFT JOIN), so a non-'Unassigned' row here
   // means an owner exists regardless of whether they spent anything this period.
   const hasOwners = ownerRows.some((r) => r.owner !== 'Unassigned');
-  const maxOwnerSpend = ownerRows[0]?.spending || 1;
+  const maxOwnerSpend = ownerRows[0]?.spending ?? 1;
   // Drift categories: 3 delta cols × 9 chars + 4 gaps of 2 = 27+8=35 for cols; plus amount(10)+gaps
   // total fixed = 2(cursor) + 10(amt) + 4(gaps to amt) + 27(3×9) + 4(gaps between deltas) = 47
   const driftCatNameW = Math.max(12, inner - 47);

--- a/tui/Settings.tsx
+++ b/tui/Settings.tsx
@@ -45,10 +45,12 @@ export function Settings({ onNavigate, isActive, showHints }: {
   showHints: boolean;
 }) {
   const setTyping = useSetTyping();
-  const [profile, setProfile] = useState<Profile>(
-    () => loadProfile() ?? { self: { name: '', birthYear: 0 }, children: [] }
-  );
+  const [profile, setProfile] = useState<Profile>({ self: { name: '', birthYear: 0 }, children: [] });
   const [cursor, setCursor] = useState(0);
+
+  useEffect(() => {
+    void loadProfile().then((p) => { if (p) setProfile(p); });
+  }, []);
   const [editing, setEditing] = useState(false);
   const [editBuffer, setEditBuffer] = useState('');
 
@@ -60,7 +62,7 @@ export function Settings({ onNavigate, isActive, showHints }: {
 
   function persist(next: Profile) {
     setProfile(next);
-    saveProfile(next);
+    void saveProfile(next);
   }
 
   function commitEdit() {


### PR DESCRIPTION
## Summary

Follow-up to #62 (account owner feature).

- **Household members → DB**: `household_members` table replaces `profile.json` as the backing store. `initDb` performs a one-time seed migration from any existing `profile.json` on first boot — no data loss. `loadProfile`/`saveProfile` are now async (DB-backed via libSQL).
- **Callers updated**: Settings loads via `useEffect` (optimistic persist stays sync fire-and-forget), Accounts reloads `ownerMembers` when the screen becomes active (picks up household changes made in Settings), `canvas-agent.ts` awaits the call.
- **Dashboard redirect fix**: removed spurious `ownerRows.length > 0 &&` guard in the "evict from owner view" effect — now correctly redirects when all accounts are unassigned even if no account rows exist.
- **`maxOwnerSpend` clarity**: `|| 1` → `?? 1` (intent is to guard against `undefined`, not falsiness).
- **Tests**: mock `loadProfile` as async in screens + canvas tests, add `household_members` to test schema.

## Test plan
- [ ] New user: no `profile.json` — app starts, Settings shows empty household, owner picker shows hint to add members
- [ ] Existing user: `profile.json` present — after upgrade, household members appear in Settings unchanged, owner picker works
- [ ] Add/edit/remove spouse and children in Settings → persisted across restart
- [ ] Assign account owner in Accounts → Dashboard owner tab appears
- [ ] Remove all owners → Dashboard owner tab disappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)