### PR TITLE
chore: remove stale Turso refs from GUI main

### DIFF
--- a/gui/main/app.ts
+++ b/gui/main/app.ts
@@ -39,10 +39,7 @@ if (!app.requestSingleInstanceLock()) {
       rebuildDisplayNames().catch((err) => console.error('[gui] display-name rebuild failed:', err));
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      const hint = /hrana|stream/i.test(msg)
-        ? '\n\nThis usually means another fungible process (TUI or MCP server) is syncing the same Turso replica. Close it and relaunch, or run against a local data dir (npm run gui:demo).'
-        : '';
-      dialog.showErrorBox('fungible — database error', msg + hint);
+      dialog.showErrorBox('fungible — database error', msg);
       app.quit();
       return;
     }

--- a/gui/main/index.ts
+++ b/gui/main/index.ts
@@ -12,7 +12,6 @@ if (process.env.FUNGIBLE_DEMO) {
 
 const { DATA_DIR } = await import('../../core/paths.js');
 
-// Env must load before core/db.ts evaluates (it reads Turso vars at import time).
 config({ path: join(DATA_DIR, '.env'), quiet: true });
 
 await import('./app.js');


### PR DESCRIPTION
## Summary
- Drop obsolete \`// Env must load before core/db.ts evaluates (it reads Turso vars at import time)\` comment in \`gui/main/index.ts\` — \`core/db.ts\` no longer reads any env at import time.
- Drop the \`/hrana|stream/\` Turso-replica hint from the DB-error dialog in \`gui/main/app.ts\` — there is no replica anymore, so the message is misleading.

## Test plan
- [ ] \`npm run gui:dev\` still boots
- [ ] Trigger a DB error (e.g. point \`FUNGIBLE_DATA_DIR\` at a non-writable path) and confirm the dialog shows just the underlying error

🤖 Generated with [Claude Code](https://claude.com/claude-code)