### PR TITLE
fix: show minus sign for negative amounts in fmt

### DIFF
--- a/core/fmt.ts
+++ b/core/fmt.ts
@@ -3,7 +3,7 @@ export function fmt(n: number, decimals = 2): string {
 }
 
 export function fmtSigned(n: number, decimals = 2): string {
-  return `${n >= 0 ? '+' : '-'}${fmt(n, decimals)}`;
+  return `${n >= 0 ? '+' : '-'}${fmt(Math.abs(n), decimals)}`;
 }
 
 export function fmtPct(n: number, decimals = 1): string {

--- a/core/fmt.ts
+++ b/core/fmt.ts
@@ -1,5 +1,5 @@
 export function fmt(n: number, decimals = 2): string {
-  return `$${Math.abs(n).toLocaleString('en-US', { minimumFractionDigits: decimals, maximumFractionDigits: decimals })}`;
+  return `${n < 0 ? '-' : ''}$${Math.abs(n).toLocaleString('en-US', { minimumFractionDigits: decimals, maximumFractionDigits: decimals })}`;
 }
 
 export function fmtSigned(n: number, decimals = 2): string {

--- a/gui/renderer/src/screens/NetWorth.tsx
+++ b/gui/renderer/src/screens/NetWorth.tsx
@@ -114,7 +114,7 @@ export function NetWorth() {
                   <Tooltip
                     contentStyle={tooltipStyle}
                     labelStyle={tooltipLabelStyle}
-                    formatter={(value, name) => [fmt(Math.abs(Number(value))), String(name)]}
+                    formatter={(value, name) => [fmt(Number(value)), String(name)]}
                   />
                   <Legend />
                   <ReferenceLine y={0} stroke={CHART.axis} />

--- a/tests/fmt.test.ts
+++ b/tests/fmt.test.ts
@@ -7,8 +7,8 @@ describe('fmt', () => {
     expect(fmt(1234.56)).toBe('$1,234.56');
   });
 
-  it('formats negative numbers using absolute value', () => {
-    expect(fmt(-50)).toBe('$50.00');
+  it('formats negative numbers with a minus sign', () => {
+    expect(fmt(-50)).toBe('-$50.00');
   });
 
   it('formats zero', () => {

--- a/tests/gui/networth.test.tsx
+++ b/tests/gui/networth.test.tsx
@@ -39,8 +39,8 @@ describe('GUI NetWorth', () => {
   it('shows a signed big net worth number', async () => {
     renderScreen(<NetWorth />);
     await waitFor(() => expect(screen.getByText('Test Checking')).toBeTruthy());
-    // assets $5,000 minus the visa liability — sign prefix proves fmtSigned path
-    expect(screen.getByText(/^[+-]\$[\d,]+\.\d{2}$/)).toBeTruthy();
+    // sign prefix on the big number span proves fmtSigned path (balance rows are <td>)
+    expect(screen.getByText(/^[+-]\$[\d,]+\.\d{2}$/, { selector: 'span' })).toBeTruthy();
   });
 
   it('group-by-type toggle switches to subtype rollups', async () => {

--- a/tui/Dashboard.tsx
+++ b/tui/Dashboard.tsx
@@ -519,7 +519,7 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
           <Box gap={6} marginY={1}>
             <StatCard label="Income" value={fmt(displaySummary.income)} color={C_POSITIVE} />
             <StatCard label="Expenses" value={fmt(displaySummary.expenses)} color={C_NEGATIVE} />
-            <StatCard label="Net" value={(displaySummary.net >= 0 ? '+' : '-') + fmt(displaySummary.net)} color={displaySummary.net >= 0 ? C_POSITIVE : C_NEGATIVE} />
+            <StatCard label="Net" value={fmtSigned(displaySummary.net)} color={displaySummary.net >= 0 ? C_POSITIVE : C_NEGATIVE} />
             {!search && uncategorized > 0 && (
               <StatCard label="Uncategorized" value={`${uncategorized} txns`} color={C_WARNING} />
             )}

--- a/tui/Health.tsx
+++ b/tui/Health.tsx
@@ -226,7 +226,7 @@ export function Health({ onNavigate, isActive, showHints }: { onNavigate: (s: Sc
           <Box gap={3} marginTop={1}>
             <Text dimColor>{'Net cash'.padEnd(L)}</Text>
             <Text bold color={netCash >= 0 ? C_POSITIVE : C_NEGATIVE}>
-              {fmt(netCash).padStart(V)}
+              {fmtSigned(netCash).padStart(V)}
             </Text>
             <Text dimColor>
               {netCash >= 0
@@ -258,7 +258,7 @@ export function Health({ onNavigate, isActive, showHints }: { onNavigate: (s: Sc
         <Box gap={3} marginTop={1}>
           <Text dimColor>{'Net worth'.padEnd(L)}</Text>
           <Text bold color={data.netWorth >= 0 ? C_POSITIVE : C_NEGATIVE}>
-            {((data.netWorth < 0 ? '-' : '') + fmtCompact(data.netWorth)).padStart(12)}
+            {fmtCompact(data.netWorth).padStart(12)}
           </Text>
         </Box>
         <Box gap={3}>

--- a/tui/Health.tsx
+++ b/tui/Health.tsx
@@ -226,7 +226,7 @@ export function Health({ onNavigate, isActive, showHints }: { onNavigate: (s: Sc
           <Box gap={3} marginTop={1}>
             <Text dimColor>{'Net cash'.padEnd(L)}</Text>
             <Text bold color={netCash >= 0 ? C_POSITIVE : C_NEGATIVE}>
-              {(netCash < 0 ? '-' : '') + fmt(netCash).padStart(V)}
+              {fmt(netCash).padStart(V)}
             </Text>
             <Text dimColor>
               {netCash >= 0

--- a/tui/Tags.tsx
+++ b/tui/Tags.tsx
@@ -3,7 +3,7 @@ import { Box, Text, useInput } from 'ink';
 import { getTagSummary, getAllTags, type MonthlySummary, type Tag } from '../core/queries.js';
 import { createTag, renameTag, deleteTag } from '../core/tags.js';
 import type { Screen, TxFilter } from './App.js';
-import { fmt, bar, truncate, Divider } from './fmt.js';
+import { fmt, fmtSigned, bar, truncate, Divider } from './fmt.js';
 import { handleNavKey } from './nav.js';
 import { useTerminalWidth, C_POSITIVE, C_NEGATIVE, C_WARNING, C_ACCENT } from './ui.js';
 import { StatCard, ModalPanel, SectionHeader, TextInput, SelectableRow, useStatusMessage, PageHeader, SearchBar } from './components/index.js';
@@ -185,7 +185,7 @@ export function Tags({ onNavigate, isActive, showHints, initialFilter }: { onNav
           <Box gap={6} marginY={1}>
             <StatCard label="Income" value={fmt(tagSummary.income)} color={C_POSITIVE} />
             <StatCard label="Expenses" value={fmt(tagSummary.expenses)} color={C_NEGATIVE} />
-            <StatCard label="Net" value={(tagSummary.net >= 0 ? '+' : '-') + fmt(tagSummary.net)} color={tagSummary.net >= 0 ? C_POSITIVE : C_NEGATIVE} />
+            <StatCard label="Net" value={fmtSigned(tagSummary.net)} color={tagSummary.net >= 0 ? C_POSITIVE : C_NEGATIVE} />
             <StatCard label="Transactions" value={String(tag.count)} />
           </Box>
 

--- a/tui/Trends.tsx
+++ b/tui/Trends.tsx
@@ -294,7 +294,7 @@ export function Trends({
                   <SelectableRow key={row.from} selected={isSelected}>
                     <Text color={isSelected ? C_ACCENT : undefined}>{row.label.padEnd(labelWidth)}</Text>
                     <Text color={isSelected ? C_NEUTRAL : undefined} dimColor={!isSelected}>
-                      {fmt(Math.abs(row.total)).padStart(13)}
+                      {fmt(row.total).padStart(13)}
                     </Text>
                     <Text color={searchColor} dimColor={!isSelected}>
                       {bar(Math.abs(row.total), absMax, BAR_WIDTH)}


### PR DESCRIPTION
## Summary
- `fmt()` was calling `Math.abs(n)` unconditionally, stripping the sign from negative values
- Negative amounts displayed as e.g. `$50.00` instead of `-$50.00` on the Trends page (tooltip + summary cards)
- Added a `n < 0 ? '-' : ''` prefix before the `$` sign

## Test plan
- [ ] Open Trends page and check a view with expense/negative totals — amounts should now show `-$X.XX`
- [ ] Verify `fmtSigned` still works correctly (e.g. `-$X.XX` for negative, `+$X.XX` for positive)
- [ ] Verify `fmtCompact` Y-axis labels are unaffected (has its own sign handling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)