### PR TITLE
fix: guard countPatternMatches against stale results in GUI

### DIFF
--- a/gui/renderer/src/hooks/useLoadGuard.ts
+++ b/gui/renderer/src/hooks/useLoadGuard.ts
@@ -1,0 +1,8 @@
+import { useCallback, useRef } from 'react';
+
+export function useLoadGuard() {
+  const seq = useRef(0);
+  const begin = useCallback(() => ++seq.current, []);
+  const isLatest = useCallback((token: number) => token === seq.current, []);
+  return { begin, isLatest } as const;
+}

--- a/gui/renderer/src/screens/Transactions.tsx
+++ b/gui/renderer/src/screens/Transactions.tsx
@@ -10,6 +10,7 @@ import { MONTHS } from '../../../../core/dateUtils.js';
 import type { SortMode, TxRow } from '../../../../core/queries.js';
 import { isFilterActive } from '../../../../core/filters.js';
 import { useFilter } from '../hooks/useFilter.js';
+import { useLoadGuard } from '../hooks/useLoadGuard.js';
 import type { TagOption } from '../../../../core/tags.js';
 import styles from './Transactions.module.css';
 
@@ -442,10 +443,13 @@ function EditModal({
   const [pattern, setPattern] = useState('');
   const [matchType, setMatchType] = useState<'name' | 'regex'>('name');
   const [matchCount, setMatchCount] = useState(0);
+  const matchGuard = useLoadGuard();
 
   useEffect(() => {
     if (pattern.trim()) {
-      void api.rules.countPatternMatches(pattern, matchType).then(setMatchCount);
+      const token = matchGuard.begin();
+      void api.rules.countPatternMatches(pattern, matchType)
+        .then((count) => { if (matchGuard.isLatest(token)) setMatchCount(count); });
     } else {
       setMatchCount(0);
     }


### PR DESCRIPTION
## Summary

- Adds `useLoadGuard` to `gui/renderer/src/hooks/` (same shape as `tui/useLoadGuard.ts` from #76)
- Wires it into the rule-edit modal's `countPatternMatches` effect in `Transactions.tsx` — rapid typing can fire queries faster than they resolve, and the guard drops any result that's been superseded by a newer one

Closes out the GUI follow-up mentioned in the #76 review thread.

## Test plan
- Open the rule-edit modal on a transaction, type quickly in the pattern field — match count should always reflect the latest pattern, never a stale one
- Type a pattern, clear it — count resets to 0 immediately without waiting for an in-flight query

🤖 Generated with [Claude Code](https://claude.com/claude-code)