### PR TITLE
feat: shared filter data layer and session-global filter state

### DIFF
--- a/core/filters.ts
+++ b/core/filters.ts
@@ -1,0 +1,121 @@
+// Shared, multi-dimension transaction filter used across the Dashboard,
+// Transactions, and Trends views. The four dimensions AND together; within a
+// dimension the selected members OR together.
+//
+// Semantics of each dimension on the query side:
+//   - absent (undefined)  → no constraint (all)
+//   - present, non-empty   → restrict to those members
+//   - present, empty array → match nothing (the user explicitly cleared it)
+//
+// The panel UI works with an explicit "selected" set initialized to the full
+// universe and serializes "everything selected" back to `undefined`, so a
+// fully-selected section imposes no constraint.
+
+export type TagPredicate = { name: string; mode: 'has' | 'lacks' };
+
+export type Filter = {
+  categories?: string[];
+  accounts?: string[];   // account ids
+  owners?: string[];     // owner names ('Unassigned' for accounts with no owner)
+  tags?: TagPredicate[];
+};
+
+export const EMPTY_FILTER: Filter = {};
+
+/** Whether the filter constrains anything (used to show/hide the header hint). */
+export function isFilterActive(f?: Filter): boolean {
+  if (!f) return false;
+  return f.categories !== undefined
+    || f.accounts !== undefined
+    || f.owners !== undefined
+    || (f.tags?.length ?? 0) > 0;
+}
+
+/** Compact one-line description of the active filter, e.g. "2 accounts, 4 categories". */
+export function filterSummary(f?: Filter): string {
+  if (!f) return '';
+  const parts: string[] = [];
+  const plural = (n: number, one: string, many: string) => `${n} ${n === 1 ? one : many}`;
+  if (f.accounts) parts.push(plural(f.accounts.length, 'account', 'accounts'));
+  if (f.categories) parts.push(plural(f.categories.length, 'category', 'categories'));
+  if (f.owners) parts.push(plural(f.owners.length, 'owner', 'owners'));
+  if (f.tags?.length) parts.push(plural(f.tags.length, 'tag', 'tags'));
+  return parts.join(', ');
+}
+
+/**
+ * AND two filters together — used to layer a screen's local/scoped filter on
+ * top of the shared one. For the set-valued dimensions the result is the
+ * intersection (a row must satisfy both); tag predicates concatenate (all must
+ * hold). When only one side constrains a dimension, that side wins.
+ */
+export function mergeFilters(base: Filter | undefined, extra: Filter | undefined): Filter {
+  if (!base) return extra ?? {};
+  if (!extra) return base;
+  const out: Filter = {};
+  for (const dim of ['categories', 'accounts', 'owners'] as const) {
+    const a = base[dim];
+    const b = extra[dim];
+    if (a !== undefined && b !== undefined) out[dim] = a.filter((v) => b.includes(v));
+    else if (a !== undefined) out[dim] = a;
+    else if (b !== undefined) out[dim] = b;
+  }
+  const tags = [...(base.tags ?? []), ...(extra.tags ?? [])];
+  if (tags.length) out.tags = tags;
+  return out;
+}
+
+/**
+ * Builds the SQL condition fragments + bound args that restrict rows by the
+ * filter. `alias` is the alias (or table name) of the transactions row the
+ * conditions reference — 't' in aliased queries, 'transactions' in unaliased
+ * ones. Tag predicates correlate an EXISTS subquery against `${alias}.id`.
+ */
+export function buildFilterConditions(
+  filter: Filter | undefined,
+  alias: string,
+): { conditions: string[]; args: string[] } {
+  if (!filter) return { conditions: [], args: [] };
+  const conditions: string[] = [];
+  const args: string[] = [];
+
+  const inList = (col: string, values: string[]) => {
+    if (values.length === 0) { conditions.push('1 = 0'); return; }
+    conditions.push(`${col} IN (${values.map(() => '?').join(', ')})`);
+    args.push(...values);
+  };
+
+  if (filter.categories !== undefined) inList(`${alias}.category`, filter.categories);
+  if (filter.accounts !== undefined) inList(`${alias}.account_id`, filter.accounts);
+  if (filter.owners !== undefined) {
+    if (filter.owners.length === 0) {
+      conditions.push('1 = 0');
+    } else {
+      const ph = filter.owners.map(() => '?').join(', ');
+      conditions.push(
+        `${alias}.account_id IN (SELECT id FROM accounts WHERE COALESCE(NULLIF(TRIM(owner), ''), 'Unassigned') IN (${ph}))`,
+      );
+      args.push(...filter.owners);
+    }
+  }
+  for (const t of filter.tags ?? []) {
+    const exists = `EXISTS (SELECT 1 FROM transaction_tags tt JOIN tags tg ON tg.id = tt.tag_id WHERE tt.transaction_id = ${alias}.id AND tg.name = ?)`;
+    conditions.push(t.mode === 'has' ? exists : `NOT ${exists}`);
+    args.push(t.name);
+  }
+
+  return { conditions, args };
+}
+
+/**
+ * Same as {@link buildFilterConditions} but returns a single clause ready to
+ * splice after an existing WHERE — prefixed with ` AND ` (or empty when the
+ * filter imposes no constraint).
+ */
+export function buildFilterClause(
+  filter: Filter | undefined,
+  alias: string,
+): { clause: string; args: string[] } {
+  const { conditions, args } = buildFilterConditions(filter, alias);
+  return { clause: conditions.length ? ' AND ' + conditions.join(' AND ') : '', args };
+}

--- a/core/queries.ts
+++ b/core/queries.ts
@@ -1,4 +1,5 @@
 import { db } from './db.js';
+import { buildFilterClause, buildFilterConditions, type Filter } from './filters.js';
 
 export type CategorySummary = { category: string; total: number };
 export type MonthlySummary  = { income: number; expenses: number; net: number; byCategory: CategorySummary[] };
@@ -22,16 +23,15 @@ export async function getMonthlySummary(year: number, month: number): Promise<Mo
   return getRangeSummary(from, to);
 }
 
