### PR TITLE
fix: renderer sandbox + Plaid callback host (Copilot findings from #74)

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -42,6 +42,9 @@ export default defineConfig({
     plugins: [externalizeDepsPlugin()],
     build: {
       lib: { entry: resolve(import.meta.dirname, 'gui/preload/index.ts') },
+      // CJS so the renderer can run sandboxed — Electron's sandbox can't load
+      // ESM preload scripts.
+      rollupOptions: { output: { format: 'cjs' } },
     },
   },
   renderer: {

--- a/gui/main/app.ts
+++ b/gui/main/app.ts
@@ -86,10 +86,10 @@ function createWindow() {
     title: 'fungible',
     backgroundColor: '#0d1117',
     webPreferences: {
-      preload: join(import.meta.dirname, '../preload/index.mjs'),
+      preload: join(import.meta.dirname, '../preload/index.cjs'),
       contextIsolation: true,
       nodeIntegration: false,
-      sandbox: false, // ESM preload (.mjs) requires an unsandboxed renderer
+      sandbox: true,
     },
   });
 

--- a/gui/main/plaid-link.ts
+++ b/gui/main/plaid-link.ts
@@ -199,7 +199,9 @@ export function runPlaidLink(daysRequested?: number): Promise<{ institutionName:
       server.listen(0, '127.0.0.1', () => {
         const addr = server.address();
         const port = typeof addr === 'object' && addr ? addr.port : 0;
-        void shell.openExternal(`http://localhost:${port}`);
+        // 127.0.0.1, not localhost: the server listens IPv4-only, and on some
+        // systems localhost resolves to ::1 first and the connection fails.
+        void shell.openExternal(`http://127.0.0.1:${port}`);
       });
 
       server.on('error', (err) => {


### PR DESCRIPTION
## Summary
Addresses the two actionable Copilot review comments on #74:

- **Renderer sandbox enabled**: the only reason for `sandbox: false` was the ESM preload, which Electron's sandbox can't load. The preload now builds as CJS (`out/preload/index.cjs`) and `sandbox: true` is on, completing the hardening trio with `contextIsolation` + `nodeIntegration: false`.
- **Plaid callback opens `http://127.0.0.1:<port>`** instead of `localhost`, matching the server's IPv4-only listen address (IPv6-first `localhost` resolution could fail to connect).

Not addressed (intentionally): the `useQuery` rejection comment was stale (already fixed with error state + ErrorBoundary re-throw), and the `api-types.ts` type-only import of `fullRegistry` is hygiene we'll take only if it ever bites.

## Test plan
- [x] typecheck clean; gui:build emits `index.cjs`
- [x] Built app driven via Playwright in demo mode under the sandbox: bridge calls, filter panel, drill-ins all work, zero console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)