### PR TITLE
fix: remove dead Turso embedded-replica code path

### DIFF
--- a/core/db.ts
+++ b/core/db.ts
@@ -8,18 +8,7 @@ const DB_PATH = path.join(DATA_DIR, 'fungible.db');
 
 fs.mkdirSync(DATA_DIR, { recursive: true });
 
-function createDb(): Client {
-  const syncUrl   = process.env.FUNGIBLE_TURSO_URL;
-  const authToken = process.env.FUNGIBLE_TURSO_TOKEN;
-  if (syncUrl && authToken) {
-    // Paid tier: embedded replica syncs with Turso
-    return createClient({ url: `file:${DB_PATH}`, syncUrl, authToken });
-  }
-  // Free tier: local file only
-  return createClient({ url: `file:${DB_PATH}` });
-}
-
-export const db: Client = createDb();
+export const db: Client = createClient({ url: `file:${DB_PATH}` });
 
 export async function initDb() {
   // Create all tables (idempotent)


### PR DESCRIPTION
## Summary
- Removes the `FUNGIBLE_TURSO_URL`/`FUNGIBLE_TURSO_TOKEN` embedded-replica branch from `core/db.ts`; the client is now always plain local-file libsql.
- The Turso sync feature (#28) was closed unmerged, but this hook from the libsql migration (#27) stayed behind. It silently activated via leftover env vars, and libsql embedded replicas are not multi-process safe — running TUI/MCP/GUI concurrently corrupted the local DB (recovered from daily backup on 2026-06-10).
- Local-file mode uses standard SQLite locking, which is safe across processes.

## Test plan
- [x] `tsc --noEmit` clean
- [x] Full vitest suite: 506 tests pass
- [x] TUI net worth screen verified working against real data post-change

🤖 Generated with [Claude Code](https://claude.com/claude-code)