-export async function getRangeSummary(from: string, to: string, accountId?: string): Promise<MonthlySummary> {
-  const acctClause = accountId ? 'AND account_id = ?' : '';
-  const args: (string | number | null)[] = accountId ? [from, to, accountId] : [from, to];
+export async function getRangeSummary(from: string, to: string, filter?: Filter): Promise<MonthlySummary> {
+  const f = buildFilterClause(filter, 'transactions');
   const result = await db.execute({
     sql: `SELECT category, SUM(amount) as total
           FROM transactions
-          WHERE date >= ? AND date <= ? AND pending = 0 AND ignored = 0 ${acctClause}
+          WHERE date >= ? AND date <= ? AND pending = 0 AND ignored = 0${f.clause}
             AND category NOT IN (SELECT category FROM hidden_categories)
           GROUP BY category ORDER BY total DESC`,
-    args,
+    args: [from, to, ...f.args],
   });
   const rows = result.rows as unknown as { category: string; total: number }[];
   const income   = rows.filter((r) => r.total < 0).reduce((s, r) => s + Math.abs(r.total), 0);
@@ -62,22 +62,20 @@ export async function getMerchantSummary(
   category: string,
   from: string,
   to: string,
-  accountId?: string,
+  filter?: Filter,
 ): Promise<MerchantSummaryRow[]> {
-  const acctClause = accountId ? 'AND account_id = ?' : '';
-  const args: (string | number | null)[] = accountId ? [from, to, category, accountId] : [from, to, category];
+  const f = buildFilterClause(filter, 'transactions');
 
   const result = await db.execute({
     sql: `SELECT COALESCE(display_name, name) as merchant, SUM(amount) as total, COUNT(*) as count
           FROM transactions
           WHERE date >= ? AND date <= ? AND category = ?
             AND pending = 0 AND ignored = 0
-            AND category NOT IN (SELECT category FROM hidden_categories)
-            ${acctClause}
+            AND category NOT IN (SELECT category FROM hidden_categories)${f.clause}
           GROUP BY merchant
           HAVING SUM(amount) > 0
           ORDER BY total DESC, count DESC, merchant ASC`,
-    args,
+    args: [from, to, category, ...f.args],
   });
   const rows = result.rows as unknown as { merchant: string; total: number; count: number }[];
 
@@ -96,8 +94,8 @@ export async function getMerchantSummary(
 
 export type FlexSummary = { fixed: number; flexible: number; discretionary: number; untagged: number };
 
-export async function getFlexSummary(from: string, to: string, accountId?: string): Promise<FlexSummary> {
-  return queryFlexTotals(from, to, accountId);
+export async function getFlexSummary(from: string, to: string, filter?: Filter): Promise<FlexSummary> {
+  return queryFlexTotals(from, to, filter);
 }
 
 export async function getRecentTransactions(limit = 10): Promise<RecentTransaction[]> {
@@ -113,14 +111,13 @@ export async function hasAccounts(): Promise<boolean> {
   return Number((result.rows[0] as unknown as { count: number }).count) > 0;
 }
 
-export async function getUncategorizedCount(from: string, to: string, accountId?: string): Promise<number> {
-  const where = accountId ? 'AND account_id = ?' : '';
-  const args: (string | number | null)[] = accountId ? [from, to, accountId] : [from, to];
+export async function getUncategorizedCount(from: string, to: string, filter?: Filter): Promise<number> {
+  const f = buildFilterClause(filter, 'transactions');
   const result = await db.execute({
     sql: `SELECT COUNT(*) as c FROM transactions
           WHERE category = 'Uncategorized' AND pending = 0 AND ignored = 0
-            AND date >= ? AND date <= ? ${where}`,
-    args,
+            AND date >= ? AND date <= ?${f.clause}`,
+    args: [from, to, ...f.args],
   });
   return Number((result.rows[0] as unknown as { c: number }).c);
 }
@@ -187,38 +184,36 @@ export type FlexDriftData = Record<keyof FlexSummary, DriftSlice>;
 export type AccountDrift  = { id: string; name: string; subtype: string | null } & DriftSlice;
 type Window = { from: string; to: string };
 
-async function queryCategoryTotals(from: string, to: string, accountId?: string): Promise<Map<string, number>> {
-  const acctClause = accountId ? 'AND account_id = ?' : '';
-  const args: (string | number | null)[] = accountId ? [from, to, accountId] : [from, to];
+async function queryCategoryTotals(from: string, to: string, filter?: Filter): Promise<Map<string, number>> {
+  const f = buildFilterClause(filter, 'transactions');
   const result = await db.execute({
     sql: `SELECT category, SUM(amount) as total
           FROM transactions
-          WHERE date >= ? AND date <= ? ${acctClause}
+          WHERE date >= ? AND date <= ?
             AND amount > 0 AND pending = 0 AND ignored = 0
-            AND category NOT IN (SELECT category FROM hidden_categories)
+            AND category NOT IN (SELECT category FROM hidden_categories)${f.clause}
           GROUP BY category HAVING SUM(amount) > 0`,
-    args,
+    args: [from, to, ...f.args],
   });
   const rows = result.rows as unknown as { category: string; total: number }[];
   return new Map(rows.map((r) => [r.category, Number(r.total)]));
 }
 
-async function queryFlexTotals(from: string, to: string, accountId?: string): Promise<FlexSummary> {
-  const acctClause = accountId ? 'AND t.account_id = ?' : '';
-  const args: (string | number | null)[] = accountId ? [from, to, accountId] : [from, to];
+async function queryFlexTotals(from: string, to: string, filter?: Filter): Promise<FlexSummary> {
+  const f = buildFilterClause(filter, 't');
   const result = await db.execute({
     sql: `SELECT COALESCE(c.flexibility, 'untagged') as tier, SUM(cat_totals.total) as total
           FROM (
             SELECT t.category, SUM(t.amount) as total
             FROM transactions t
-            WHERE t.date >= ? AND t.date <= ? ${acctClause}
+            WHERE t.date >= ? AND t.date <= ?
               AND t.pending = 0 AND t.ignored = 0
-              AND t.category NOT IN (SELECT category FROM hidden_categories)
+              AND t.category NOT IN (SELECT category FROM hidden_categories)${f.clause}
             GROUP BY t.category HAVING SUM(t.amount) > 0
           ) as cat_totals
           LEFT JOIN categories c ON c.name = cat_totals.category
           GROUP BY tier`,
-    args,
+    args: [from, to, ...f.args],
   });
   const rows = result.rows as unknown as { tier: string; total: number }[];
   const out: FlexSummary = { fixed: 0, flexible: 0, discretionary: 0, untagged: 0 };
@@ -250,13 +245,13 @@ function sliceFor(current: number, last: number, year: number, rolling: number[]
 }
 
 export async function getCategoryDriftData(
-  currentWin: Window, lastPeriodWin: Window, lastYearWin: Window, rolling12: Window[], accountId?: string,
+  currentWin: Window, lastPeriodWin: Window, lastYearWin: Window, rolling12: Window[], filter?: Filter,
 ): Promise<CategoryDrift[]> {
   const [cur, last, yr, ...rolls] = await Promise.all([
-    queryCategoryTotals(currentWin.from, currentWin.to, accountId),
-    queryCategoryTotals(lastPeriodWin.from, lastPeriodWin.to, accountId),
-    queryCategoryTotals(lastYearWin.from, lastYearWin.to, accountId),
-    ...rolling12.map((w) => queryCategoryTotals(w.from, w.to, accountId)),
+    queryCategoryTotals(currentWin.from, currentWin.to, filter),
+    queryCategoryTotals(lastPeriodWin.from, lastPeriodWin.to, filter),
+    queryCategoryTotals(lastYearWin.from, lastYearWin.to, filter),
+    ...rolling12.map((w) => queryCategoryTotals(w.from, w.to, filter)),
   ]);
   return [...cur.entries()]
     .map(([category, currentAmt]) => ({
@@ -267,13 +262,13 @@ export async function getCategoryDriftData(
 }
 
 export async function getFlexDriftData(
-  currentWin: Window, lastPeriodWin: Window, lastYearWin: Window, rolling12: Window[], accountId?: string,
+  currentWin: Window, lastPeriodWin: Window, lastYearWin: Window, rolling12: Window[], filter?: Filter,
 ): Promise<FlexDriftData> {
   const [cur, last, yr, ...rolls] = await Promise.all([
-    queryFlexTotals(currentWin.from, currentWin.to, accountId),
-    queryFlexTotals(lastPeriodWin.from, lastPeriodWin.to, accountId),
-    queryFlexTotals(lastYearWin.from, lastYearWin.to, accountId),
-    ...rolling12.map((w) => queryFlexTotals(w.from, w.to, accountId)),
+    queryFlexTotals(currentWin.from, currentWin.to, filter),
+    queryFlexTotals(lastPeriodWin.from, lastPeriodWin.to, filter),
+    queryFlexTotals(lastYearWin.from, lastYearWin.to, filter),
+    ...rolling12.map((w) => queryFlexTotals(w.from, w.to, filter)),
   ]);
   const tiers: (keyof FlexSummary)[] = ['fixed', 'flexible', 'discretionary', 'untagged'];
   return Object.fromEntries(
@@ -304,19 +299,18 @@ export async function getAccountDriftData(
 }
 
 export async function getSearchFilteredData(
-  from: string, to: string, search: string, accountId?: string,
+  from: string, to: string, search: string, filter?: Filter,
 ): Promise<{ summary: MonthlySummary; flexData: FlexSummary }> {
-  const acctClause = accountId ? 'AND t.account_id = ?' : '';
-  const args: (string | number | null)[] = accountId ? [from, to, accountId] : [from, to];
+  const f = buildFilterClause(filter, 't');
   const result = await db.execute({
     sql: `SELECT COALESCE(t.display_name, t.name) as display, t.merchant_name, t.amount, t.category,
             COALESCE(c.flexibility, 'untagged') as flex
           FROM transactions t
           LEFT JOIN categories c ON c.name = t.category
-          WHERE t.date >= ? AND t.date <= ? ${acctClause}
+          WHERE t.date >= ? AND t.date <= ?
             AND t.pending = 0 AND t.ignored = 0
-            AND t.category NOT IN (SELECT category FROM hidden_categories)`,
-    args,
+            AND t.category NOT IN (SELECT category FROM hidden_categories)${f.clause}`,
+    args: [from, to, ...f.args],
   });
   const rows = result.rows as unknown as { display: string; merchant_name: string | null; amount: number; category: string; flex: string }[];
 
@@ -427,22 +421,19 @@ export function buildSearchRe(search: string): RegExp {
 }
 
 export async function getTransactions(filters: {
-  category?: string | null; from?: string | null; to?: string | null;
-  search?: string; tag?: string | null; account?: string | null; sort?: SortMode;
+  filter?: Filter; from?: string | null; to?: string | null;
+  search?: string; sort?: SortMode;
   txType?: 'income' | 'expenses' | null;
   flex?: 'fixed' | 'flexible' | 'discretionary' | null;
 }): Promise<TxRow[]> {
-  const { category, from, to, search, tag, account, sort = 'date-desc', txType, flex } = filters;
+  const { filter, from, to, search, sort = 'date-desc', txType, flex } = filters;
   const conditions: string[] = [];
   const args: (string | number | null)[] = [];
 
-  if (category) { conditions.push('t.category = ?'); args.push(category); }
   if (from && to) { conditions.push('t.date >= ? AND t.date <= ?'); args.push(from, to); }
-  if (tag) {
-    conditions.push('EXISTS (SELECT 1 FROM transaction_tags tt JOIN tags tg ON tg.id = tt.tag_id WHERE tt.transaction_id = t.id AND tg.name = ?)');
-    args.push(tag);
-  }
-  if (account) { conditions.push('t.account_id = ?'); args.push(account); }
+  const fc = buildFilterConditions(filter, 't');
+  conditions.push(...fc.conditions);
+  args.push(...fc.args);
   if (txType === 'income') { conditions.push('t.amount < 0'); conditions.push('t.category NOT IN (SELECT category FROM hidden_categories)'); }
   if (txType === 'expenses') { conditions.push('t.amount > 0'); conditions.push('t.category NOT IN (SELECT category FROM hidden_categories)'); }
   if (flex) { conditions.push('EXISTS (SELECT 1 FROM categories c WHERE c.name = t.category AND c.flexibility = ?)'); args.push(flex); }
@@ -463,15 +454,14 @@ export async function getTransactions(filters: {
 }
 
 export async function countSearchMatches(
-  from: string, to: string, search: string, accountId?: string,
+  from: string, to: string, search: string, filter?: Filter,
 ): Promise<{ count: number; expenses: number }> {
   if (!search) return { count: 0, expenses: 0 };
-  const acctClause = accountId ? 'AND account_id = ?' : '';
-  const args: (string | number | null)[] = accountId ? [from, to, accountId] : [from, to];
+  const f = buildFilterClause(filter, 'transactions');
   const result = await db.execute({
     sql: `SELECT COALESCE(display_name, name) as display, merchant_name, amount
-          FROM transactions WHERE date >= ? AND date <= ? ${acctClause} AND pending = 0 AND ignored = 0`,
-    args,
+          FROM transactions WHERE date >= ? AND date <= ?${f.clause} AND pending = 0 AND ignored = 0`,
+    args: [from, to, ...f.args],
   });
   const rows = result.rows as unknown as { display: string; merchant_name: string | null; amount: number }[];
   const re = buildSearchRe(search);

--- a/core/tools.ts
+++ b/core/tools.ts
@@ -458,6 +458,7 @@ async function executeToolImpl(
       const from = str('from'); const to = str('to');
       const year = num('year'); const month = num('month');
       const accountId = str('account_id') || undefined;
+      const acctFilter = accountId ? { accounts: [accountId] } : undefined;
 
       const fmtRows = (rows: Awaited<ReturnType<typeof getMerchantSummary>>, label: string) => {
         if (!rows.length) return `No merchant spend found for "${category}" in ${label}.`;
@@ -465,12 +466,12 @@ async function executeToolImpl(
       };
 
       if (from && to) {
-        return fmtRows(await getMerchantSummary(category, from, to, accountId), `${from} – ${to}`);
+        return fmtRows(await getMerchantSummary(category, from, to, acctFilter), `${from} – ${to}`);
       }
       if (year && month) {
         const start = `${year}-${String(month).padStart(2, '0')}-01`;
         const end   = `${year}-${String(month).padStart(2, '0')}-${String(new Date(year, month, 0).getDate()).padStart(2, '0')}`;
-        return fmtRows(await getMerchantSummary(category, start, end, accountId), `${new Date(year, month - 1).toLocaleString('en-US', { month: 'long' })} ${year}`);
+        return fmtRows(await getMerchantSummary(category, start, end, acctFilter), `${new Date(year, month - 1).toLocaleString('en-US', { month: 'long' })} ${year}`);
       }
       return "Provide either (year + month) or (from + to).";
     }

--- a/core/trends.ts
+++ b/core/trends.ts
@@ -1,6 +1,7 @@
 import { db } from './db.js';
 import { MONTHS, addDays, weekLabel, type TrendsRange } from './dateUtils.js';
 import { buildSearchRe } from './queries.js';
+import { buildFilterClause, type Filter } from './filters.js';
 
 const pad = (n: number) => String(n).padStart(2, '0');
 const Q_FROM = ['01', '04', '07', '10'];
@@ -84,8 +85,9 @@ export async function generateAllPeriods(range: TrendsRange): Promise<Array<{ la
   return result;
 }
 
-export async function getPeriodTotals(view: View, range: TrendsRange): Promise<PeriodRow[]> {
+export async function getPeriodTotals(view: View, range: TrendsRange, filter?: Filter): Promise<PeriodRow[]> {
   const allPeriods = await generateAllPeriods(range);
+  const f = buildFilterClause(filter, 't');
 
   if (view.mode === 'flexbreakdown') {
     const flexExpr = `
@@ -103,7 +105,7 @@ export async function getPeriodTotals(view: View, range: TrendsRange): Promise<P
             t.category, SUM(t.amount) as total
           FROM transactions t
           WHERE t.pending = 0 AND t.ignored = 0
-            AND t.category NOT IN (SELECT category FROM hidden_categories)
+            AND t.category NOT IN (SELECT category FROM hidden_categories)${f.clause}
           GROUP BY y, m, t.category HAVING SUM(t.amount) > 0
         ) cat LEFT JOIN categories c ON c.name = cat.category
         GROUP BY cat.y, cat.m ORDER BY cat.y, cat.m
@@ -116,7 +118,7 @@ export async function getPeriodTotals(view: View, range: TrendsRange): Promise<P
             t.category, SUM(t.amount) as total
           FROM transactions t
           WHERE t.pending = 0 AND t.ignored = 0
-            AND t.category NOT IN (SELECT category FROM hidden_categories)
+            AND t.category NOT IN (SELECT category FROM hidden_categories)${f.clause}
           GROUP BY y, q, t.category HAVING SUM(t.amount) > 0
         ) cat LEFT JOIN categories c ON c.name = cat.category
         GROUP BY cat.y, cat.q ORDER BY cat.y, cat.q
@@ -128,7 +130,7 @@ export async function getPeriodTotals(view: View, range: TrendsRange): Promise<P
           SELECT CAST(substr(t.date,1,4) AS INTEGER) as y, t.category, SUM(t.amount) as total
           FROM transactions t
           WHERE t.pending = 0 AND t.ignored = 0
-            AND t.category NOT IN (SELECT category FROM hidden_categories)
+            AND t.category NOT IN (SELECT category FROM hidden_categories)${f.clause}
           GROUP BY y, t.category HAVING SUM(t.amount) > 0
         ) cat LEFT JOIN categories c ON c.name = cat.category
         GROUP BY cat.y ORDER BY cat.y
@@ -141,13 +143,13 @@ export async function getPeriodTotals(view: View, range: TrendsRange): Promise<P
             t.category, SUM(t.amount) as total
           FROM transactions t
           WHERE t.pending = 0 AND t.ignored = 0
-            AND t.category NOT IN (SELECT category FROM hidden_categories)
+            AND t.category NOT IN (SELECT category FROM hidden_categories)${f.clause}
           GROUP BY week_start, t.category HAVING SUM(t.amount) > 0
         ) cat LEFT JOIN categories c ON c.name = cat.category
         GROUP BY cat.week_start ORDER BY cat.week_start
       `;
     }
-    const rawResult = await db.execute(sql);
+    const rawResult = await db.execute({ sql, args: f.args });
     const rawRows = rawResult.rows as unknown as any[];
 
     const actual = new Map<string, PeriodRow>();
@@ -176,7 +178,7 @@ export async function getPeriodTotals(view: View, range: TrendsRange): Promise<P
     : 'AND t.category NOT IN (SELECT category FROM hidden_categories)';
 
   const amtFilter = view.mode === 'income' ? 'AND t.amount < 0' : view.mode === 'net' ? '' : 'AND t.amount > 0';
-  const base = `FROM transactions t WHERE t.pending = 0 AND t.ignored = 0 ${amtFilter} ${catFilter}`;
+  const base = `FROM transactions t WHERE t.pending = 0 AND t.ignored = 0 ${amtFilter} ${catFilter}${f.clause}`;
   const isNet = view.mode === 'net';
   const totalExpr = isNet
     ? 'SUM(CASE WHEN t.amount < 0 THEN ABS(t.amount) ELSE 0 END) as income, SUM(CASE WHEN t.amount > 0 THEN t.amount ELSE 0 END) as expenses, SUM(CASE WHEN t.amount < 0 THEN ABS(t.amount) ELSE -t.amount END) as total'
@@ -204,7 +206,7 @@ export async function getPeriodTotals(view: View, range: TrendsRange): Promise<P
     };
   }
 
-  const rawResult = await db.execute(sql);
+  const rawResult = await db.execute({ sql, args: f.args });
   const rawRows = rawResult.rows as unknown as any[];
   const actual = new Map<string, PeriodRow>(rawRows.map((r) => { const row = toActual(r); return [row.from, row]; }));
   return allPeriods.map((p) => actual.get(p.from) ?? zeroRow(p));
@@ -224,12 +226,16 @@ function periodFrom(date: string, range: TrendsRange): string {
   return mon.toISOString().slice(0, 10);
 }
 
-export async function getSearchPeriodTotals(search: string, range: TrendsRange): Promise<PeriodRow[]> {
+export async function getSearchPeriodTotals(search: string, range: TrendsRange, filter?: Filter): Promise<PeriodRow[]> {
   if (!search) return [];
-  const result = await db.execute(`
+  const f = buildFilterClause(filter, 'transactions');
+  const result = await db.execute({
+    sql: `
     SELECT COALESCE(display_name, name) as display, merchant_name, date, amount
-    FROM transactions WHERE pending = 0 AND ignored = 0
-  `);
+    FROM transactions WHERE pending = 0 AND ignored = 0${f.clause}
+  `,
+    args: f.args,
+  });
   const rows = result.rows as unknown as { display: string; merchant_name: string | null; date: string; amount: number }[];
   const re = buildSearchRe(search);
   const periodMap = new Map<string, { income: number; expenses: number }>();
@@ -253,12 +259,17 @@ export async function getSearchPeriodTotals(search: string, range: TrendsRange):
 export async function getSearchMatchingPeriods(
   search: string,
   range: TrendsRange,
+  filter?: Filter,
 ): Promise<{ periods: Set<string>; count: number }> {
   if (!search) return { periods: new Set(), count: 0 };
-  const result = await db.execute(`
+  const f = buildFilterClause(filter, 'transactions');
+  const result = await db.execute({
+    sql: `
     SELECT COALESCE(display_name, name) as display, merchant_name, date
-    FROM transactions WHERE pending = 0 AND ignored = 0
-  `);
+    FROM transactions WHERE pending = 0 AND ignored = 0${f.clause}
+  `,
+    args: f.args,
+  });
   const rows = result.rows as unknown as { display: string; merchant_name: string | null; date: string }[];
   const re = buildSearchRe(search);
   const periods = new Set<string>();

--- a/docs/filter-panel-plan.md
+++ b/docs/filter-panel-plan.md
@@ -1,0 +1,133 @@
+# Implementation Plan: Unified Filter Panel
+
+A shared, keyboard-driven filter panel across Dashboard, Transactions, and Trends,
+per the proposal in [issue #44](https://github.com/tomfunk/fungible/issues/44#issuecomment-4623842591).
+Filter state is session-global and follows you between the three screens.
+
+## Decisions locked in
+
+- **Cross-dimension = AND, within-dimension = OR**, non-configurable. Owner is an
+  independent AND'd dimension implemented as an `account_id` constraint, so
+  "Owner=Mark AND Account=Chase" = Chase accounts owned by Mark.
+- **Tags are tri-state** per row, cycling `[ ] → [✓ has] → [✗ lacks]`; multiple
+  tags AND together.
+- **Session-only** state, no disk persistence.
+- Panel **replaces** Space-to-filter and `[c]` on the Dashboard account view.
+- Free-text `/` search stays a **separate ephemeral mechanism** (not a panel
+  section), leaving room to grow it into omnisearch later.
+- The `filter-txs-tags-has-lacks` branch is **abandoned**; we salvage its
+  `tagFilterClause` SQL pattern and its tag-filter tests.
+- **Invert key = `i`** (safe — the panel is modal and gates host-screen input).
+- **Drill-downs write into the shared filter** (e.g. clicking a category sets
+  `categories:[that one]`, leaving the other dimensions untouched) so there is a
+  single source of truth and the destination screen's header reflects it.
+
+## Model & semantics
+
+The "empty vs all" subtlety is the one real modeling trap:
+
+- The **query-facing filter** treats an **absent dimension = no constraint (all)**,
+  a **present array = exactly those** (empty array → match nothing).
+- The **panel** works internally with an explicit selected `Set` initialized to the
+  full universe. On apply it serializes: full universe → omit the dimension; subset
+  → the array; none → empty array.
+
+This round-trips cleanly when re-opening the panel and dodges the invalid `IN ()`
+problem.
+
+## PR 1 — Data layer + shared state (no visible UI change)
+
+The risky, mechanical half. Filter starts empty, so behavior is identical to today;
+this PR is pure refactor + plumbing and is reviewable on its own.
+
+1. **`core/filters.ts` (new)** — shared by core and TUI:
+   - `TagPredicate = { name: string; mode: 'has' | 'lacks' }`
+   - `Filter = { categories?: string[]; accounts?: string[]; owners?: string[]; tags?: TagPredicate[] }`
+   - helpers: `isFilterActive(f)`, `filterSummary(f)` → `"2 accounts, 4 categories"`
+     for the header hint.
+
+2. **`buildFilterClause(filter, alias)`** (in `core/queries.ts`, generalizing the
+   salvaged `tagFilterClause`): emits an `AND …`-prefixed clause + parameterized args.
+   - categories → `${alias}.category IN (…)`
+   - accounts → `${alias}.account_id IN (…)`
+   - owners → `${alias}.account_id IN (SELECT id FROM accounts WHERE COALESCE(NULLIF(TRIM(owner),''),'Unassigned') IN (…))`
+     (handles the `Unassigned` bucket the owner split already uses)
+   - tags → one `EXISTS`/`NOT EXISTS` per predicate
+   - empty array on any dim → `1=0`; absent → skipped.
+
+3. **Thread `filter?: Filter` through the query layer**, replacing the current
+   one-off `accountId?`/`tagFilter?` params:
+   - `queries.ts`: `getRangeSummary`, `getMerchantSummary`, `getFlexSummary`,
+     `getUncategorizedCount`, `queryCategoryTotals`, `queryFlexTotals`, the
+     rolling/comparison series, `countSearchMatches`, and `getTransactions`
+     (replace its inline category/tag/account with `buildFilterClause`; keep
+     `search`/`txType`/`flex`/`sort`).
+   - `trends.ts`: `getPeriodTotals`, `getSearchPeriodTotals`,
+     `getSearchMatchingPeriods`. Splice the clause into each `WHERE`; keep their
+     existing args parameterized.
+   - Owner split (`getOwnerSpending`) groups *by* owner, so it ignores the owner
+     dimension but still honors the other three.
+
+4. **`tui/FilterContext.tsx` (new)** — mirrors `RefreshContext`/`TypingContext`:
+   `{ filter, setFilter }`, `useFilter()`. Wrap `<AppInner/>` in `<FilterProvider>`
+   in `App.tsx`. Session-only `useState`.
+
+5. **Shrink `TxFilter`** to navigation-only fields
+   (`from/to/range/anchor/search/txType/flex/canvasSpec`); the four structured
+   dimensions move to `FilterContext`. Update Dashboard/Transactions/Trends to read
+   `useFilter()` and pass `filter` into their queries. Migrate drill-downs to
+   `setFilter(...)`.
+
+6. **Tests:** `buildFilterClause` unit tests (each dim, multi-select, owner subquery
+   incl. `Unassigned`, tag has/lacks/multi, empty=nothing, absent=all) — adapt the
+   salvaged tag tests; plus `getTransactions`/`getRangeSummary`/trends with a filter
+   applied.
+
+## PR 2 — Filter panel UI
+
+7. **`tui/components/FilterPanel.tsx` (new)**, built on the existing `ModalPanel`:
+   - Loads universes: categories, accounts (`getLinkedAccounts`), owners
+     (`householdMembers` + `Unassigned`), tags (`core/tags.ts`).
+   - State: focused section, per-section selection `Set` (+ tag tri-state map),
+     per-section cursor, inline-search string.
+   - Init from current `filter` (absent dim → all checked; array → those; `[]` → none).
+   - Keys (captured while open): `f`/`Esc` close (`Esc` restores prior state),
+     `←/→` section, `↑/↓` row, `x` toggle (tags cycle), `a` select-all, `i` invert,
+     `/` inline search within section (narrows list, selections persist), `Enter`
+     apply → serialize → `setFilter` → close.
+
+8. **Wire into the three screens:** local `panelOpen` state, render `<FilterPanel>`,
+   `f` toggles it, and gate the host `useInput` while open (same pattern as
+   `searchMode`). Header hint via `filterSummary(filter)` in `PageHeader`, shown only
+   when `isFilterActive`.
+
+9. **Remove** the Dashboard account-view Space-to-filter + `[c]` plumbing. Keep the
+   *owner spending* DashView as a display — it's separate from the owner filter
+   dimension.
+
+10. **Tests** (`tests/tui/screens.test.tsx`): open/close, toggle + apply updates the
+    summary, **filter persists across a screen switch** (set on Dashboard, switch to
+    Transactions, assert applied), `Esc` restores.
+
+## Search composition
+
+`/` search and the panel filter compose with AND. The transaction list already
+applies search as a post-filter on top of the WHERE clause, so it composes for free.
+The only change: Dashboard's separate search-recompute path
+(`getSearchFilteredData`/`countSearchMatches`) must also take the shared filter.
+
+## Risks / watch-items
+
+- Input gating where modal + Chat focus + `/` search overlap — get the early-returns
+  right.
+- `trends.ts` builds SQL via template strings (e.g. `view.flex` is interpolated);
+  keep our additions parameterized via args, don't interpolate filter values.
+- The empty-vs-all serialization is the most bug-prone bit — covered by dedicated
+  unit tests in PR 1.
+
+## Out of scope (possible later)
+
+- **Omnisearch** (`tag:happyhour`, `!tag:x`, `owner:Mark`) as a power-user
+  accelerator that mutates the same `FilterContext` — a possible PR 3.
+- Configurable AND/OR logic.
+- Cross-restart filter persistence.

--- a/tests/drift.test.ts
+++ b/tests/drift.test.ts
@@ -263,7 +263,7 @@ describe('getCategoryDriftData', () => {
     await insertTx({ date: '2026-05-15', amount: 100, category: 'Food', account_id: 'acct1' });
     await insertTx({ date: '2026-05-15', amount: 200, category: 'Food', account_id: 'acct2' });
 
-    const result = await getCategoryDriftData(current, lastPeriod, lastYear, rolling12, 'acct1');
+    const result = await getCategoryDriftData(current, lastPeriod, lastYear, rolling12, { accounts: ['acct1'] });
     const row = result.find((r) => r.category === 'Food')!;
     expect(row.current).toBeCloseTo(100);
   });

--- a/tests/filters.test.ts
+++ b/tests/filters.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  buildFilterConditions, buildFilterClause, mergeFilters,
+  isFilterActive, filterSummary, type Filter,
+} from '../core/filters.js';
+
+// ── Pure clause-builder tests (no database) ────────────────────────────────────
+
+describe('buildFilterConditions', () => {
+  it('returns nothing for undefined or empty filter', () => {
+    expect(buildFilterConditions(undefined, 't')).toEqual({ conditions: [], args: [] });
+    expect(buildFilterConditions({}, 't')).toEqual({ conditions: [], args: [] });
+  });
+
+  it('builds an IN list for categories with one placeholder per value', () => {
+    const { conditions, args } = buildFilterConditions({ categories: ['Rent', 'Dining'] }, 't');
+    expect(conditions).toEqual(['t.category IN (?, ?)']);
+    expect(args).toEqual(['Rent', 'Dining']);
+  });
+
+  it('builds an IN list for accounts using the given alias', () => {
+    const { conditions, args } = buildFilterConditions({ accounts: ['a1'] }, 'transactions');
+    expect(conditions).toEqual(['transactions.account_id IN (?)']);
+    expect(args).toEqual(['a1']);
+  });
+
+  it('resolves owners through an accounts subquery, normalizing Unassigned', () => {
+    const { conditions, args } = buildFilterConditions({ owners: ['Mark', 'Unassigned'] }, 't');
+    expect(conditions[0]).toContain('t.account_id IN (SELECT id FROM accounts WHERE');
+    expect(conditions[0]).toContain("COALESCE(NULLIF(TRIM(owner), ''), 'Unassigned') IN (?, ?)");
+    expect(args).toEqual(['Mark', 'Unassigned']);
+  });
+
+  it('emits EXISTS for has and NOT EXISTS for lacks, one per tag predicate', () => {
+    const { conditions, args } = buildFilterConditions(
+      { tags: [{ name: 'shared', mode: 'has' }, { name: 'personal', mode: 'lacks' }] },
+      't',
+    );
+    expect(conditions[0].startsWith('EXISTS')).toBe(true);
+    expect(conditions[0]).toContain('tt.transaction_id = t.id');
+    expect(conditions[1].startsWith('NOT EXISTS')).toBe(true);
+    expect(args).toEqual(['shared', 'personal']);
+  });
+
+  it('treats a present-but-empty dimension as match-nothing (1 = 0)', () => {
+    expect(buildFilterConditions({ categories: [] }, 't').conditions).toEqual(['1 = 0']);
+    expect(buildFilterConditions({ accounts: [] }, 't').conditions).toEqual(['1 = 0']);
+    expect(buildFilterConditions({ owners: [] }, 't').conditions).toEqual(['1 = 0']);
+  });
+
+  it('ANDs multiple dimensions together', () => {
+    const { conditions, args } = buildFilterConditions(
+      { categories: ['Rent'], accounts: ['a1'] }, 't',
+    );
+    expect(conditions).toEqual(['t.category IN (?)', 't.account_id IN (?)']);
+    expect(args).toEqual(['Rent', 'a1']);
+  });
+});
+
+describe('buildFilterClause', () => {
+  it('prefixes a spliceable AND clause, or empty string when unconstrained', () => {
+    expect(buildFilterClause(undefined, 't').clause).toBe('');
+    expect(buildFilterClause({ categories: ['Rent'] }, 't').clause).toBe(' AND t.category IN (?)');
+  });
+});
+
+describe('mergeFilters', () => {
+  it('uses whichever side constrains a dimension when the other does not', () => {
+    expect(mergeFilters({}, { categories: ['A'] })).toEqual({ categories: ['A'] });
+    expect(mergeFilters({ accounts: ['a1'] }, undefined)).toEqual({ accounts: ['a1'] });
+    expect(mergeFilters(undefined, { accounts: ['a1'] })).toEqual({ accounts: ['a1'] });
+  });
+
+  it('intersects set dimensions constrained on both sides', () => {
+    expect(mergeFilters({ categories: ['A', 'B'] }, { categories: ['B', 'C'] }))
+      .toEqual({ categories: ['B'] });
+  });
+
+  it('concatenates tag predicates from both sides', () => {
+    const merged = mergeFilters(
+      { tags: [{ name: 'x', mode: 'has' }] },
+      { tags: [{ name: 'y', mode: 'lacks' }] },
+    );
+    expect(merged.tags).toEqual([{ name: 'x', mode: 'has' }, { name: 'y', mode: 'lacks' }]);
+  });
+});
+
+describe('isFilterActive / filterSummary', () => {
+  it('is inactive for empty/undefined and for tag-only empty arrays', () => {
+    expect(isFilterActive(undefined)).toBe(false);
+    expect(isFilterActive({})).toBe(false);
+    expect(isFilterActive({ tags: [] })).toBe(false);
+  });
+
+  it('is active when any set dimension is present, even when empty', () => {
+    expect(isFilterActive({ categories: [] })).toBe(true);
+    expect(isFilterActive({ accounts: ['a1'] })).toBe(true);
+    expect(isFilterActive({ tags: [{ name: 'x', mode: 'has' }] })).toBe(true);
+  });
+
+  it('summarizes active dimensions with correct pluralization', () => {
+    expect(filterSummary({ accounts: ['a1', 'a2'], categories: ['Rent'] }))
+      .toBe('2 accounts, 1 category');
+    expect(filterSummary({})).toBe('');
+  });
+});
+
+// ── Database-backed integration tests ──────────────────────────────────────────
+
+vi.mock('../core/db.js', async () => {
+  const { makeTestDb } = await import('./helpers/makeTestDb.js');
+  return { db: await makeTestDb() };
+});
+
+const { db } = await import('../core/db.js');
+const { getTransactions, getRangeSummary } = await import('../core/queries.js');
+const { getPeriodTotals } = await import('../core/trends.js');
+
+let txId = 0;
+async function insertTx(opts: { amount: number; category?: string; accountId?: string; date?: string }) {
+  txId++;
+  await db.execute({
+    sql: `INSERT INTO transactions (id, account_id, date, name, amount, category, pending, ignored)
+          VALUES (?, ?, ?, ?, ?, ?, 0, 0)`,
+    args: [`tx${txId}`, opts.accountId ?? 'a1', opts.date ?? '2025-01-15', 'Tx', opts.amount, opts.category ?? 'Shopping'],
+  });
+  return `tx${txId}`;
+}
+const addAccount = (id: string, owner: string | null) =>
+  db.execute({ sql: "INSERT INTO accounts (id, name, type, owner) VALUES (?, ?, 'depository', ?)", args: [id, id, owner] });
+async function tagTx(txId: string, tagName: string) {
+  await db.execute({ sql: 'INSERT OR IGNORE INTO tags (name) VALUES (?)', args: [tagName] });
+  const r = await db.execute({ sql: 'SELECT id FROM tags WHERE name = ?', args: [tagName] });
+  const tagId = (r.rows[0] as unknown as { id: number }).id;
+  await db.execute({ sql: 'INSERT INTO transaction_tags (transaction_id, tag_id) VALUES (?, ?)', args: [txId, tagId] });
+}
+
+beforeEach(async () => {
+  txId = 0;
+  for (const t of ['transaction_tags', 'tags', 'transactions', 'accounts', 'hidden_categories', 'categories']) {
+    await db.execute(`DELETE FROM ${t}`);
+  }
+});
+
+describe('getTransactions with a Filter', () => {
+  it('restricts to the selected categories (OR within the dimension)', async () => {
+    await insertTx({ category: 'Rent', amount: 100 });
+    await insertTx({ category: 'Dining', amount: 50 });
+    await insertTx({ category: 'Shopping', amount: 25 });
+    const rows = await getTransactions({ filter: { categories: ['Rent', 'Dining'] } });
+    expect(rows.map((r) => r.category).sort()).toEqual(['Dining', 'Rent']);
+  });
+
+  it('restricts to the selected accounts', async () => {
+    await insertTx({ accountId: 'a1', amount: 100 });
+    await insertTx({ accountId: 'a2', amount: 200 });
+    const rows = await getTransactions({ filter: { accounts: ['a1'] } });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].amount).toBe(100);
+  });
+
+  it('restricts by owner — Chase txns owned by Mark (account AND owner)', async () => {
+    await addAccount('chase', 'Mark');
+    await addAccount('amex', 'Mark');
+    await addAccount('joint', 'Partner');
+    await insertTx({ accountId: 'chase', amount: 10 });
+    await insertTx({ accountId: 'amex', amount: 20 });
+    await insertTx({ accountId: 'joint', amount: 30 });
+    const rows = await getTransactions({ filter: { owners: ['Mark'], accounts: ['chase'] } });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].amount).toBe(10);
+  });
+
+  it('buckets owner-less accounts under Unassigned', async () => {
+    await addAccount('a1', 'Mark');
+    await addAccount('a2', null);
+    await insertTx({ accountId: 'a1', amount: 10 });
+    await insertTx({ accountId: 'a2', amount: 20 });
+    const rows = await getTransactions({ filter: { owners: ['Unassigned'] } });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].amount).toBe(20);
+  });
+
+  it('filters by tag presence (has) and absence (lacks)', async () => {
+    const t1 = await insertTx({ amount: 10 });
+    await insertTx({ amount: 20 });
+    await tagTx(t1, 'personal');
+    expect((await getTransactions({ filter: { tags: [{ name: 'personal', mode: 'has' }] } }))
+      .map((r) => r.amount)).toEqual([10]);
+    expect((await getTransactions({ filter: { tags: [{ name: 'personal', mode: 'lacks' }] } }))
+      .map((r) => r.amount)).toEqual([20]);
+  });
+
+  it('ANDs multiple tag predicates: has shared AND lacks personal', async () => {
+    const t1 = await insertTx({ amount: 10 });
+    const t2 = await insertTx({ amount: 20 });
+    await tagTx(t1, 'shared');
+    await tagTx(t2, 'shared'); await tagTx(t2, 'personal');
+    const rows = await getTransactions({
+      filter: { tags: [{ name: 'shared', mode: 'has' }, { name: 'personal', mode: 'lacks' }] },
+    });
+    expect(rows.map((r) => r.amount)).toEqual([10]);
+  });
+
+  it('returns nothing for an explicitly-empty dimension', async () => {
+    await insertTx({ amount: 10 });
+    expect(await getTransactions({ filter: { categories: [] } })).toHaveLength(0);
+  });
+});
+
+describe('getRangeSummary with a Filter', () => {
+  it('applies category and tag constraints to the headline totals', async () => {
+    const t1 = await insertTx({ category: 'Dining', amount: 100 });
+    await insertTx({ category: 'Rent', amount: 400 });
+    await tagTx(t1, 'personal');
+    const all = await getRangeSummary('2025-01-01', '2025-01-31');
+    expect(all.expenses).toBeCloseTo(500);
+    const noPersonal = await getRangeSummary('2025-01-01', '2025-01-31', { tags: [{ name: 'personal', mode: 'lacks' }] });
+    expect(noPersonal.expenses).toBeCloseTo(400);
+  });
+});
+
+describe('getPeriodTotals with a Filter', () => {
+  it('restricts the trend series to the selected accounts', async () => {
+    await insertTx({ accountId: 'a1', amount: 100, date: '2025-01-10' });
+    await insertTx({ accountId: 'a2', amount: 250, date: '2025-01-20' });
+    const view = { mode: 'expenses' as const, category: null, flex: null, label: 'Expenses' };
+    const all = await getPeriodTotals(view, 'month');
+    expect(all.find((p) => p.from === '2025-01-01')?.total).toBeCloseTo(350);
+    const a1 = await getPeriodTotals(view, 'month', { accounts: ['a1'] });
+    expect(a1.find((p) => p.from === '2025-01-01')?.total).toBeCloseTo(100);
+  });
+});

--- a/tests/queries.test.ts
+++ b/tests/queries.test.ts
@@ -259,7 +259,7 @@ describe('getRangeSummary with accountId', () => {
   it('filters to the given account', async () => {
     await insertTx({ amount: 100, category: 'Shopping', accountId: 'acct1' });
     await insertTx({ amount: 200, category: 'Dining',   accountId: 'acct2' });
-    const s = await getRangeSummary('2025-01-01', '2025-01-31', 'acct1');
+    const s = await getRangeSummary('2025-01-01', '2025-01-31', { accounts: ['acct1'] });
     expect(s.expenses).toBeCloseTo(100);
     expect(s.byCategory).toHaveLength(1);
     expect(s.byCategory[0].category).toBe('Shopping');
@@ -267,7 +267,7 @@ describe('getRangeSummary with accountId', () => {
 
   it('returns zeros when account has no transactions in range', async () => {
     await insertTx({ amount: 100, accountId: 'acct2' });
-    const s = await getRangeSummary('2025-01-01', '2025-01-31', 'acct1');
+    const s = await getRangeSummary('2025-01-01', '2025-01-31', { accounts: ['acct1'] });
     expect(s.expenses).toBe(0);
     expect(s.income).toBe(0);
   });
@@ -313,7 +313,7 @@ describe('getMerchantSummary', () => {
     await insertTx({ amount: 200, category: 'Food', name: 'D', accountId: 'acct1', ignored: 1 });
     await insertTx({ amount: 500, category: 'Transfer', name: 'E', accountId: 'acct1' });
 
-    const rows = await getMerchantSummary('Food', '2025-01-01', '2025-01-31', 'acct1');
+    const rows = await getMerchantSummary('Food', '2025-01-01', '2025-01-31', { accounts: ['acct1'] });
     expect(rows).toHaveLength(1);
     expect(rows[0].merchant).toBe('A');
     expect(rows[0].total).toBeCloseTo(90);
@@ -330,14 +330,14 @@ describe('getFlexSummary with accountId', () => {
     await insertCat('Rent', 'fixed');
     await insertTx({ amount: 1500, category: 'Rent', accountId: 'acct1' });
     await insertTx({ amount: 999,  category: 'Rent', accountId: 'acct2' });
-    const s = await getFlexSummary('2025-01-01', '2025-01-31', 'acct1');
+    const s = await getFlexSummary('2025-01-01', '2025-01-31', { accounts: ['acct1'] });
     expect(s.fixed).toBeCloseTo(1500);
   });
 
   it('returns zeros when account has no transactions', async () => {
     await insertCat('Rent', 'fixed');
     await insertTx({ amount: 1500, category: 'Rent', accountId: 'acct2' });
-    const s = await getFlexSummary('2025-01-01', '2025-01-31', 'acct1');
+    const s = await getFlexSummary('2025-01-01', '2025-01-31', { accounts: ['acct1'] });
     expect(s.fixed).toBe(0);
   });
 });

--- a/tui/App.tsx
+++ b/tui/App.tsx
@@ -14,6 +14,7 @@ import { Canvas } from './Canvas.js';
 import { Settings } from './Settings.js';
 import { Chat } from './Chat.js';
 import { RefreshProvider, useRefreshKey } from './RefreshContext.js';
+import { FilterProvider } from './FilterContext.js';
 import type { CanvasSpec } from '../core/canvas-agent.js';
 import { CANVAS_SPEC_PATH } from '../core/canvas-history.js';
 
@@ -118,7 +119,9 @@ function AppInner() {
 export function App() {
   return (
     <RefreshProvider>
-      <AppInner />
+      <FilterProvider>
+        <AppInner />
+      </FilterProvider>
     </RefreshProvider>
   );
 }

--- a/tui/Dashboard.tsx
+++ b/tui/Dashboard.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { Box, Text, useInput } from 'ink';
 import {
   getRangeSummary, getFlexSummary, getUncategorizedCount, getDataBounds, getAccountRows, getOwnerRows,
@@ -18,6 +18,8 @@ import { useTerminalWidth, FLEX_COLORS, C_POSITIVE, C_NEGATIVE, C_WARNING, C_NEU
 import { StatCard, SectionHeader, SelectableRow, TextInput, PageHeader } from './components/index.js';
 import { useSetTyping } from './TypingContext.js';
 import { useRefreshKey } from './RefreshContext.js';
+import { useFilter } from './FilterContext.js';
+import { mergeFilters, type Filter } from '../core/filters.js';
 
 const BAR_WIDTH = 20;
 
@@ -54,6 +56,7 @@ const FLEX_TIERS: Array<{ key: keyof FlexSummary; label: string; color: string }
 
 export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { onNavigate: (s: Screen, filter?: TxFilter) => void; isActive?: boolean; initialFilter?: TxFilter; showHints: boolean }) {
   const refreshKey = useRefreshKey();
+  const { filter: sharedFilter } = useFilter();
   const now = new Date();
   const [range, setRange] = useState<Range>(() => {
     const r = initialFilter?.range;
@@ -98,43 +101,44 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
   // Owner split
   const [ownerRows, setOwnerRows] = useState<OwnerRow[]>([]);
 
-  function load(r: Range, a: Date, acct: AccountRow | null) {
+  // The session-global filter ANDed with the local account selection drives all
+  // summary queries. Until the filter panel lands (PR2) the shared filter is
+  // empty, so this reduces to the previous account-only behavior.
+  const queryFilter: Filter = useMemo(
+    () => mergeFilters(sharedFilter, selectedAccount ? { accounts: [selectedAccount.id] } : undefined),
+    [sharedFilter, selectedAccount?.id ?? null],
+  );
+
+  function load(r: Range, a: Date, qf: Filter) {
     const { from, to } = getPeriodDates(r, a);
     void getAccountRows(from, to).then(setAccountRows);
     void getOwnerRows(from, to).then(setOwnerRows);
     setAcctCursor(0);
-    if (acct) {
-      void getRangeSummary(from, to, acct.id).then(setSummary);
-      void getFlexSummary(from, to, acct.id).then(setFlexData);
-      void getUncategorizedCount(from, to, acct.id).then(setUncategorized);
-    } else {
-      void getRangeSummary(from, to).then(setSummary);
-      void getFlexSummary(from, to).then(setFlexData);
-      void getUncategorizedCount(from, to).then(setUncategorized);
-    }
+    void getRangeSummary(from, to, qf).then(setSummary);
+    void getFlexSummary(from, to, qf).then(setFlexData);
+    void getUncategorizedCount(from, to, qf).then(setUncategorized);
   }
 
   function openMerchantDrill(category: string, from: string, to: string) {
     setMerchantDrill({ category, from, to });
     setMerchantCursor(0);
-    void getMerchantSummary(category, from, to, selectedAccount?.id ?? undefined).then(setMerchantRows);
+    void getMerchantSummary(category, from, to, queryFilter).then(setMerchantRows);
   }
 
   useEffect(() => {
-    load(range, anchor, selectedAccount);
+    load(range, anchor, queryFilter);
     setCatCursor(0);
-  }, [range, anchor.toISOString().slice(0, 10), selectedAccount?.id ?? null, refreshKey]);
+  }, [range, anchor.toISOString().slice(0, 10), queryFilter, refreshKey]);
 
   useEffect(() => {
     if (!driftMode) { setCatDrift(null); setFlexDrift(null); setAcctDrift(null); return; }
     const windows = getDriftWindows(range, anchor, new Date());
     if (!windows) { setCatDrift(null); setFlexDrift(null); setAcctDrift(null); return; }
     const { current, lastPeriod, lastYear, rolling12 } = windows;
-    const acctId = selectedAccount?.id ?? undefined;
-    void getCategoryDriftData(current, lastPeriod, lastYear, rolling12, acctId).then(setCatDrift);
-    void getFlexDriftData(current, lastPeriod, lastYear, rolling12, acctId).then(setFlexDrift);
+    void getCategoryDriftData(current, lastPeriod, lastYear, rolling12, queryFilter).then(setCatDrift);
+    void getFlexDriftData(current, lastPeriod, lastYear, rolling12, queryFilter).then(setFlexDrift);
     void getAccountDriftData(current, lastPeriod, lastYear, rolling12).then(setAcctDrift);
-  }, [driftMode, range, anchor.toISOString().slice(0, 10), selectedAccount?.id ?? null]);
+  }, [driftMode, range, anchor.toISOString().slice(0, 10), queryFilter]);
 
   const setTyping = useSetTyping();
   useEffect(() => { setTyping(searchMode); }, [searchMode]);
@@ -143,18 +147,18 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
     const term = searchMode ? searchInput : search;
     if (!term) { setSearchStats(null); return; }
     const { from, to } = getPeriodDates(range, anchor);
-    void countSearchMatches(from, to, term, selectedAccount?.id ?? undefined).then(setSearchStats);
-  }, [searchMode ? searchInput : search, range, anchor.toISOString().slice(0, 10), selectedAccount?.id ?? null]);
+    void countSearchMatches(from, to, term, queryFilter).then(setSearchStats);
+  }, [searchMode ? searchInput : search, range, anchor.toISOString().slice(0, 10), queryFilter]);
 
   // When a search is committed, recompute category + flex data to only show matching transactions
   useEffect(() => {
     if (!search) { setFilteredSummary(null); setFilteredFlex(null); return; }
     const { from, to } = getPeriodDates(range, anchor);
-    void getSearchFilteredData(from, to, search, selectedAccount?.id ?? undefined).then(({ summary: fs, flexData: ff }) => {
+    void getSearchFilteredData(from, to, search, queryFilter).then(({ summary: fs, flexData: ff }) => {
       setFilteredSummary(fs);
       setFilteredFlex(ff);
     });
-  }, [search, range, anchor.toISOString().slice(0, 10), selectedAccount?.id ?? null]);
+  }, [search, range, anchor.toISOString().slice(0, 10), queryFilter]);
 
   // Close drill when filter context changes significantly
   // Note: anchor and range are intentionally excluded — period/range nav keeps drill open
@@ -162,7 +166,7 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
     setMerchantDrill(null);
     setMerchantRows([]);
     setMerchantCursor(0);
-  }, [selectedAccount?.id ?? null, search, driftMode, view]);
+  }, [queryFilter, search, driftMode, view]);
 
   // Re-fetch merchant data when period or range changes while drill is active
   useEffect(() => {
@@ -171,7 +175,7 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
     const { category } = merchantDrill;
     setMerchantDrill({ category, from, to });
     setMerchantCursor(0);
-    void getMerchantSummary(category, from, to, selectedAccount?.id ?? undefined).then(setMerchantRows);
+    void getMerchantSummary(category, from, to, queryFilter).then(setMerchantRows);
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [anchor.toISOString().slice(0, 10), range]);
 

--- a/tui/FilterContext.tsx
+++ b/tui/FilterContext.tsx
@@ -1,0 +1,19 @@
+import React, { createContext, useContext, useState } from 'react';
+import { EMPTY_FILTER, type Filter } from '../core/filters.js';
+
+// Session-global filter shared across Dashboard, Transactions, and Trends.
+// State lives above the screens so applying a filter on one carries to the
+// others. It is intentionally not persisted to disk — it resets each session.
+
+type FilterCtx = { filter: Filter; setFilter: (f: Filter) => void };
+
+const Ctx = createContext<FilterCtx>({ filter: EMPTY_FILTER, setFilter: () => {} });
+
+export function FilterProvider({ children }: { children: React.ReactNode }) {
+  const [filter, setFilter] = useState<Filter>(EMPTY_FILTER);
+  return <Ctx.Provider value={{ filter, setFilter }}>{children}</Ctx.Provider>;
+}
+
+export function useFilter(): FilterCtx {
+  return useContext(Ctx);
+}

--- a/tui/Transactions.tsx
+++ b/tui/Transactions.tsx
@@ -14,7 +14,9 @@ import {
 import { applyCategoriesToAll } from '../core/categorize.js';
 import { countPatternMatches } from '../core/rule-utils.js';
 import { getTransactions, getAllCategories, getDataBounds, type TxRow, type SortMode } from '../core/queries.js';
+import { mergeFilters } from '../core/filters.js';
 import type { Screen, TxFilter } from './App.js';
+import { useFilter } from './FilterContext.js';
 import { handleNavKey } from './nav.js';
 import { Divider } from './fmt.js';
 import { useTerminalWidth, MONTHS, C_POSITIVE, C_NEGATIVE, C_WARNING, C_NEUTRAL, C_MANUAL, C_ACCENT, C_DIM } from './ui.js';
@@ -49,6 +51,7 @@ function truncate(s: string, n: number) {
 
 export function Transactions({ onNavigate, initialFilter, isActive, showHints }: { onNavigate: (s: Screen, f?: TxFilter) => void; initialFilter?: TxFilter; isActive?: boolean; showHints: boolean }) {
   const refreshKey = useRefreshKey();
+  const { filter: sharedFilter } = useFilter();
   const [category, setCategory] = useState<string | null>(initialFilter?.category ?? null);
   const [from, setFrom] = useState<string | null>(initialFilter?.from ?? null);
   const [to, setTo] = useState<string | null>(initialFilter?.to ?? null);
@@ -81,7 +84,12 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
   const [tagInput, setTagInput] = useState('');
 
   function load(s = search, keepCursor = false) {
-    void getTransactions({ category, from, to, search: s, tag, account, sort, txType, flex }).then((rows) => {
+    const queryFilter = mergeFilters(sharedFilter, {
+      categories: category ? [category] : undefined,
+      accounts: account ? [account] : undefined,
+      tags: tag ? [{ name: tag, mode: 'has' }] : undefined,
+    });
+    void getTransactions({ filter: queryFilter, from, to, search: s, sort, txType, flex }).then((rows) => {
       setTxs(rows);
       if (!keepCursor) setCursor(0);
       else setCursor((c) => Math.min(c, Math.max(0, rows.length - 1)));
@@ -89,7 +97,7 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
   }
 
   useEffect(() => { void getDataBounds().then(setBounds); void getAllCategories().then(setCategories); }, []);
-  useEffect(() => { load(); }, [category, from, to, search, tag, account, sort, txType, flex, refreshKey]);
+  useEffect(() => { load(); }, [category, from, to, search, tag, account, sort, txType, flex, sharedFilter, refreshKey]);
 
   const setTyping = useSetTyping();
   useEffect(() => {

--- a/tui/Trends.tsx
+++ b/tui/Trends.tsx
@@ -3,6 +3,7 @@ import { Box, Text, useInput } from 'ink';
 import { type TrendsRange } from '../core/dateUtils.js';
 import { buildTrendViews, generateAllPeriods, getPeriodTotals, getSearchMatchingPeriods, getSearchPeriodTotals, type View, type PeriodRow } from '../core/trends.js';
 import type { Screen, TxFilter } from './App.js';
+import { useFilter } from './FilterContext.js';
 import { fmt, fmtSigned, bar, Divider } from './fmt.js';
 import { handleNavKey } from './nav.js';
 import { useTerminalWidth, FLEX_COLORS, C_POSITIVE, C_NEGATIVE, C_NEUTRAL, C_ACCENT } from './ui.js';
@@ -33,6 +34,7 @@ export function Trends({
   showHints: boolean;
 }) {
   const refreshKey = useRefreshKey();
+  const { filter: sharedFilter } = useFilter();
   const [views, setViews] = useState<View[]>([
     { mode: 'expenses',      category: null, flex: null,            label: 'Expenses'      },
     { mode: 'income',        category: null, flex: null,            label: 'Income'        },
@@ -74,26 +76,26 @@ export function Trends({
 
   useEffect(() => {
     if (!view) return;
-    void getPeriodTotals(view, range).then((data) => {
+    void getPeriodTotals(view, range, sharedFilter).then((data) => {
       setRows(data);
       setCursor(Math.max(0, data.length - 1));
     });
-  }, [viewIdx, range, views, refreshKey]);
+  }, [viewIdx, range, views, sharedFilter, refreshKey]);
 
   // Live match count while typing; committed search rows
   const liveSearch = searchMode ? searchInput : search;
   useEffect(() => {
     if (!liveSearch) { setMatchCount(null); return; }
-    void getSearchMatchingPeriods(liveSearch, range).then(({ count }) => setMatchCount(count));
-  }, [liveSearch, range]);
+    void getSearchMatchingPeriods(liveSearch, range, sharedFilter).then(({ count }) => setMatchCount(count));
+  }, [liveSearch, range, sharedFilter]);
 
   useEffect(() => {
     if (!search) { setSearchRows([]); return; }
-    void getSearchPeriodTotals(search, range).then((data) => {
+    void getSearchPeriodTotals(search, range, sharedFilter).then((data) => {
       setSearchRows(data);
       setCursor(Math.max(0, data.length - 1));
     });
-  }, [search, range]);
+  }, [search, range, sharedFilter]);
 
   const activeRows = search ? searchRows : rows;
   const clampedCursor = activeRows.length > 0 ? Math.min(cursor, activeRows.length - 1) : 0;


### PR DESCRIPTION
First PR in a stack to complete #44.

--

Introduce a multi-dimension Filter (categories, accounts, owners, tags) with AND-across / OR-within semantics, and thread it through the query and trends layers in place of the old accountId string argument.

- core/filters.ts: Filter/TagPredicate types plus buildFilterConditions, buildFilterClause, mergeFilters, isFilterActive, filterSummary. Absent dimension = no constraint; present-but-empty = match nothing. Owners resolve via an accounts subquery (Unassigned bucket); tags as EXISTS / NOT EXISTS.
- core/queries.ts, core/trends.ts: summary/drift/search/transaction and period queries take filter?: Filter, routed through the clause builder. Account/owner breakdown queries stay unfiltered (navigation aids).
- core/tools.ts: merchant_summary adapts its accountId into a Filter.
- tui/FilterContext.tsx: session-global { filter, setFilter } provider.
- tui/App.tsx wraps the app; Dashboard/Transactions/Trends read the shared filter and mergeFilters it with their local scalar filters.

Behavior-preserving: the shared filter starts empty, so this is a pure refactor until the panel UI (PR2) populates it. Shrinking TxFilter and migrating drill-downs to setFilter are deferred to PR2.

Adds tests/filters.test.ts (23 tests); adapts queries/drift call sites.