### PR TITLE
Create filter panel builds from unified filters in #71

### DIFF
--- a/core/filters.ts
+++ b/core/filters.ts
@@ -82,6 +82,73 @@ export function selectionFromDim(dim: string[] | undefined, universe: string[]):
   return dim === undefined ? new Set(universe) : new Set(dim);
 }
 
+/** Complement of a selection against its universe. */
+export function invertSelection(selected: Set<string>, universe: string[]): Set<string> {
+  return new Set(universe.filter((v) => !selected.has(v)));
+}
+
+/**
+ * Invert tag predicates: has↔lacks for tags that are set; off tags stay off.
+ * Tags are predicates rather than a membership set, so inverting means negating
+ * each predicate — turning untouched (off) tags into constraints would AND a
+ * 'lacks' for every tag in the universe, which is never what's wanted. This
+ * definition is also its own inverse.
+ */
+export function invertTagModes(
+  modes: Map<string, 'has' | 'lacks'>,
+): Map<string, 'has' | 'lacks'> {
+  return new Map([...modes].map(([name, m]) => [name, m === 'has' ? 'lacks' : 'has']));
+}
+
+/**
+ * Deep, order-insensitive filter equality. An undefined dimension is NOT equal
+ * to an empty array — unconstrained vs match-nothing (see header comment).
+ */
+export function filtersEqual(a: Filter | undefined, b: Filter | undefined): boolean {
+  const fa = a ?? EMPTY_FILTER;
+  const fb = b ?? EMPTY_FILTER;
+  const setEq = (x: string[] | undefined, y: string[] | undefined) => {
+    if (x === undefined || y === undefined) return x === y;
+    if (x.length !== y.length) return false;
+    const sy = new Set(y);
+    return x.every((v) => sy.has(v));
+  };
+  for (const dim of ['categories', 'accounts', 'owners'] as const) {
+    if (!setEq(fa[dim], fb[dim])) return false;
+  }
+  const tagKeys = (tags: TagPredicate[] | undefined) =>
+    (tags ?? []).map((t) => `${t.name}\0${t.mode}`);
+  return setEq(tagKeys(fa.tags), tagKeys(fb.tags));
+}
+
+/**
+ * History of shared-filter values so Esc can step back one level at a time
+ * instead of clearing everything. `current` is the live filter; `stack` holds
+ * prior values, oldest first.
+ */
+export type FilterHistory = { current: Filter; stack: Filter[] };
+
+export const MAX_FILTER_HISTORY = 20;
+
+/** Set a new current filter, pushing the previous one. No-op when equal. */
+export function pushFilter(h: FilterHistory, next: Filter): FilterHistory {
+  if (filtersEqual(h.current, next)) return h;
+  return { current: next, stack: [...h.stack, h.current].slice(-MAX_FILTER_HISTORY) };
+}
+
+/**
+ * Step back one level: restore the top of the stack. With an empty stack an
+ * active filter clears (so Esc always makes progress, even after the history
+ * cap evicted entries); an inactive one is a no-op.
+ */
+export function popFilter(h: FilterHistory): FilterHistory {
+  if (h.stack.length) {
+    return { current: h.stack[h.stack.length - 1], stack: h.stack.slice(0, -1) };
+  }
+  if (isFilterActive(h.current)) return { current: EMPTY_FILTER, stack: [] };
+  return h;
+}
+
 /**
  * Builds the SQL condition fragments + bound args that restrict rows by the
  * filter. `alias` is the alias (or table name) of the transactions row the

--- a/core/filters.ts
+++ b/core/filters.ts
@@ -66,6 +66,23 @@ export function mergeFilters(base: Filter | undefined, extra: Filter | undefined
 }
 
 /**
+ * Panel serialization helpers for the select-from-universe dimensions
+ * (categories/accounts/owners). The panel holds the *selected* members as a Set;
+ * these convert to/from the Filter representation, where a fully-selected
+ * universe means "no constraint" (undefined) and a partial selection is the
+ * explicit member list (an empty Set serializes to [] = match-nothing).
+ */
+export function selectionToDim(selected: Set<string>, universe: string[]): string[] | undefined {
+  return selected.size === universe.length && universe.every((v) => selected.has(v))
+    ? undefined
+    : [...selected];
+}
+
+export function selectionFromDim(dim: string[] | undefined, universe: string[]): Set<string> {
+  return dim === undefined ? new Set(universe) : new Set(dim);
+}
+
+/**
  * Builds the SQL condition fragments + bound args that restrict rows by the
  * filter. `alias` is the alias (or table name) of the transactions row the
  * conditions reference — 't' in aliased queries, 'transactions' in unaliased

--- a/core/queries.ts
+++ b/core/queries.ts
@@ -132,7 +132,13 @@ export async function getDataBounds(): Promise<{ minDate: string; maxDate: strin
 
 export type AccountRow = { id: string; name: string; subtype: string | null; spending: number; income: number };
 
-export async function getAccountRows(from: string, to: string): Promise<AccountRow[]> {
+// Per-account spending/income. Honors the shared filter's other dimensions
+// (categories/owners/tags) but ignores its own accounts dimension — the view
+// groups by account and doubles as the account picker, so every account keeps
+// its row. Filter conditions live in the LEFT JOIN ON clause so accounts with
+// no matching transactions still appear with zero totals.
+export async function getAccountRows(from: string, to: string, filter?: Filter): Promise<AccountRow[]> {
+  const f = buildFilterClause({ ...filter, accounts: undefined }, 't');
   const result = await db.execute({
     sql: `SELECT a.id, a.name, a.subtype,
             COALESCE(SUM(CASE WHEN t.amount > 0 AND t.date >= ? AND t.date <= ?
@@ -142,10 +148,10 @@ export async function getAccountRows(from: string, to: string): Promise<AccountR
                                AND t.pending = 0 AND t.ignored = 0
                                AND t.category != 'Transfer' THEN t.amount ELSE 0 END), 0) as income
           FROM accounts a
-          LEFT JOIN transactions t ON t.account_id = a.id
+          LEFT JOIN transactions t ON t.account_id = a.id${f.clause}
           GROUP BY a.id, a.name, a.subtype
           ORDER BY CASE a.type WHEN 'depository' THEN 0 WHEN 'investment' THEN 1 ELSE 2 END, spending DESC`,
-    args: [from, to, from, to],
+    args: [from, to, from, to, ...f.args],
   });
   return result.rows as unknown as AccountRow[];
 }
@@ -155,10 +161,13 @@ export type OwnerRow = { owner: string; spending: number };
 // Total expenses grouped by account owner, for splitting shared spending. Accounts
 // with no owner fall under 'Unassigned'. Uses the same expense definition as the
 // dashboard's headline Expenses (getRangeSummary): excludes hidden categories,
-// pending, and ignored transactions. Filters live in the LEFT JOIN ON clause (not
-// WHERE) so every owned account still yields a row even with zero spend this
-// period — callers rely on that to detect whether any owner has been assigned.
-export async function getOwnerRows(from: string, to: string): Promise<OwnerRow[]> {
+// pending, and ignored transactions. Honors the shared filter's other dimensions
+// (categories/accounts/tags) but ignores its own owners dimension, since it
+// groups by owner. Filters live in the LEFT JOIN ON clause (not WHERE) so every
+// owned account still yields a row even with zero spend this period — callers
+// rely on that to detect whether any owner has been assigned.
+export async function getOwnerRows(from: string, to: string, filter?: Filter): Promise<OwnerRow[]> {
+  const f = buildFilterClause({ ...filter, owners: undefined }, 't');
   const result = await db.execute({
     sql: `SELECT COALESCE(NULLIF(TRIM(a.owner), ''), 'Unassigned') as owner,
             COALESCE(SUM(t.amount), 0) as spending
@@ -168,10 +177,10 @@ export async function getOwnerRows(from: string, to: string): Promise<OwnerRow[]
             AND t.amount > 0
             AND t.date >= ? AND t.date <= ?
             AND t.pending = 0 AND t.ignored = 0
-            AND t.category NOT IN (SELECT category FROM hidden_categories)
+            AND t.category NOT IN (SELECT category FROM hidden_categories)${f.clause}
           GROUP BY COALESCE(NULLIF(TRIM(a.owner), ''), 'Unassigned')
           ORDER BY spending DESC, owner`,
-    args: [from, to],
+    args: [from, to, ...f.args],
   });
   return result.rows as unknown as OwnerRow[];
 }

--- a/core/queries.ts
+++ b/core/queries.ts
@@ -363,6 +363,38 @@ export async function getAllCategories(): Promise<string[]> {
   return (result.rows as unknown as { name: string }[]).map((r) => r.name);
 }
 
+// Option universes for the shared filter panel: every category, account
+// (id/name/owner), distinct owner bucket ('Unassigned' for accounts with no
+// owner), and tag name. The panel selects from these and serializes a Filter.
+export type FilterOptionAccount = { id: string; name: string; owner: string };
+export type FilterOptions = {
+  categories: string[];
+  accounts: FilterOptionAccount[];
+  owners: string[];
+  tags: string[];
+};
+
+export async function getFilterOptions(): Promise<FilterOptions> {
+  const [cats, accts, tags] = await Promise.all([
+    db.execute('SELECT name FROM categories ORDER BY name'),
+    db.execute(
+      `SELECT id, name, COALESCE(NULLIF(TRIM(owner), ''), 'Unassigned') as owner
+       FROM accounts ORDER BY name`,
+    ),
+    db.execute('SELECT name FROM tags ORDER BY name'),
+  ]);
+  const accounts = (accts.rows as unknown as FilterOptionAccount[]).map((r) => ({
+    id: r.id, name: r.name, owner: r.owner,
+  }));
+  const owners = [...new Set(accounts.map((a) => a.owner))].sort();
+  return {
+    categories: (cats.rows as unknown as { name: string }[]).map((r) => r.name),
+    accounts,
+    owners,
+    tags: (tags.rows as unknown as { name: string }[]).map((r) => r.name),
+  };
+}
+
 export async function getCategoryDetails(): Promise<CategoryDetail[]> {
   const result = await db.execute('SELECT name, flexibility FROM categories ORDER BY name');
   return result.rows as unknown as CategoryDetail[];

--- a/docs/filter-panel-plan.md
+++ b/docs/filter-panel-plan.md
@@ -85,16 +85,21 @@ this PR is pure refactor + plumbing and is reviewable on its own.
 
 ## PR 2 — Filter panel UI
 
-7. **`tui/components/FilterPanel.tsx` (new)**, built on the existing `ModalPanel`:
-   - Loads universes: categories, accounts (`getLinkedAccounts`), owners
-     (`householdMembers` + `Unassigned`), tags (`core/tags.ts`).
+7. **`tui/FilterPanel.tsx` (new)**, built on the existing `ModalPanel`:
+   - Loads universes via `getFilterOptions()` (`core/queries.ts`): categories,
+     accounts (id/name/owner), owners derived from accounts (`Unassigned` bucket),
+     tags.
    - State: focused section, per-section selection `Set` (+ tag tri-state map),
-     per-section cursor, inline-search string.
+     per-section cursor.
    - Init from current `filter` (absent dim → all checked; array → those; `[]` → none).
-   - Keys (captured while open): `f`/`Esc` close (`Esc` restores prior state),
-     `←/→` section, `↑/↓` row, `x` toggle (tags cycle), `a` select-all, `i` invert,
-     `/` inline search within section (narrows list, selections persist), `Enter`
-     apply → serialize → `setFilter` → close.
+   - Keys (captured while open): `Esc` close (discards the draft), `←/→` section,
+     `↑/↓` row, `Space` toggle (tags cycle), `a` select-all, `n` select-none,
+     `i` invert (set dims complement; tags swap has↔lacks), `c` clear all sections,
+     `Enter` apply → serialize → `setFilter` → close.
+   - **Deferred** (not in the shipped panel): `/` inline search within a section
+     (narrows list, selections persist) and `f` to close the panel — `f` only
+     opens it today. Both are follow-up candidates; inline search matters most
+     once a category universe outgrows the visible window.
 
 8. **Wire into the three screens:** local `panelOpen` state, render `<FilterPanel>`,
    `f` toggles it, and gate the host `useInput` while open (same pattern as
@@ -127,6 +132,8 @@ The only change: Dashboard's separate search-recompute path
 
 ## Out of scope (possible later)
 
+- **`/` inline section search and `f`-to-close in the panel** — deferred from
+  PR 2's key map (see item 7).
 - **Omnisearch** (`tag:happyhour`, `!tag:x`, `owner:Mark`) as a power-user
   accelerator that mutates the same `FilterContext` — a possible PR 3.
 - Configurable AND/OR logic.

--- a/docs/filter-panel-plan.md
+++ b/docs/filter-panel-plan.md
@@ -134,7 +134,16 @@ The only change: Dashboard's separate search-recompute path
 
 - **`/` inline section search and `f`-to-close in the panel** — deferred from
   PR 2's key map (see item 7).
+- **Live preview of filter on dashboard** - as I make decisions on the filter panel
+  update the numbers on the dashboard above. 
 - **Omnisearch** (`tag:happyhour`, `!tag:x`, `owner:Mark`) as a power-user
   accelerator that mutates the same `FilterContext` — a possible PR 3.
 - Configurable AND/OR logic.
 - Cross-restart filter persistence.
+
+
+## Live preview plan:
+1. FilterContext.tsx — add a preview: Filter | null state alongside the history. Have the filter value that useFilter() returns become preview ?? current. Every view instantly gains live preview with zero changes, because they all just read filter. Expose setPreview, and expose the committed value separately for the panel's hydration.
+2. FilterPanel.tsx — the serialization block inside apply() (the selectionToDim calls building next) gets extracted into a draftFilter memo. A useEffect publishes it via setPreview(draftFilter) as the draft changes, and clears it (setPreview(null)) on unmount. Enter commits via setFilter as today — one history push, so the Esc step-back behavior we just built stays clean. Esc just clears the preview, so cancel restores the original view for free.
+
+That last point is the nice part of the design: because preview bypasses pushFilter, toggling 15 checkboxes while previewing doesn't pollute the filter history — only the final Enter does.

--- a/tests/filters.test.ts
+++ b/tests/filters.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import {
   buildFilterConditions, buildFilterClause, mergeFilters,
-  isFilterActive, filterSummary, type Filter,
+  isFilterActive, filterSummary, selectionToDim, selectionFromDim, type Filter,
 } from '../core/filters.js';
 
 // ── Pure clause-builder tests (no database) ────────────────────────────────────
@@ -105,6 +105,37 @@ describe('isFilterActive / filterSummary', () => {
   });
 });
 
+describe('selectionToDim / selectionFromDim (panel serialization)', () => {
+  const universe = ['Rent', 'Dining', 'Shopping'];
+
+  it('serializes a fully-selected universe to undefined (no constraint)', () => {
+    expect(selectionToDim(new Set(universe), universe)).toBeUndefined();
+  });
+
+  it('serializes a partial selection to the member list', () => {
+    expect(selectionToDim(new Set(['Rent', 'Dining']), universe)?.sort()).toEqual(['Dining', 'Rent']);
+  });
+
+  it('serializes an empty selection to [] (match nothing)', () => {
+    expect(selectionToDim(new Set(), universe)).toEqual([]);
+  });
+
+  it('treats an empty universe as no constraint', () => {
+    expect(selectionToDim(new Set(), [])).toBeUndefined();
+  });
+
+  it('hydrates undefined to the full universe and a list back to itself', () => {
+    expect(selectionFromDim(undefined, universe)).toEqual(new Set(universe));
+    expect(selectionFromDim(['Rent'], universe)).toEqual(new Set(['Rent']));
+    expect(selectionFromDim([], universe)).toEqual(new Set());
+  });
+
+  it('round-trips a partial selection', () => {
+    const sel = selectionFromDim(['Dining'], universe);
+    expect(selectionToDim(sel, universe)).toEqual(['Dining']);
+  });
+});
+
 // ── Database-backed integration tests ──────────────────────────────────────────
 
 vi.mock('../core/db.js', async () => {
@@ -113,7 +144,7 @@ vi.mock('../core/db.js', async () => {
 });
 
 const { db } = await import('../core/db.js');
-const { getTransactions, getRangeSummary } = await import('../core/queries.js');
+const { getTransactions, getRangeSummary, getFilterOptions } = await import('../core/queries.js');
 const { getPeriodTotals } = await import('../core/trends.js');
 
 let txId = 0;
@@ -229,5 +260,26 @@ describe('getPeriodTotals with a Filter', () => {
     expect(all.find((p) => p.from === '2025-01-01')?.total).toBeCloseTo(350);
     const a1 = await getPeriodTotals(view, 'month', { accounts: ['a1'] });
     expect(a1.find((p) => p.from === '2025-01-01')?.total).toBeCloseTo(100);
+  });
+});
+
+describe('getFilterOptions', () => {
+  it('returns categories, accounts (with owner), distinct owners, and tags', async () => {
+    await db.execute("INSERT INTO categories (name) VALUES ('Rent'), ('Dining')");
+    await addAccount('chase', 'Mark');
+    await addAccount('amex', 'Mark');
+    await addAccount('joint', null); // null owner → Unassigned bucket
+    const tx = await insertTx({ accountId: 'chase', amount: 10 });
+    await tagTx(tx, 'shared');
+
+    const opts = await getFilterOptions();
+    expect(opts.categories).toEqual(['Dining', 'Rent']); // alphabetical
+    expect(opts.accounts).toEqual([
+      { id: 'amex', name: 'amex', owner: 'Mark' },
+      { id: 'chase', name: 'chase', owner: 'Mark' },
+      { id: 'joint', name: 'joint', owner: 'Unassigned' },
+    ]);
+    expect(opts.owners).toEqual(['Mark', 'Unassigned']); // distinct, sorted
+    expect(opts.tags).toEqual(['shared']);
   });
 });

--- a/tests/filters.test.ts
+++ b/tests/filters.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import {
   buildFilterConditions, buildFilterClause, mergeFilters,
-  isFilterActive, filterSummary, selectionToDim, selectionFromDim, type Filter,
+  isFilterActive, filterSummary, selectionToDim, selectionFromDim,
+  invertSelection, invertTagModes, filtersEqual,
+  pushFilter, popFilter, MAX_FILTER_HISTORY,
+  type Filter, type FilterHistory,
 } from '../core/filters.js';
 
 // ── Pure clause-builder tests (no database) ────────────────────────────────────
@@ -133,6 +136,104 @@ describe('selectionToDim / selectionFromDim (panel serialization)', () => {
   it('round-trips a partial selection', () => {
     const sel = selectionFromDim(['Dining'], universe);
     expect(selectionToDim(sel, universe)).toEqual(['Dining']);
+  });
+});
+
+describe('invertSelection', () => {
+  const universe = ['Rent', 'Dining', 'Shopping'];
+
+  it('complements a partial selection against the universe', () => {
+    expect(invertSelection(new Set(['Rent']), universe)).toEqual(new Set(['Dining', 'Shopping']));
+  });
+
+  it('maps full to empty and empty to full', () => {
+    expect(invertSelection(new Set(universe), universe)).toEqual(new Set());
+    expect(invertSelection(new Set(), universe)).toEqual(new Set(universe));
+  });
+
+  it('double-invert is identity', () => {
+    const sel = new Set(['Dining']);
+    expect(invertSelection(invertSelection(sel, universe), universe)).toEqual(sel);
+  });
+});
+
+describe('invertTagModes', () => {
+  it('swaps has and lacks; off (absent) tags stay off', () => {
+    const inverted = invertTagModes(new Map([['shared', 'has'], ['personal', 'lacks']]));
+    expect(inverted).toEqual(new Map([['shared', 'lacks'], ['personal', 'has']]));
+    expect(inverted.has('untouched')).toBe(false);
+  });
+
+  it('double-invert is identity', () => {
+    const modes = new Map<string, 'has' | 'lacks'>([['x', 'has'], ['y', 'lacks']]);
+    expect(invertTagModes(invertTagModes(modes))).toEqual(modes);
+  });
+});
+
+describe('filtersEqual', () => {
+  it('treats empty, undefined, and absent dimensions as equal', () => {
+    expect(filtersEqual({}, {})).toBe(true);
+    expect(filtersEqual(undefined, {})).toBe(true);
+    expect(filtersEqual({ categories: undefined }, {})).toBe(true);
+  });
+
+  it('distinguishes undefined (unconstrained) from [] (match nothing)', () => {
+    expect(filtersEqual({ categories: [] }, {})).toBe(false);
+    expect(filtersEqual({ categories: [] }, { categories: [] })).toBe(true);
+  });
+
+  it('compares set dimensions order-insensitively', () => {
+    expect(filtersEqual({ categories: ['A', 'B'] }, { categories: ['B', 'A'] })).toBe(true);
+    expect(filtersEqual({ categories: ['A'] }, { categories: ['A', 'B'] })).toBe(false);
+  });
+
+  it('compares tags by name and mode, order-insensitively', () => {
+    const a: Filter = { tags: [{ name: 'x', mode: 'has' }, { name: 'y', mode: 'lacks' }] };
+    const b: Filter = { tags: [{ name: 'y', mode: 'lacks' }, { name: 'x', mode: 'has' }] };
+    expect(filtersEqual(a, b)).toBe(true);
+    expect(filtersEqual(a, { tags: [{ name: 'x', mode: 'lacks' }, { name: 'y', mode: 'lacks' }] })).toBe(false);
+  });
+});
+
+describe('pushFilter / popFilter (filter history)', () => {
+  const empty: FilterHistory = { current: {}, stack: [] };
+
+  it('pushes the previous current onto the stack', () => {
+    const h = pushFilter(empty, { categories: ['Rent'] });
+    expect(h.current).toEqual({ categories: ['Rent'] });
+    expect(h.stack).toEqual([{}]);
+  });
+
+  it('skips deep-equal no-op sets, including reordered arrays', () => {
+    const h = pushFilter(empty, { categories: ['A', 'B'] });
+    expect(pushFilter(h, { categories: ['B', 'A'] })).toBe(h);
+    expect(pushFilter(empty, {})).toBe(empty);
+  });
+
+  it('caps the stack, dropping the oldest entries', () => {
+    let h = empty;
+    for (let i = 0; i < MAX_FILTER_HISTORY + 5; i++) {
+      h = pushFilter(h, { categories: [`c${i}`] });
+    }
+    expect(h.stack).toHaveLength(MAX_FILTER_HISTORY);
+    expect(h.stack[0]).toEqual({ categories: ['c4'] });
+  });
+
+  it('pop restores the top of the stack one level at a time', () => {
+    let h = pushFilter(empty, { categories: ['A'] });
+    h = pushFilter(h, { categories: ['B'] });
+    h = pushFilter(h, { categories: ['C'] });
+    h = popFilter(h);
+    expect(h.current).toEqual({ categories: ['B'] });
+    h = popFilter(h);
+    expect(h.current).toEqual({ categories: ['A'] });
+  });
+
+  it('pop with an empty stack clears an active filter, no-ops on an inactive one', () => {
+    const active: FilterHistory = { current: { categories: ['A'] }, stack: [] };
+    expect(popFilter(active).current).toEqual({});
+    const inactive: FilterHistory = { current: {}, stack: [] };
+    expect(popFilter(inactive)).toBe(inactive);
   });
 });
 

--- a/tests/filters.test.ts
+++ b/tests/filters.test.ts
@@ -245,7 +245,7 @@ vi.mock('../core/db.js', async () => {
 });
 
 const { db } = await import('../core/db.js');
-const { getTransactions, getRangeSummary, getFilterOptions } = await import('../core/queries.js');
+const { getTransactions, getRangeSummary, getFilterOptions, getAccountRows, getOwnerRows } = await import('../core/queries.js');
 const { getPeriodTotals } = await import('../core/trends.js');
 
 let txId = 0;
@@ -349,6 +349,59 @@ describe('getRangeSummary with a Filter', () => {
     expect(all.expenses).toBeCloseTo(500);
     const noPersonal = await getRangeSummary('2025-01-01', '2025-01-31', { tags: [{ name: 'personal', mode: 'lacks' }] });
     expect(noPersonal.expenses).toBeCloseTo(400);
+  });
+});
+
+describe('getAccountRows with a Filter', () => {
+  it('honors other dimensions but keeps a row per account', async () => {
+    await addAccount('a1', 'Mark');
+    await addAccount('a2', 'Sam');
+    await insertTx({ accountId: 'a1', category: 'Dining', amount: 100 });
+    await insertTx({ accountId: 'a1', category: 'Rent', amount: 400 });
+    await insertTx({ accountId: 'a2', category: 'Dining', amount: 50 });
+
+    const dining = await getAccountRows('2025-01-01', '2025-01-31', { categories: ['Dining'] });
+    expect(dining.find((r) => r.id === 'a1')?.spending).toBeCloseTo(100);
+    expect(dining.find((r) => r.id === 'a2')?.spending).toBeCloseTo(50);
+  });
+
+  it('ignores its own accounts dimension so the picker keeps every row', async () => {
+    await addAccount('a1', 'Mark');
+    await addAccount('a2', 'Sam');
+    await insertTx({ accountId: 'a1', amount: 100 });
+    await insertTx({ accountId: 'a2', amount: 50 });
+
+    const rows = await getAccountRows('2025-01-01', '2025-01-31', { accounts: ['a1'] });
+    expect(rows.find((r) => r.id === 'a2')?.spending).toBeCloseTo(50);
+  });
+});
+
+describe('getOwnerRows with a Filter', () => {
+  it('honors category and tag constraints (the spouse-split use case)', async () => {
+    await addAccount('a1', 'Mark');
+    await addAccount('a2', 'Sam');
+    const t1 = await insertTx({ accountId: 'a1', category: 'Dining', amount: 100 });
+    await insertTx({ accountId: 'a1', category: 'Rent', amount: 400 });
+    await insertTx({ accountId: 'a2', category: 'Dining', amount: 50 });
+    await tagTx(t1, 'personal');
+
+    const dining = await getOwnerRows('2025-01-01', '2025-01-31', { categories: ['Dining'] });
+    expect(dining.find((r) => r.owner === 'Mark')?.spending).toBeCloseTo(100);
+    expect(dining.find((r) => r.owner === 'Sam')?.spending).toBeCloseTo(50);
+
+    const noPersonal = await getOwnerRows('2025-01-01', '2025-01-31', { tags: [{ name: 'personal', mode: 'lacks' }] });
+    expect(noPersonal.find((r) => r.owner === 'Mark')?.spending).toBeCloseTo(400);
+    expect(noPersonal.find((r) => r.owner === 'Sam')?.spending).toBeCloseTo(50);
+  });
+
+  it('ignores its own owners dimension since it groups by owner', async () => {
+    await addAccount('a1', 'Mark');
+    await addAccount('a2', 'Sam');
+    await insertTx({ accountId: 'a1', amount: 100 });
+    await insertTx({ accountId: 'a2', amount: 50 });
+
+    const rows = await getOwnerRows('2025-01-01', '2025-01-31', { owners: ['Mark'] });
+    expect(rows.find((r) => r.owner === 'Sam')?.spending).toBeCloseTo(50);
   });
 });
 

--- a/tests/tui/screens.test.tsx
+++ b/tests/tui/screens.test.tsx
@@ -13,6 +13,7 @@ import { App } from '../../tui/App.js';
 import { Dashboard } from '../../tui/Dashboard.js';
 import { Transactions } from '../../tui/Transactions.js';
 import { Trends } from '../../tui/Trends.js';
+import { FilterPanel } from '../../tui/FilterPanel.js';
 import { NetWorth } from '../../tui/NetWorth.js';
 import { Tags } from '../../tui/Tags.js';
 import { Rules } from '../../tui/Rules.js';
@@ -21,6 +22,7 @@ import * as accountsApi from '../../core/accounts.js';
 import { Health } from '../../tui/Health.js';
 import { Settings } from '../../tui/Settings.js';
 import { RefreshProvider } from '../../tui/RefreshContext.js';
+import { FilterProvider } from '../../tui/FilterContext.js';
 import { TypingContext } from '../../tui/TypingContext.js';
 import { loadProfile, saveProfile } from '../../core/profile.js';
 
@@ -357,11 +359,19 @@ describe('Transactions', () => {
     await waitFor(() => expect(onNavigate).toHaveBeenCalledWith('dashboard', undefined));
   });
 
-  it('shows category filter label when category is provided', async () => {
-    const r = txns({ initialFilter: { ...MAY_DATE_FILTER, category: 'Grocery' } });
+  it('shows a filter-summary label when the shared filter is active', async () => {
+    const r = render(
+      <RefreshProvider>
+        <TypingContext.Provider value={() => {}}>
+          <FilterProvider initial={{ categories: ['Grocery'] }}>
+            <Transactions onNavigate={noop} showHints={false} initialFilter={MAY_DATE_FILTER} />
+          </FilterProvider>
+        </TypingContext.Provider>
+      </RefreshProvider>,
+    );
     await waitFor(() => {
       const f = frame(r);
-      expect(f).toContain('Grocery');
+      expect(f).toContain('1 category');
     });
   });
 
@@ -1439,5 +1449,48 @@ describe('App', () => {
     await waitFor(() => expect(frame(r)).toContain('Dashboard'));
     r.stdin.write('0');
     await waitFor(() => expect(frame(r)).toContain('Settings'));
+  });
+});
+
+// ── FilterPanel ─────────────────────────────────────────────────────────────
+describe('FilterPanel', () => {
+  function panel(initial = {}, onClose = noop) {
+    return render(
+      <RefreshProvider>
+        <TypingContext.Provider value={() => {}}>
+          <FilterProvider initial={initial}>
+            <FilterPanel isActive onClose={onClose} />
+          </FilterProvider>
+        </TypingContext.Provider>
+      </RefreshProvider>,
+    );
+  }
+
+  it('renders all four dimension sections with seeded options', async () => {
+    const r = panel();
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).toContain('Filter');
+      expect(f).toContain('Categories');
+      expect(f).toContain('Grocery');
+      expect(f).toContain('Accounts');
+      expect(f).toContain('Test Checking');
+    });
+  });
+
+  it('Esc closes without applying', async () => {
+    const onClose = vi.fn();
+    const r = panel({}, onClose);
+    await waitFor(() => expect(frame(r)).toContain('Grocery'));
+    r.stdin.write('\x1b');
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+
+  it('Enter applies and closes', async () => {
+    const onClose = vi.fn();
+    const r = panel({}, onClose);
+    await waitFor(() => expect(frame(r)).toContain('Grocery'));
+    r.stdin.write('\r');
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
   });
 });

--- a/tests/tui/screens.test.tsx
+++ b/tests/tui/screens.test.tsx
@@ -415,6 +415,19 @@ describe('Transactions', () => {
     await waitFor(() => expect(onNavigate).toHaveBeenCalledWith('dashboard', undefined));
   });
 
+  it('u narrows to Uncategorized while keeping the other filter dimensions', async () => {
+    const r = render(
+      <W>
+        <FilterProvider initial={{ accounts: ['test-credit'] }}>
+          <Transactions onNavigate={noop} showHints={false} />
+        </FilterProvider>
+      </W>,
+    );
+    await waitFor(() => expect(frame(r)).toContain('1 account'));
+    r.stdin.write('u');
+    await waitFor(() => expect(frame(r)).toContain('1 account, 1 category'));
+  });
+
   it('Escape reverses a drill-in in one press: pops the filter and returns to its screen', async () => {
     const onNavigate = vi.fn();
     const r = render(

--- a/tests/tui/screens.test.tsx
+++ b/tests/tui/screens.test.tsx
@@ -22,7 +22,8 @@ import * as accountsApi from '../../core/accounts.js';
 import { Health } from '../../tui/Health.js';
 import { Settings } from '../../tui/Settings.js';
 import { RefreshProvider } from '../../tui/RefreshContext.js';
-import { FilterProvider } from '../../tui/FilterContext.js';
+import { FilterProvider, useFilter } from '../../tui/FilterContext.js';
+import type { Filter } from '../../core/filters.js';
 import { TypingContext } from '../../tui/TypingContext.js';
 import { loadProfile, saveProfile } from '../../core/profile.js';
 
@@ -356,6 +357,60 @@ describe('Transactions', () => {
     );
     await waitFor(() => expect(frame(r)).toContain('Transactions'));
     r.stdin.write('\x1b');
+    await waitFor(() => expect(onNavigate).toHaveBeenCalledWith('dashboard', undefined));
+  });
+
+  it('Escape clears an active shared filter before navigating', async () => {
+    const onNavigate = vi.fn();
+    const r = render(
+      <W>
+        <FilterProvider initial={{ categories: ['Grocery'] }}>
+          <Transactions onNavigate={onNavigate} showHints={false} />
+        </FilterProvider>
+      </W>,
+    );
+    await waitFor(() => expect(frame(r)).toContain('1 category'));
+    r.stdin.write('\x1b');
+    await waitFor(() => expect(frame(r)).not.toContain('1 category'));
+    expect(onNavigate).not.toHaveBeenCalled();
+    r.stdin.write('\x1b');
+    await waitFor(() => expect(onNavigate).toHaveBeenCalledWith('dashboard', undefined));
+  });
+
+  it('Escape steps back one filter level at a time through history', async () => {
+    // Pushes filter levels into the shared context on mount, simulating a
+    // panel apply followed by a drill-in.
+    function PushFilters({ filters }: { filters: Filter[] }) {
+      const { setFilter } = useFilter();
+      React.useEffect(() => {
+        for (const f of filters) setFilter(f);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+      }, []);
+      return null;
+    }
+    const onNavigate = vi.fn();
+    const r = render(
+      <W>
+        <FilterProvider>
+          <PushFilters filters={[
+            { categories: ['Grocery'] },
+            { categories: ['Grocery'], accounts: ['test-credit'] },
+          ]} />
+          <Transactions onNavigate={onNavigate} showHints={false} />
+        </FilterProvider>
+      </W>,
+    );
+    await waitFor(() => expect(frame(r)).toContain('1 account, 1 category'));
+    r.stdin.write('\x1b'); // pop drill-in → back to the category-only filter
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).toContain('1 category');
+      expect(f).not.toContain('1 account');
+    });
+    r.stdin.write('\x1b'); // pop again → back to no filter
+    await waitFor(() => expect(frame(r)).not.toContain('1 category'));
+    expect(onNavigate).not.toHaveBeenCalled();
+    r.stdin.write('\x1b'); // nothing left → navigate
     await waitFor(() => expect(onNavigate).toHaveBeenCalledWith('dashboard', undefined));
   });
 
@@ -1466,15 +1521,114 @@ describe('FilterPanel', () => {
     );
   }
 
-  it('renders all four dimension sections with seeded options', async () => {
+  it('shows all four section tabs with counts; only the focused section lists items', async () => {
     const r = panel();
     await waitFor(() => {
       const f = frame(r);
       expect(f).toContain('Filter');
-      expect(f).toContain('Categories');
+      expect(f).toContain('▶ Categories (all)');
+      expect(f).toContain('Accounts (all)');
+      expect(f).toContain('Owners (all)');
+      expect(f).toContain('Tags');
       expect(f).toContain('Grocery');
-      expect(f).toContain('Accounts');
+      // Account rows live on their own tab now
+      expect(f).not.toContain('Test Checking');
+    });
+  });
+
+  it('right arrow switches to the Accounts section', async () => {
+    const r = panel();
+    await waitFor(() => expect(frame(r)).toContain('Grocery'));
+    r.stdin.write('\x1b[C');
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).toContain('▶ Accounts (all)');
       expect(f).toContain('Test Checking');
+      expect(f).not.toContain('Grocery');
+    });
+  });
+
+  it('left arrow from Categories wraps around to Tags', async () => {
+    const r = panel();
+    await waitFor(() => expect(frame(r)).toContain('Grocery'));
+    r.stdin.write('\x1b[D');
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).toContain('▶ Tags');
+      expect(f).toContain('travel');
+      expect(f).not.toContain('Grocery');
+    });
+  });
+
+  it('counts stay visible in the tab header after switching sections', async () => {
+    const r = panel();
+    await waitFor(() => expect(frame(r)).toContain('Grocery'));
+    r.stdin.write(' '); // toggle first category off
+    await waitFor(() => expect(frame(r)).toMatch(/▶ Categories \(\d+\/\d+\)/));
+    r.stdin.write('\x1b[C');
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).toContain('▶ Accounts (all)');
+      expect(f).toMatch(/Categories \(\d+\/\d+\)/);
+    });
+  });
+
+  it('keeps a per-section cursor when flipping between tabs', async () => {
+    const r = panel();
+    await waitFor(() => expect(frame(r)).toContain('Grocery'));
+    r.stdin.write('\x1b[B'); // ↓
+    r.stdin.write('\x1b[B'); // ↓ → third category (Grocery)
+    await waitFor(() => expect(frame(r)).toContain('▶ ● Grocery'));
+    r.stdin.write('\x1b[C'); // → Accounts
+    r.stdin.write('\x1b[D'); // ← back
+    await waitFor(() => expect(frame(r)).toContain('▶ ● Grocery'));
+  });
+
+  it('lowercase n deselects all and a reselects all in the focused section', async () => {
+    const r = panel();
+    await waitFor(() => expect(frame(r)).toContain('Grocery'));
+    r.stdin.write('n');
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).toMatch(/▶ Categories \(0\/\d+\)/);
+      expect(f).toContain('○ Grocery');
+    });
+    r.stdin.write('a');
+    await waitFor(() => expect(frame(r)).toContain('▶ Categories (all)'));
+  });
+
+  it('i inverts the selection in the focused section', async () => {
+    const r = panel();
+    await waitFor(() => expect(frame(r)).toContain('Grocery'));
+    r.stdin.write('n'); // none
+    await waitFor(() => expect(frame(r)).toContain('○ Grocery'));
+    r.stdin.write('\x1b[B');
+    r.stdin.write('\x1b[B');
+    await waitFor(() => expect(frame(r)).toContain('▶ ○ Grocery'));
+    r.stdin.write(' '); // select only Grocery
+    await waitFor(() => expect(frame(r)).toContain('▶ ● Grocery'));
+    r.stdin.write('i');
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).toContain('○ Grocery');
+      expect(f).toContain('● Bills & Utilities');
+      expect(f).toContain('● Dining');
+    });
+  });
+
+  it('i on the Tags section swaps has and lacks, leaving off tags off', async () => {
+    const r = panel();
+    await waitFor(() => expect(frame(r)).toContain('Grocery'));
+    r.stdin.write('\x1b[D'); // wrap to Tags
+    await waitFor(() => expect(frame(r)).toContain('travel'));
+    r.stdin.write(' '); // travel → has
+    await waitFor(() => expect(frame(r)).toContain('✓ has'));
+    r.stdin.write('i');
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).toContain('✗ lacks');
+      expect(f).not.toContain('✓ has');
+      expect(f).toContain('○ off'); // work stays off
     });
   });
 

--- a/tests/tui/screens.test.tsx
+++ b/tests/tui/screens.test.tsx
@@ -377,17 +377,18 @@ describe('Transactions', () => {
     await waitFor(() => expect(onNavigate).toHaveBeenCalledWith('dashboard', undefined));
   });
 
+  // Pushes filter levels into the shared context on mount, simulating a
+  // panel apply and/or a drill-in.
+  function PushFilters({ filters }: { filters: Filter[] }) {
+    const { setFilter } = useFilter();
+    React.useEffect(() => {
+      for (const f of filters) setFilter(f);
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+    return null;
+  }
+
   it('Escape steps back one filter level at a time through history', async () => {
-    // Pushes filter levels into the shared context on mount, simulating a
-    // panel apply followed by a drill-in.
-    function PushFilters({ filters }: { filters: Filter[] }) {
-      const { setFilter } = useFilter();
-      React.useEffect(() => {
-        for (const f of filters) setFilter(f);
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-      }, []);
-      return null;
-    }
     const onNavigate = vi.fn();
     const r = render(
       <W>
@@ -412,6 +413,32 @@ describe('Transactions', () => {
     expect(onNavigate).not.toHaveBeenCalled();
     r.stdin.write('\x1b'); // nothing left → navigate
     await waitFor(() => expect(onNavigate).toHaveBeenCalledWith('dashboard', undefined));
+  });
+
+  it('Escape reverses a drill-in in one press: pops the filter and returns to its screen', async () => {
+    const onNavigate = vi.fn();
+    const r = render(
+      <W>
+        <FilterProvider>
+          <PushFilters filters={[{ categories: ['Grocery'] }]} />
+          <Transactions
+            onNavigate={onNavigate}
+            showHints={false}
+            initialFilter={{ ...MAY_DATE_FILTER, drillFrom: 'dashboard' }}
+          />
+        </FilterProvider>
+      </W>,
+    );
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).toContain('1 category');
+      expect(f).toMatch(/May 2026/);
+    });
+    r.stdin.write('\x1b');
+    await waitFor(() => expect(onNavigate).toHaveBeenCalledWith('dashboard'));
+    // The drill's filter level was popped, not merely navigated away from
+    await waitFor(() => expect(frame(r)).not.toContain('1 category'));
+    expect(onNavigate).toHaveBeenCalledTimes(1);
   });
 
   it('shows a filter-summary label when the shared filter is active', async () => {

--- a/tui/App.tsx
+++ b/tui/App.tsx
@@ -35,6 +35,8 @@ export type TxFilter = {
   flex?: 'fixed' | 'flexible' | 'discretionary';
   focusCategory?: string; // land on this category's trend (Trends focus, not a filter)
   focusTag?: string;      // land on this tag's detail (Tags focus, not a filter)
+  drillFrom?: Screen;     // set when a drill-in pushed a shared-filter level; Esc reverses
+                          // the drill as a unit (pop + return here) instead of peeling state
 };
 
 function AppInner() {

--- a/tui/App.tsx
+++ b/tui/App.tsx
@@ -15,24 +15,26 @@ import { Settings } from './Settings.js';
 import { Chat } from './Chat.js';
 import { RefreshProvider, useRefreshKey } from './RefreshContext.js';
 import { FilterProvider } from './FilterContext.js';
+import { FilterPanel } from './FilterPanel.js';
 import type { CanvasSpec } from '../core/canvas-agent.js';
 import { CANVAS_SPEC_PATH } from '../core/canvas-history.js';
 
 export type Screen = 'dashboard' | 'transactions' | 'trends' | 'networth' | 'tags' | 'rules' | 'accounts' | 'health' | 'canvas' | 'settings';
 
+// Transient, per-navigation params. The persistent transaction-filtering
+// dimensions (categories/accounts/owners/tags) live in the shared FilterContext
+// now; what remains here is screen-scoped navigation state.
 export type TxFilter = {
-  category?: string;
   from?: string;
   to?: string;
-  tag?: string;
-  account?: string;
-  accountName?: string;
   search?: string;
   range?: string;   // 'week' | 'month' | 'quarter' | 'year' | 'alltime'
   anchor?: string;  // YYYY-MM-DD — which specific period to land on
   canvasSpec?: string; // JSON-encoded CanvasSpec, used when navigating to 'canvas'
   txType?: 'income' | 'expenses';
   flex?: 'fixed' | 'flexible' | 'discretionary';
+  focusCategory?: string; // land on this category's trend (Trends focus, not a filter)
+  focusTag?: string;      // land on this tag's detail (Tags focus, not a filter)
 };
 
 function AppInner() {
@@ -43,6 +45,7 @@ function AppInner() {
   const [chatFocused, setChatFocused] = useState(false);
   const [screenTyping, setScreenTyping] = useState(false);
   const [showHints, setShowHints]   = useState(false);
+  const [filterOpen, setFilterOpen] = useState(false);
   const { exit } = useApp();
   const refreshKey = useRefreshKey();
   const lastSpecRef = useRef<string>('');
@@ -77,12 +80,15 @@ function AppInner() {
   }
 
   useInput((input) => {
-    if (chatFocused || screenTyping) return;
+    if (chatFocused || screenTyping || filterOpen) return;
     if (input === 'q') exit();
     if (input === 'h') setShowHints((v) => !v);
+    if (input === 'f' && (screen === 'dashboard' || screen === 'transactions' || screen === 'trends')) {
+      setFilterOpen(true);
+    }
   });
 
-  const screenIsActive = !chatFocused;
+  const screenIsActive = !chatFocused && !filterOpen;
 
   const currentScreen = (() => {
     switch (screen) {
@@ -105,6 +111,7 @@ function AppInner() {
         <Box flexGrow={1}>
           {currentScreen}
         </Box>
+        {filterOpen && <FilterPanel isActive={filterOpen} onClose={() => setFilterOpen(false)} />}
         <Chat
           isActive={chatFocused}
           onActivate={() => setChatFocused(true)}

--- a/tui/Chat.tsx
+++ b/tui/Chat.tsx
@@ -7,6 +7,7 @@ import { truncate } from './fmt.js';
 import { CURSOR, C_POSITIVE, C_NEGATIVE, C_WARNING, C_ACCENT, C_DIM } from './ui.js';
 import { TextInput } from './components/index.js';
 import type { Screen, TxFilter } from './App.js';
+import { useFilter } from './FilterContext.js';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -46,6 +47,7 @@ export function Chat({
   onDeactivate: () => void;
   onNavigate: (s: Screen, f?: TxFilter) => void;
 }) {
+  const { filter: sharedFilter, setFilter } = useFilter();
   const [displayMsgs, setDisplayMsgs] = useState<DisplayMsg[]>([]);
   const [input, setInput]             = useState('');
   const [isStreaming, setIsStreaming]  = useState(false);
@@ -95,17 +97,26 @@ export function Chat({
           };
         }),
         onNavigate: (screen, filter) => {
+          const s = screen as Screen;
+          // Filtering dimensions drive the sticky shared filter (replace those
+          // dims); category/tag focus targets ride along as transient nav params.
+          if (s === 'transactions' && (filter?.category || filter?.account || filter?.tag)) {
+            setFilter({
+              ...sharedFilter,
+              ...(filter.category ? { categories: [filter.category] } : {}),
+              ...(filter.account ? { accounts: [filter.account] } : {}),
+              ...(filter.tag ? { tags: [{ name: filter.tag, mode: 'has' as const }] } : {}),
+            });
+          }
           const txFilter: TxFilter = {};
-          if (filter?.category)    txFilter.category    = filter.category;
-          if (filter?.from)        txFilter.from        = filter.from;
-          if (filter?.to)          txFilter.to          = filter.to;
-          if (filter?.tag)         txFilter.tag         = filter.tag;
-          if (filter?.account)     txFilter.account     = filter.account;
-          if (filter?.accountName) txFilter.accountName = filter.accountName;
-          if (filter?.search)      txFilter.search      = filter.search;
-          if (filter?.range)       txFilter.range       = filter.range;
-          if (filter?.anchor)      txFilter.anchor      = filter.anchor;
-          onNavigate(screen as Screen, Object.keys(txFilter).length ? txFilter : undefined);
+          if (filter?.from)     txFilter.from   = filter.from;
+          if (filter?.to)       txFilter.to     = filter.to;
+          if (filter?.search)   txFilter.search = filter.search;
+          if (filter?.range)    txFilter.range  = filter.range;
+          if (filter?.anchor)   txFilter.anchor = filter.anchor;
+          if (s === 'trends' && filter?.category) txFilter.focusCategory = filter.category;
+          if (s === 'tags'   && filter?.tag)      txFilter.focusTag      = filter.tag;
+          onNavigate(s, Object.keys(txFilter).length ? txFilter : undefined);
         },
       });
 

--- a/tui/Dashboard.tsx
+++ b/tui/Dashboard.tsx
@@ -228,6 +228,7 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
             from: merchantDrill.from,
             to: merchantDrill.to,
             search: row.merchant,
+            drillFrom: 'dashboard',
           });
         }
         return;
@@ -297,7 +298,7 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
           // Drill-in writes the sticky shared filter (replace those dimensions),
           // keeping the date range / search as transient nav params.
           setFilter({ ...sharedFilter, categories: [cat.category], ...(selectedAccount ? { accounts: [selectedAccount.id] } : {}) });
-          onNavigate('transactions', { from, to, ...(search ? { search } : {}) });
+          onNavigate('transactions', { from, to, ...(search ? { search } : {}), drillFrom: 'dashboard' });
         }
         return;
       }
@@ -306,8 +307,10 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
     if (view === 'flex') {
       if (key.return) {
         const { from, to } = getPeriodDates(range, anchor);
+        // drillFrom only when a filter level was actually pushed, so Esc's
+        // pop doesn't eat an unrelated level.
         if (selectedAccount) setFilter({ ...sharedFilter, accounts: [selectedAccount.id] });
-        onNavigate('transactions', { from, to });
+        onNavigate('transactions', { from, to, ...(selectedAccount ? { drillFrom: 'dashboard' as const } : {}) });
         return;
       }
     }
@@ -320,7 +323,7 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
         if (acct) {
           const { from, to } = getPeriodDates(range, anchor);
           setFilter({ ...sharedFilter, accounts: [acct.id] });
-          onNavigate('transactions', { from, to });
+          onNavigate('transactions', { from, to, drillFrom: 'dashboard' });
         }
         return;
       }

--- a/tui/Dashboard.tsx
+++ b/tui/Dashboard.tsx
@@ -111,8 +111,8 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
 
   function load(r: Range, a: Date, qf: Filter) {
     const { from, to } = getPeriodDates(r, a);
-    void getAccountRows(from, to).then(setAccountRows);
-    void getOwnerRows(from, to).then(setOwnerRows);
+    void getAccountRows(from, to, qf).then(setAccountRows);
+    void getOwnerRows(from, to, qf).then(setOwnerRows);
     setAcctCursor(0);
     void getRangeSummary(from, to, qf).then(setSummary);
     void getFlexSummary(from, to, qf).then(setFlexData);

--- a/tui/Dashboard.tsx
+++ b/tui/Dashboard.tsx
@@ -56,7 +56,7 @@ const FLEX_TIERS: Array<{ key: keyof FlexSummary; label: string; color: string }
 
 export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { onNavigate: (s: Screen, filter?: TxFilter) => void; isActive?: boolean; initialFilter?: TxFilter; showHints: boolean }) {
   const refreshKey = useRefreshKey();
-  const { filter: sharedFilter } = useFilter();
+  const { filter: sharedFilter, setFilter } = useFilter();
   const now = new Date();
   const [range, setRange] = useState<Range>(() => {
     const r = initialFilter?.range;
@@ -223,12 +223,11 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
       if (key.return) {
         const row = merchantRows[merchantCursor];
         if (row && merchantDrill) {
+          setFilter({ ...sharedFilter, categories: [merchantDrill.category], ...(selectedAccount ? { accounts: [selectedAccount.id] } : {}) });
           onNavigate('transactions', {
-            category: merchantDrill.category,
             from: merchantDrill.from,
             to: merchantDrill.to,
             search: row.merchant,
-            ...(selectedAccount ? { account: selectedAccount.id, accountName: selectedAccount.name } : {}),
           });
         }
         return;
@@ -295,7 +294,10 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
         const cat = displayCats[catCursor];
         if (cat) {
           const { from, to } = getPeriodDates(range, anchor);
-          onNavigate('transactions', { category: cat.category, from, to, ...(selectedAccount ? { account: selectedAccount.id, accountName: selectedAccount.name } : {}), ...(search ? { search } : {}) });
+          // Drill-in writes the sticky shared filter (replace those dimensions),
+          // keeping the date range / search as transient nav params.
+          setFilter({ ...sharedFilter, categories: [cat.category], ...(selectedAccount ? { accounts: [selectedAccount.id] } : {}) });
+          onNavigate('transactions', { from, to, ...(search ? { search } : {}) });
         }
         return;
       }
@@ -304,7 +306,8 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
     if (view === 'flex') {
       if (key.return) {
         const { from, to } = getPeriodDates(range, anchor);
-        onNavigate('transactions', { from, to, ...(selectedAccount ? { account: selectedAccount.id, accountName: selectedAccount.name } : {}) });
+        if (selectedAccount) setFilter({ ...sharedFilter, accounts: [selectedAccount.id] });
+        onNavigate('transactions', { from, to });
         return;
       }
     }
@@ -316,7 +319,8 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
         const acct = accountRows[acctCursor];
         if (acct) {
           const { from, to } = getPeriodDates(range, anchor);
-          onNavigate('transactions', { account: acct.id, accountName: acct.name, from, to });
+          setFilter({ ...sharedFilter, accounts: [acct.id] });
+          onNavigate('transactions', { from, to });
         }
         return;
       }
@@ -357,9 +361,9 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
     // Intercept '2' to carry search + period filter into Transactions
     if (input === '2') {
       const { from, to } = getPeriodDates(range, anchor);
+      if (selectedAccount) setFilter({ ...sharedFilter, accounts: [selectedAccount.id] });
       onNavigate('transactions', {
         from, to,
-        ...(selectedAccount ? { account: selectedAccount.id, accountName: selectedAccount.name } : {}),
         ...(search ? { search } : {}),
       });
       return;

--- a/tui/FilterContext.tsx
+++ b/tui/FilterContext.tsx
@@ -9,8 +9,8 @@ type FilterCtx = { filter: Filter; setFilter: (f: Filter) => void };
 
 const Ctx = createContext<FilterCtx>({ filter: EMPTY_FILTER, setFilter: () => {} });
 
-export function FilterProvider({ children }: { children: React.ReactNode }) {
-  const [filter, setFilter] = useState<Filter>(EMPTY_FILTER);
+export function FilterProvider({ initial, children }: { initial?: Filter; children: React.ReactNode }) {
+  const [filter, setFilter] = useState<Filter>(initial ?? EMPTY_FILTER);
   return <Ctx.Provider value={{ filter, setFilter }}>{children}</Ctx.Provider>;
 }
 

--- a/tui/FilterContext.tsx
+++ b/tui/FilterContext.tsx
@@ -1,17 +1,41 @@
-import React, { createContext, useContext, useState } from 'react';
-import { EMPTY_FILTER, type Filter } from '../core/filters.js';
+import React, { createContext, useCallback, useContext, useState } from 'react';
+import {
+  EMPTY_FILTER,
+  pushFilter,
+  popFilter as popFilterCore,
+  type Filter,
+  type FilterHistory,
+} from '../core/filters.js';
 
 // Session-global filter shared across Dashboard, Transactions, and Trends.
 // State lives above the screens so applying a filter on one carries to the
 // others. It is intentionally not persisted to disk — it resets each session.
+// Every setFilter pushes the previous value onto a bounded history stack so
+// popFilter can step back one level at a time (Esc in Transactions).
 
-type FilterCtx = { filter: Filter; setFilter: (f: Filter) => void };
+type FilterCtx = {
+  filter: Filter;
+  setFilter: (f: Filter) => void;
+  popFilter: () => void;
+  canPop: boolean;
+};
 
-const Ctx = createContext<FilterCtx>({ filter: EMPTY_FILTER, setFilter: () => {} });
+const Ctx = createContext<FilterCtx>({
+  filter: EMPTY_FILTER,
+  setFilter: () => {},
+  popFilter: () => {},
+  canPop: false,
+});
 
 export function FilterProvider({ initial, children }: { initial?: Filter; children: React.ReactNode }) {
-  const [filter, setFilter] = useState<Filter>(initial ?? EMPTY_FILTER);
-  return <Ctx.Provider value={{ filter, setFilter }}>{children}</Ctx.Provider>;
+  const [hist, setHist] = useState<FilterHistory>({ current: initial ?? EMPTY_FILTER, stack: [] });
+  const setFilter = useCallback((f: Filter) => setHist((h) => pushFilter(h, f)), []);
+  const popFilter = useCallback(() => setHist(popFilterCore), []);
+  return (
+    <Ctx.Provider value={{ filter: hist.current, setFilter, popFilter, canPop: hist.stack.length > 0 }}>
+      {children}
+    </Ctx.Provider>
+  );
 }
 
 export function useFilter(): FilterCtx {

--- a/tui/FilterPanel.tsx
+++ b/tui/FilterPanel.tsx
@@ -2,7 +2,10 @@ import React, { useState, useEffect } from 'react';
 import { Box, Text, useInput } from 'ink';
 import { getFilterOptions, type FilterOptions } from '../core/queries.js';
 import { useFilter } from './FilterContext.js';
-import { selectionToDim, selectionFromDim, type Filter, type TagPredicate } from '../core/filters.js';
+import {
+  selectionToDim, selectionFromDim, invertSelection, invertTagModes,
+  type Filter, type TagPredicate,
+} from '../core/filters.js';
 import { ModalPanel } from './components/index.js';
 import { C_ACCENT, C_POSITIVE, C_NEGATIVE, C_DIM } from './ui.js';
 
@@ -10,16 +13,16 @@ import { C_ACCENT, C_POSITIVE, C_NEGATIVE, C_DIM } from './ui.js';
 // shared filter into a draft, lets you adjust all four dimensions, and writes it
 // back via setFilter on apply. Categories/accounts/owners use a select-from-
 // universe model (everything selected → no constraint); tags are tri-state
-// (off / has / lacks) matching the TagPredicate model.
+// (off / has / lacks) matching the TagPredicate model. The dimensions render as
+// horizontal tabs (←/→ to switch) so every section is discoverable at a glance.
 
 type Section = 'categories' | 'accounts' | 'owners' | 'tags';
+const SECTIONS: Section[] = ['categories', 'accounts', 'owners', 'tags'];
 const SECTION_LABEL: Record<Section, string> = {
   categories: 'Categories', accounts: 'Accounts', owners: 'Owners', tags: 'Tags',
 };
 
-type Row =
-  | { kind: 'header'; section: Section }
-  | { kind: 'item'; section: Section; key: string; label: string; sub?: string };
+type Item = { key: string; label: string; sub?: string };
 
 const WINDOW = 16;
 
@@ -33,7 +36,12 @@ export function FilterPanel({ isActive, onClose }: { isActive: boolean; onClose:
   const [acctSel, setAcctSel] = useState<Set<string>>(new Set());
   const [ownerSel, setOwnerSel] = useState<Set<string>>(new Set());
   const [tagModes, setTagModes] = useState<Map<string, 'has' | 'lacks'>>(new Map());
-  const [cursor, setCursor] = useState(0);
+  const [section, setSection] = useState(0);
+  // Per-section cursors, kept while the panel is open so flipping between tabs
+  // doesn't lose your place in a long list.
+  const [cursors, setCursors] = useState<Record<Section, number>>({
+    categories: 0, accounts: 0, owners: 0, tags: 0,
+  });
 
   // Load options + hydrate the draft from the current shared filter on open.
   useEffect(() => {
@@ -43,27 +51,24 @@ export function FilterPanel({ isActive, onClose }: { isActive: boolean; onClose:
       setAcctSel(selectionFromDim(filter.accounts, o.accounts.map((a) => a.id)));
       setOwnerSel(selectionFromDim(filter.owners, o.owners));
       setTagModes(new Map((filter.tags ?? []).map((t) => [t.name, t.mode])));
-      setCursor(0);
+      setSection(0);
+      setCursors({ categories: 0, accounts: 0, owners: 0, tags: 0 });
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Flattened row list (headers + items) and the indices that are selectable.
-  const rows: Row[] = [];
-  if (opts) {
-    rows.push({ kind: 'header', section: 'categories' });
-    for (const c of opts.categories) rows.push({ kind: 'item', section: 'categories', key: c, label: c });
-    rows.push({ kind: 'header', section: 'accounts' });
-    for (const a of opts.accounts) rows.push({ kind: 'item', section: 'accounts', key: a.id, label: a.name, sub: a.owner });
-    rows.push({ kind: 'header', section: 'owners' });
-    for (const o of opts.owners) rows.push({ kind: 'item', section: 'owners', key: o, label: o });
-    rows.push({ kind: 'header', section: 'tags' });
-    for (const t of opts.tags) rows.push({ kind: 'item', section: 'tags', key: t, label: t });
+  const currentSection = SECTIONS[section];
+
+  function itemsForSection(s: Section): Item[] {
+    if (!opts) return [];
+    if (s === 'categories') return opts.categories.map((c) => ({ key: c, label: c }));
+    if (s === 'accounts') return opts.accounts.map((a) => ({ key: a.id, label: a.name, sub: a.owner }));
+    if (s === 'owners') return opts.owners.map((o) => ({ key: o, label: o }));
+    return opts.tags.map((t) => ({ key: t, label: t }));
   }
-  const selectable = rows.map((r, i) => (r.kind === 'item' ? i : -1)).filter((i) => i >= 0);
-  const cursorRowIdx = selectable[Math.min(cursor, Math.max(0, selectable.length - 1))] ?? 0;
-  const current = rows[cursorRowIdx];
-  const currentSection: Section | null = current?.kind === 'item' ? current.section : null;
+  const items = itemsForSection(currentSection);
+  const cursor = Math.min(cursors[currentSection], Math.max(0, items.length - 1));
+  const current: Item | undefined = items[cursor];
 
   function selForSection(s: Section): [Set<string>, (next: Set<string>) => void] {
     if (s === 'categories') return [catSel, setCatSel];
@@ -77,9 +82,16 @@ export function FilterPanel({ isActive, onClose }: { isActive: boolean; onClose:
     return opts.owners;
   }
 
+  function moveCursor(delta: number) {
+    setCursors((c) => ({
+      ...c,
+      [currentSection]: Math.max(0, Math.min(items.length - 1, c[currentSection] + delta)),
+    }));
+  }
+
   function toggleCurrent() {
-    if (current?.kind !== 'item') return;
-    if (current.section === 'tags') {
+    if (!current) return;
+    if (currentSection === 'tags') {
       setTagModes((m) => {
         const n = new Map(m);
         const cur = n.get(current.key);
@@ -90,20 +102,28 @@ export function FilterPanel({ isActive, onClose }: { isActive: boolean; onClose:
       });
       return;
     }
-    const [sel, set] = selForSection(current.section);
+    const [sel, set] = selForSection(currentSection);
     const n = new Set(sel);
     if (n.has(current.key)) n.delete(current.key); else n.add(current.key);
     set(n);
   }
 
   function bulk(all: boolean) {
-    if (!currentSection) return;
     if (currentSection === 'tags') {
       if (!all) setTagModes(new Map());
       return;
     }
     const [, set] = selForSection(currentSection);
     set(all ? new Set(universeForSection(currentSection)) : new Set());
+  }
+
+  function invert() {
+    if (currentSection === 'tags') {
+      setTagModes((m) => invertTagModes(m));
+      return;
+    }
+    const [sel, set] = selForSection(currentSection);
+    set(invertSelection(sel, universeForSection(currentSection)));
   }
 
   function clearAll() {
@@ -132,19 +152,26 @@ export function FilterPanel({ isActive, onClose }: { isActive: boolean; onClose:
   useInput((input, key) => {
     if (key.escape) { onClose(); return; }
     if (key.return) { apply(); return; }
-    if (key.upArrow) { setCursor((c) => Math.max(0, c - 1)); return; }
-    if (key.downArrow) { setCursor((c) => Math.min(selectable.length - 1, c + 1)); return; }
+    if (key.leftArrow) { setSection((s) => (s + SECTIONS.length - 1) % SECTIONS.length); return; }
+    if (key.rightArrow) { setSection((s) => (s + 1) % SECTIONS.length); return; }
+    if (key.upArrow) { moveCursor(-1); return; }
+    if (key.downArrow) { moveCursor(1); return; }
     if (input === ' ') { toggleCurrent(); return; }
-    if (input === 'A') { bulk(true); return; }
-    if (input === 'N') { bulk(false); return; }
+    const k = input.toLowerCase();
+    if (k === 'a') { bulk(true); return; }
+    if (k === 'n') { bulk(false); return; }
+    if (k === 'i') { invert(); return; }
     if (input === 'c') { clearAll(); return; }
   }, { isActive });
 
   if (!opts) return null;
 
-  // Window the row list around the cursor so a long universe stays bounded.
-  const winStart = Math.max(0, Math.min(cursorRowIdx - Math.floor(WINDOW / 2), rows.length - WINDOW));
-  const visible = rows.slice(winStart, winStart + WINDOW);
+  // Window the focused section's list around the cursor so a long universe
+  // stays bounded.
+  const winStart = Math.max(0, Math.min(cursor - Math.floor(WINDOW / 2), items.length - WINDOW));
+  const visible = items.slice(winStart, winStart + WINDOW);
+  const clippedAbove = winStart;
+  const clippedBelow = items.length - (winStart + visible.length);
 
   function sectionCount(s: Section): string {
     if (s === 'tags') {
@@ -159,46 +186,53 @@ export function FilterPanel({ isActive, onClose }: { isActive: boolean; onClose:
   return (
     <ModalPanel title="Filter" borderColor={C_ACCENT}>
       <Text dimColor>
-        ↑↓ move  ·  Space toggle  ·  A all  ·  N none  ·  c clear  ·  Enter apply  ·  Esc cancel
+        ←→ section  ·  ↑↓ move  ·  Space toggle  ·  a all  ·  n none  ·  i invert  ·  c clear  ·  Enter apply  ·  Esc cancel
       </Text>
+      <Box marginTop={1} gap={3}>
+        {SECTIONS.map((s) => (
+          <Text
+            key={s}
+            bold={s === currentSection}
+            color={s === currentSection ? C_ACCENT : undefined}
+            dimColor={s !== currentSection}
+          >
+            {s === currentSection ? '▶ ' : '  '}{SECTION_LABEL[s]}{sectionCount(s)}
+          </Text>
+        ))}
+      </Box>
       <Box flexDirection="column" marginTop={1}>
-        {visible.map((row, i) => {
-          const idx = winStart + i;
-          if (row.kind === 'header') {
-            return (
-              <Box key={`h-${row.section}`} marginTop={i === 0 ? 0 : 1}>
-                <Text bold color={currentSection === row.section ? C_ACCENT : undefined}>
-                  {SECTION_LABEL[row.section]}{sectionCount(row.section)}
-                </Text>
-              </Box>
-            );
-          }
-          const isCursor = idx === cursorRowIdx;
+        {items.length === 0 ? (
+          <Text dimColor>  no {SECTION_LABEL[currentSection].toLowerCase()}</Text>
+        ) : null}
+        {clippedAbove > 0 ? <Text color={C_DIM}>  ↑ {clippedAbove} more</Text> : null}
+        {visible.map((item, i) => {
+          const isCursor = winStart + i === cursor;
           let mark: React.ReactNode;
-          if (row.section === 'tags') {
-            const mode = tagModes.get(row.key);
+          if (currentSection === 'tags') {
+            const mode = tagModes.get(item.key);
             mark = mode === 'has'
               ? <Text color={C_POSITIVE}>✓ has  </Text>
               : mode === 'lacks'
                 ? <Text color={C_NEGATIVE}>✗ lacks</Text>
                 : <Text dimColor>○ off  </Text>;
           } else {
-            const [sel] = selForSection(row.section);
-            mark = sel.has(row.key)
+            const [sel] = selForSection(currentSection);
+            mark = sel.has(item.key)
               ? <Text color={C_POSITIVE}>●</Text>
               : <Text dimColor>○</Text>;
           }
           return (
-            <Box key={`${row.section}-${row.key}`}>
+            <Box key={`${currentSection}-${item.key}`}>
               <Text color={isCursor ? C_ACCENT : undefined}>{isCursor ? '▶ ' : '  '}</Text>
               <Box gap={1}>
                 {mark}
-                <Text color={isCursor ? C_ACCENT : undefined} dimColor={!isCursor}>{row.label}</Text>
-                {row.sub ? <Text color={C_DIM}>{row.sub}</Text> : null}
+                <Text color={isCursor ? C_ACCENT : undefined} dimColor={!isCursor}>{item.label}</Text>
+                {item.sub ? <Text color={C_DIM}>{item.sub}</Text> : null}
               </Box>
             </Box>
           );
         })}
+        {clippedBelow > 0 ? <Text color={C_DIM}>  ↓ {clippedBelow} more</Text> : null}
       </Box>
     </ModalPanel>
   );

--- a/tui/FilterPanel.tsx
+++ b/tui/FilterPanel.tsx
@@ -1,0 +1,205 @@
+import React, { useState, useEffect } from 'react';
+import { Box, Text, useInput } from 'ink';
+import { getFilterOptions, type FilterOptions } from '../core/queries.js';
+import { useFilter } from './FilterContext.js';
+import { selectionToDim, selectionFromDim, type Filter, type TagPredicate } from '../core/filters.js';
+import { ModalPanel } from './components/index.js';
+import { C_ACCENT, C_POSITIVE, C_NEGATIVE, C_DIM } from './ui.js';
+
+// Global, session-wide filter panel. Opens over any screen; reads the current
+// shared filter into a draft, lets you adjust all four dimensions, and writes it
+// back via setFilter on apply. Categories/accounts/owners use a select-from-
+// universe model (everything selected → no constraint); tags are tri-state
+// (off / has / lacks) matching the TagPredicate model.
+
+type Section = 'categories' | 'accounts' | 'owners' | 'tags';
+const SECTION_LABEL: Record<Section, string> = {
+  categories: 'Categories', accounts: 'Accounts', owners: 'Owners', tags: 'Tags',
+};
+
+type Row =
+  | { kind: 'header'; section: Section }
+  | { kind: 'item'; section: Section; key: string; label: string; sub?: string };
+
+const WINDOW = 16;
+
+export function FilterPanel({ isActive, onClose }: { isActive: boolean; onClose: () => void }) {
+  const { filter, setFilter } = useFilter();
+  const [opts, setOpts] = useState<FilterOptions | null>(null);
+
+  // Draft selection state. Sets hold the *selected* members of each universe;
+  // tagModes maps a tag name to its predicate ('has'/'lacks'), absent = off.
+  const [catSel, setCatSel] = useState<Set<string>>(new Set());
+  const [acctSel, setAcctSel] = useState<Set<string>>(new Set());
+  const [ownerSel, setOwnerSel] = useState<Set<string>>(new Set());
+  const [tagModes, setTagModes] = useState<Map<string, 'has' | 'lacks'>>(new Map());
+  const [cursor, setCursor] = useState(0);
+
+  // Load options + hydrate the draft from the current shared filter on open.
+  useEffect(() => {
+    void getFilterOptions().then((o) => {
+      setOpts(o);
+      setCatSel(selectionFromDim(filter.categories, o.categories));
+      setAcctSel(selectionFromDim(filter.accounts, o.accounts.map((a) => a.id)));
+      setOwnerSel(selectionFromDim(filter.owners, o.owners));
+      setTagModes(new Map((filter.tags ?? []).map((t) => [t.name, t.mode])));
+      setCursor(0);
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Flattened row list (headers + items) and the indices that are selectable.
+  const rows: Row[] = [];
+  if (opts) {
+    rows.push({ kind: 'header', section: 'categories' });
+    for (const c of opts.categories) rows.push({ kind: 'item', section: 'categories', key: c, label: c });
+    rows.push({ kind: 'header', section: 'accounts' });
+    for (const a of opts.accounts) rows.push({ kind: 'item', section: 'accounts', key: a.id, label: a.name, sub: a.owner });
+    rows.push({ kind: 'header', section: 'owners' });
+    for (const o of opts.owners) rows.push({ kind: 'item', section: 'owners', key: o, label: o });
+    rows.push({ kind: 'header', section: 'tags' });
+    for (const t of opts.tags) rows.push({ kind: 'item', section: 'tags', key: t, label: t });
+  }
+  const selectable = rows.map((r, i) => (r.kind === 'item' ? i : -1)).filter((i) => i >= 0);
+  const cursorRowIdx = selectable[Math.min(cursor, Math.max(0, selectable.length - 1))] ?? 0;
+  const current = rows[cursorRowIdx];
+  const currentSection: Section | null = current?.kind === 'item' ? current.section : null;
+
+  function selForSection(s: Section): [Set<string>, (next: Set<string>) => void] {
+    if (s === 'categories') return [catSel, setCatSel];
+    if (s === 'accounts') return [acctSel, setAcctSel];
+    return [ownerSel, setOwnerSel];
+  }
+  function universeForSection(s: Section): string[] {
+    if (!opts) return [];
+    if (s === 'categories') return opts.categories;
+    if (s === 'accounts') return opts.accounts.map((a) => a.id);
+    return opts.owners;
+  }
+
+  function toggleCurrent() {
+    if (current?.kind !== 'item') return;
+    if (current.section === 'tags') {
+      setTagModes((m) => {
+        const n = new Map(m);
+        const cur = n.get(current.key);
+        if (cur === undefined) n.set(current.key, 'has');
+        else if (cur === 'has') n.set(current.key, 'lacks');
+        else n.delete(current.key);
+        return n;
+      });
+      return;
+    }
+    const [sel, set] = selForSection(current.section);
+    const n = new Set(sel);
+    if (n.has(current.key)) n.delete(current.key); else n.add(current.key);
+    set(n);
+  }
+
+  function bulk(all: boolean) {
+    if (!currentSection) return;
+    if (currentSection === 'tags') {
+      if (!all) setTagModes(new Map());
+      return;
+    }
+    const [, set] = selForSection(currentSection);
+    set(all ? new Set(universeForSection(currentSection)) : new Set());
+  }
+
+  function clearAll() {
+    if (!opts) return;
+    setCatSel(new Set(opts.categories));
+    setAcctSel(new Set(opts.accounts.map((a) => a.id)));
+    setOwnerSel(new Set(opts.owners));
+    setTagModes(new Map());
+  }
+
+  function apply() {
+    if (!opts) { onClose(); return; }
+    const tags: TagPredicate[] = [...tagModes.entries()].map(([name, mode]) => ({ name, mode }));
+    const next: Filter = {};
+    const cats = selectionToDim(catSel, opts.categories);
+    const accts = selectionToDim(acctSel, opts.accounts.map((a) => a.id));
+    const owners = selectionToDim(ownerSel, opts.owners);
+    if (cats !== undefined) next.categories = cats;
+    if (accts !== undefined) next.accounts = accts;
+    if (owners !== undefined) next.owners = owners;
+    if (tags.length) next.tags = tags;
+    setFilter(next);
+    onClose();
+  }
+
+  useInput((input, key) => {
+    if (key.escape) { onClose(); return; }
+    if (key.return) { apply(); return; }
+    if (key.upArrow) { setCursor((c) => Math.max(0, c - 1)); return; }
+    if (key.downArrow) { setCursor((c) => Math.min(selectable.length - 1, c + 1)); return; }
+    if (input === ' ') { toggleCurrent(); return; }
+    if (input === 'A') { bulk(true); return; }
+    if (input === 'N') { bulk(false); return; }
+    if (input === 'c') { clearAll(); return; }
+  }, { isActive });
+
+  if (!opts) return null;
+
+  // Window the row list around the cursor so a long universe stays bounded.
+  const winStart = Math.max(0, Math.min(cursorRowIdx - Math.floor(WINDOW / 2), rows.length - WINDOW));
+  const visible = rows.slice(winStart, winStart + WINDOW);
+
+  function sectionCount(s: Section): string {
+    if (s === 'tags') {
+      const n = [...tagModes.values()].length;
+      return n ? ` (${n})` : '';
+    }
+    const [sel] = selForSection(s);
+    const total = universeForSection(s).length;
+    return sel.size === total ? ' (all)' : ` (${sel.size}/${total})`;
+  }
+
+  return (
+    <ModalPanel title="Filter" borderColor={C_ACCENT}>
+      <Text dimColor>
+        ↑↓ move  ·  Space toggle  ·  A all  ·  N none  ·  c clear  ·  Enter apply  ·  Esc cancel
+      </Text>
+      <Box flexDirection="column" marginTop={1}>
+        {visible.map((row, i) => {
+          const idx = winStart + i;
+          if (row.kind === 'header') {
+            return (
+              <Box key={`h-${row.section}`} marginTop={i === 0 ? 0 : 1}>
+                <Text bold color={currentSection === row.section ? C_ACCENT : undefined}>
+                  {SECTION_LABEL[row.section]}{sectionCount(row.section)}
+                </Text>
+              </Box>
+            );
+          }
+          const isCursor = idx === cursorRowIdx;
+          let mark: React.ReactNode;
+          if (row.section === 'tags') {
+            const mode = tagModes.get(row.key);
+            mark = mode === 'has'
+              ? <Text color={C_POSITIVE}>✓ has  </Text>
+              : mode === 'lacks'
+                ? <Text color={C_NEGATIVE}>✗ lacks</Text>
+                : <Text dimColor>○ off  </Text>;
+          } else {
+            const [sel] = selForSection(row.section);
+            mark = sel.has(row.key)
+              ? <Text color={C_POSITIVE}>●</Text>
+              : <Text dimColor>○</Text>;
+          }
+          return (
+            <Box key={`${row.section}-${row.key}`}>
+              <Text color={isCursor ? C_ACCENT : undefined}>{isCursor ? '▶ ' : '  '}</Text>
+              <Box gap={1}>
+                {mark}
+                <Text color={isCursor ? C_ACCENT : undefined} dimColor={!isCursor}>{row.label}</Text>
+                {row.sub ? <Text color={C_DIM}>{row.sub}</Text> : null}
+              </Box>
+            </Box>
+          );
+        })}
+      </Box>
+    </ModalPanel>
+  );
+}

--- a/tui/Tags.tsx
+++ b/tui/Tags.tsx
@@ -123,13 +123,13 @@ export function Tags({ onNavigate, isActive, showHints, initialFilter }: { onNav
         const cat = tagSummary?.byCategory[catCursor];
         if (tag) {
           setFilter({ ...filter, tags: [{ name: tag.name, mode: 'has' }], ...(cat ? { categories: [cat.category] } : {}) });
-          onNavigate('transactions');
+          onNavigate('transactions', { drillFrom: 'tags' });
         }
         return;
       }
       if (input === 't' && visibleTags[cursor]) {
         setFilter({ ...filter, tags: [{ name: visibleTags[cursor].name, mode: 'has' }] });
-        onNavigate('transactions');
+        onNavigate('transactions', { drillFrom: 'tags' });
         return;
       }
       if (handleNavKey(input, 'tags', onNavigate)) return;
@@ -161,7 +161,7 @@ export function Tags({ onNavigate, isActive, showHints, initialFilter }: { onNav
     }
     if (input === 't' && visibleTags[cursor]) {
       setFilter({ ...filter, tags: [{ name: visibleTags[cursor].name, mode: 'has' }] });
-      onNavigate('transactions');
+      onNavigate('transactions', { drillFrom: 'tags' });
       return;
     }
   }, { isActive: isActive !== false });

--- a/tui/Tags.tsx
+++ b/tui/Tags.tsx
@@ -9,11 +9,13 @@ import { useTerminalWidth, C_POSITIVE, C_NEGATIVE, C_WARNING, C_ACCENT } from '.
 import { StatCard, ModalPanel, SectionHeader, TextInput, SelectableRow, useStatusMessage, PageHeader, SearchBar } from './components/index.js';
 import { useSetTyping } from './TypingContext.js';
 import { useRefreshKey } from './RefreshContext.js';
+import { useFilter } from './FilterContext.js';
 
 type Mode = 'list' | 'search' | 'add' | 'detail' | 'rename';
 
 export function Tags({ onNavigate, isActive, showHints, initialFilter }: { onNavigate: (s: Screen, f?: TxFilter) => void; isActive?: boolean; showHints: boolean; initialFilter?: TxFilter }) {
   const refreshKey = useRefreshKey();
+  const { filter, setFilter } = useFilter();
   const [tags, setTags] = useState<Tag[]>([]);
   const [cursor, setCursor] = useState(0);
   const [mode, setMode] = useState<Mode>('list');
@@ -31,7 +33,7 @@ export function Tags({ onNavigate, isActive, showHints, initialFilter }: { onNav
       setTags(loaded);
       if (!initialNavDone.current) {
         initialNavDone.current = true;
-        const target = initialFilter?.tag;
+        const target = initialFilter?.focusTag;
         if (target) {
           const idx = loaded.findIndex((t) => t.name.toLowerCase() === target.toLowerCase());
           if (idx >= 0) { setCursor(idx); openDetail(loaded[idx]); }
@@ -119,11 +121,15 @@ export function Tags({ onNavigate, isActive, showHints, initialFilter }: { onNav
       if (key.return) {
         const tag = visibleTags[cursor];
         const cat = tagSummary?.byCategory[catCursor];
-        if (tag) onNavigate('transactions', { tag: tag.name, category: cat?.category });
+        if (tag) {
+          setFilter({ ...filter, tags: [{ name: tag.name, mode: 'has' }], ...(cat ? { categories: [cat.category] } : {}) });
+          onNavigate('transactions');
+        }
         return;
       }
       if (input === 't' && visibleTags[cursor]) {
-        onNavigate('transactions', { tag: visibleTags[cursor].name });
+        setFilter({ ...filter, tags: [{ name: visibleTags[cursor].name, mode: 'has' }] });
+        onNavigate('transactions');
         return;
       }
       if (handleNavKey(input, 'tags', onNavigate)) return;
@@ -154,7 +160,8 @@ export function Tags({ onNavigate, isActive, showHints, initialFilter }: { onNav
       return;
     }
     if (input === 't' && visibleTags[cursor]) {
-      onNavigate('transactions', { tag: visibleTags[cursor].name });
+      setFilter({ ...filter, tags: [{ name: visibleTags[cursor].name, mode: 'has' }] });
+      onNavigate('transactions');
       return;
     }
   }, { isActive: isActive !== false });

--- a/tui/Transactions.tsx
+++ b/tui/Transactions.tsx
@@ -51,7 +51,7 @@ function truncate(s: string, n: number) {
 
 export function Transactions({ onNavigate, initialFilter, isActive, showHints }: { onNavigate: (s: Screen, f?: TxFilter) => void; initialFilter?: TxFilter; isActive?: boolean; showHints: boolean }) {
   const refreshKey = useRefreshKey();
-  const { filter: sharedFilter, setFilter } = useFilter();
+  const { filter: sharedFilter, setFilter, popFilter, canPop } = useFilter();
   const [from, setFrom] = useState<string | null>(initialFilter?.from ?? null);
   const [to, setTo] = useState<string | null>(initialFilter?.to ?? null);
   const [txType] = useState<'income' | 'expenses' | null>(initialFilter?.txType ?? null);
@@ -316,7 +316,9 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
       if (key.escape) {
         if (search) { setSearch(''); setSearchInput(''); return; }
         if (from) { setFrom(null); setTo(null); return; }
-        if (isFilterActive(sharedFilter)) { setFilter({}); return; }
+        // Step back one filter level per press rather than clearing all at once;
+        // popFilter clears when the history is exhausted but a filter is active.
+        if (canPop || isFilterActive(sharedFilter)) { popFilter(); return; }
         onNavigate('dashboard', search ? { search } : undefined);
         return;
       }

--- a/tui/Transactions.tsx
+++ b/tui/Transactions.tsx
@@ -345,7 +345,7 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
       if (input === '/') { setMode('search'); return; }
       if (key.upArrow) setCursor((c) => Math.max(0, c - 1));
       if (key.downArrow) setCursor((c) => Math.min(txs.length - 1, c + 1));
-      if (input === 'u') { setSearch(''); setSearchInput(''); setFrom(null); setTo(null); setFilter({ categories: ['Uncategorized'] }); }
+      if (input === 'u') { setSearch(''); setSearchInput(''); setFrom(null); setTo(null); setFilter({ ...sharedFilter, categories: ['Uncategorized'] }); }
       if (input === 'a') { setSearch(''); setSearchInput(''); setFrom(null); setTo(null); setFilter({}); }
       if (key.return && selected) openEdit();
       if (input === 'E' && txs.length > 0) {

--- a/tui/Transactions.tsx
+++ b/tui/Transactions.tsx
@@ -314,6 +314,10 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
       if (input === '3') { onNavigate('trends', search ? { search } : undefined); return; }
       if (handleNavKey(input, 'transactions', onNavigate)) return;
       if (key.escape) {
+        // Arriving via a drill-in is reversed as a unit: pop the filter level
+        // the drill pushed and return to its screen — date range, search and
+        // all — rather than peeling those layers one keypress at a time.
+        if (initialFilter?.drillFrom) { popFilter(); onNavigate(initialFilter.drillFrom); return; }
         if (search) { setSearch(''); setSearchInput(''); return; }
         if (from) { setFrom(null); setTo(null); return; }
         // Step back one filter level per press rather than clearing all at once;

--- a/tui/Transactions.tsx
+++ b/tui/Transactions.tsx
@@ -14,7 +14,7 @@ import {
 import { applyCategoriesToAll } from '../core/categorize.js';
 import { countPatternMatches } from '../core/rule-utils.js';
 import { getTransactions, getAllCategories, getDataBounds, type TxRow, type SortMode } from '../core/queries.js';
-import { mergeFilters } from '../core/filters.js';
+import { isFilterActive, filterSummary } from '../core/filters.js';
 import type { Screen, TxFilter } from './App.js';
 import { useFilter } from './FilterContext.js';
 import { handleNavKey } from './nav.js';
@@ -51,13 +51,9 @@ function truncate(s: string, n: number) {
 
 export function Transactions({ onNavigate, initialFilter, isActive, showHints }: { onNavigate: (s: Screen, f?: TxFilter) => void; initialFilter?: TxFilter; isActive?: boolean; showHints: boolean }) {
   const refreshKey = useRefreshKey();
-  const { filter: sharedFilter } = useFilter();
-  const [category, setCategory] = useState<string | null>(initialFilter?.category ?? null);
+  const { filter: sharedFilter, setFilter } = useFilter();
   const [from, setFrom] = useState<string | null>(initialFilter?.from ?? null);
   const [to, setTo] = useState<string | null>(initialFilter?.to ?? null);
-  const [tag, setTag] = useState<string | null>(initialFilter?.tag ?? null);
-  const [account, setAccount] = useState<string | null>(initialFilter?.account ?? null);
-  const [accountName, setAccountName] = useState<string | null>(initialFilter?.accountName ?? null);
   const [txType] = useState<'income' | 'expenses' | null>(initialFilter?.txType ?? null);
   const [flex] = useState<'fixed' | 'flexible' | 'discretionary' | null>(initialFilter?.flex ?? null);
   const [sort, setSort] = useState<SortMode>('date-desc');
@@ -84,12 +80,7 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
   const [tagInput, setTagInput] = useState('');
 
   function load(s = search, keepCursor = false) {
-    const queryFilter = mergeFilters(sharedFilter, {
-      categories: category ? [category] : undefined,
-      accounts: account ? [account] : undefined,
-      tags: tag ? [{ name: tag, mode: 'has' }] : undefined,
-    });
-    void getTransactions({ filter: queryFilter, from, to, search: s, sort, txType, flex }).then((rows) => {
+    void getTransactions({ filter: sharedFilter, from, to, search: s, sort, txType, flex }).then((rows) => {
       setTxs(rows);
       if (!keepCursor) setCursor(0);
       else setCursor((c) => Math.min(c, Math.max(0, rows.length - 1)));
@@ -97,7 +88,7 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
   }
 
   useEffect(() => { void getDataBounds().then(setBounds); void getAllCategories().then(setCategories); }, []);
-  useEffect(() => { load(); }, [category, from, to, search, tag, account, sort, txType, flex, sharedFilter, refreshKey]);
+  useEffect(() => { load(); }, [from, to, search, sort, txType, flex, sharedFilter, refreshKey]);
 
   const setTyping = useSetTyping();
   useEffect(() => {
@@ -325,8 +316,7 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
       if (key.escape) {
         if (search) { setSearch(''); setSearchInput(''); return; }
         if (from) { setFrom(null); setTo(null); return; }
-        if (tag) { setTag(null); return; }
-        if (account) { setAccount(null); setAccountName(null); return; }
+        if (isFilterActive(sharedFilter)) { setFilter({}); return; }
         onNavigate('dashboard', search ? { search } : undefined);
         return;
       }
@@ -349,8 +339,8 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
       if (input === '/') { setMode('search'); return; }
       if (key.upArrow) setCursor((c) => Math.max(0, c - 1));
       if (key.downArrow) setCursor((c) => Math.min(txs.length - 1, c + 1));
-      if (input === 'u') { setSearch(''); setSearchInput(''); setCategory('Uncategorized'); setFrom(null); setTo(null); setTag(null); setAccount(null); setAccountName(null); }
-      if (input === 'a') { setSearch(''); setSearchInput(''); setCategory(null); setFrom(null); setTo(null); setTag(null); setAccount(null); setAccountName(null); }
+      if (input === 'u') { setSearch(''); setSearchInput(''); setFrom(null); setTo(null); setFilter({ categories: ['Uncategorized'] }); }
+      if (input === 'a') { setSearch(''); setSearchInput(''); setFrom(null); setTo(null); setFilter({}); }
       if (key.return && selected) openEdit();
       if (input === 'E' && txs.length > 0) {
         void getAllCategories().then((cats) => {
@@ -416,10 +406,8 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
 
   const dl = dateLabel();
   const filterLabel = [
-    accountName,
-    tag ? `#${tag}` : null,
+    filterSummary(sharedFilter) || null,
     search ? `"${search}"` : null,
-    category,
     txType ? txType.charAt(0).toUpperCase() + txType.slice(1) : null,
     flex ? flex.charAt(0).toUpperCase() + flex.slice(1) : null,
   ].filter(Boolean).join(' · ');
@@ -456,7 +444,7 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
       </Box>
       <Text dimColor>
         {showHints
-          ? `[/] search  ·  ${from ? '← →  ·  ' : ''}[s] sort  ·  Enter edit  [g] tag  [i] ignore  [x] delete`
+          ? `[/] search  ·  [f] filter  ·  ${from ? '← →  ·  ' : ''}[s] sort  ·  Enter edit  [g] tag  [i] ignore  [x] delete`
           : '[/] search'}
       </Text>
 

--- a/tui/Trends.tsx
+++ b/tui/Trends.tsx
@@ -148,6 +148,8 @@ export function Trends({
           ...(!search && view.mode === 'flex' && view.flex ? { flex: view.flex } : {}),
           from: row.from, to: row.to,
           ...(search ? { search } : {}),
+          // drillFrom only when a filter level was actually pushed
+          ...(!search && view.category ? { drillFrom: 'trends' as const } : {}),
         });
       }
     }

--- a/tui/Trends.tsx
+++ b/tui/Trends.tsx
@@ -34,7 +34,7 @@ export function Trends({
   showHints: boolean;
 }) {
   const refreshKey = useRefreshKey();
-  const { filter: sharedFilter } = useFilter();
+  const { filter: sharedFilter, setFilter } = useFilter();
   const [views, setViews] = useState<View[]>([
     { mode: 'expenses',      category: null, flex: null,            label: 'Expenses'      },
     { mode: 'income',        category: null, flex: null,            label: 'Income'        },
@@ -62,7 +62,7 @@ export function Trends({
   useEffect(() => {
     void buildTrendViews().then((loaded) => {
       setViews(loaded);
-      const cat = initialFilter?.category;
+      const cat = initialFilter?.focusCategory;
       if (cat) {
         const idx = loaded.findIndex((v) => v.category === cat);
         if (idx >= 0) setViewIdx(idx);
@@ -117,9 +117,9 @@ export function Trends({
     if (input === '1') { onNavigate('dashboard', search ? { search } : undefined); return; }
     if (input === '2') {
       const row = activeRows[clampedCursor];
+      if (!search && view.category) setFilter({ ...sharedFilter, categories: [view.category] });
       onNavigate('transactions', {
         ...(row ? { from: row.from, to: row.to } : {}),
-        ...(!search && view.category ? { category: view.category } : {}),
         ...(!search && view.mode === 'income' ? { txType: 'income' as const } : {}),
         ...(!search && view.mode === 'expenses' ? { txType: 'expenses' as const } : {}),
         ...(!search && view.mode === 'flex' && view.flex ? { flex: view.flex } : {}),
@@ -140,14 +140,16 @@ export function Trends({
     }
     if (key.return) {
       const row = activeRows[clampedCursor];
-      if (row) onNavigate('transactions', {
-        ...(!search && view.category ? { category: view.category } : {}),
-        ...(!search && view.mode === 'income' ? { txType: 'income' as const } : {}),
-        ...(!search && view.mode === 'expenses' ? { txType: 'expenses' as const } : {}),
-        ...(!search && view.mode === 'flex' && view.flex ? { flex: view.flex } : {}),
-        from: row.from, to: row.to,
-        ...(search ? { search } : {}),
-      });
+      if (row) {
+        if (!search && view.category) setFilter({ ...sharedFilter, categories: [view.category] });
+        onNavigate('transactions', {
+          ...(!search && view.mode === 'income' ? { txType: 'income' as const } : {}),
+          ...(!search && view.mode === 'expenses' ? { txType: 'expenses' as const } : {}),
+          ...(!search && view.mode === 'flex' && view.flex ? { flex: view.flex } : {}),
+          from: row.from, to: row.to,
+          ...(search ? { search } : {}),
+        });
+      }
     }
   }, { isActive: isActive !== false });
 


### PR DESCRIPTION
Closes #44 .  Stacked on #71.

---

feat: global filter panel and drill-in migration to shared filter
Add the session-global filter panel (f key) over all four dimensions:
categories/accounts/owners as select-from-universe multi-select, tags as
tri-state has/lacks/off. The panel hydrates from and writes the shared
FilterContext via setFilter.

Migrate every drill-in (Dashboard, Tags, Trends, Chat) to write the sticky
shared filter with replace-that-dimension semantics, and shrink TxFilter to
just the transient nav params (dropping category/account/accountName/tag,
adding focusCategory/focusTag for Trends/Tags focus targets). Transactions
now reads its filtering wholly from the shared filter.

- core/queries.ts: getFilterOptions() option-universe loader
- core/filters.ts: pure selectionToDim/selectionFromDim serialization helpers
- tui/FilterPanel.tsx: the panel UI
- tests: serialization, getFilterOptions, and FilterPanel render/apply coverage

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>