### PR TITLE
fix: preserve dashboard month when Esc reverses a drill-in

### DIFF
--- a/gui/renderer/src/screens/Dashboard.tsx
+++ b/gui/renderer/src/screens/Dashboard.tsx
@@ -94,7 +94,7 @@ export function Dashboard() {
       ...(selectedAccount ? { accounts: [selectedAccount.id] } : {}),
       ...dims,
     });
-    navigate('transactions', { from, to, drillFrom: 'dashboard', ...nav });
+    navigate('transactions', { from, to, range, anchor: from, drillFrom: 'dashboard', ...nav });
   }
 
   const bounds = useQuery(() => api.queries.getDataBounds(), []);
@@ -494,7 +494,7 @@ export function Dashboard() {
                                 // drillFrom only when a filter level was actually
                                 // pushed, so Esc's pop doesn't eat an unrelated level.
                                 if (selectedAccount) drillToTransactions({}, { flex: flexKey });
-                                else navigate('transactions', { from, to, flex: flexKey });
+                                else navigate('transactions', { from, to, range, anchor: from, flex: flexKey });
                               }
                             : undefined
                         }

--- a/gui/renderer/src/screens/Transactions.tsx
+++ b/gui/renderer/src/screens/Transactions.tsx
@@ -127,7 +127,7 @@ export function Transactions() {
       // the drill pushed and return to its screen (same semantics as the TUI).
       if (txFilter.drillFrom) {
         popFilter();
-        navigate(txFilter.drillFrom);
+        navigate(txFilter.drillFrom, { range: txFilter.range, anchor: from ?? txFilter.anchor });
         return;
       }
       if (search) setSearch('');
@@ -135,7 +135,7 @@ export function Transactions() {
         setFrom(null);
         setTo(null);
       } else if (canPop || isFilterActive(sharedFilter)) popFilter();
-      else navigate('dashboard');
+      else navigate('dashboard', { range: txFilter.range, anchor: from ?? txFilter.anchor });
     },
   });
 

--- a/tests/gui/transactions.test.tsx
+++ b/tests/gui/transactions.test.tsx
@@ -53,6 +53,25 @@ describe('GUI Transactions', () => {
     localStorage.removeItem('fungible-keys');
   });
 
+  it('Escape reversing a drill-in returns to the dashboard on the same month', async () => {
+    localStorage.setItem('fungible-keys', 'on');
+    const navigate = vi.fn();
+    // Arrived here by drilling Grocery from the dashboard while viewing May 2026.
+    renderScreen(<Transactions />, {
+      txFilter: { from: '2026-05-01', to: '2026-05-31', range: 'month', anchor: '2026-05-15', drillFrom: 'dashboard' },
+      initialFilter: { categories: ['Grocery'] },
+      navigate,
+    });
+    await waitFor(() => expect(screen.getByText(/\d+ transactions/)).toBeTruthy());
+    await userEvent.keyboard('{Escape}');
+    // The month travels back via range + anchor (period start), so the dashboard
+    // reopens on May 2026 instead of snapping to the most recent month.
+    await waitFor(() =>
+      expect(navigate).toHaveBeenCalledWith('dashboard', { range: 'month', anchor: '2026-05-01' }),
+    );
+    localStorage.removeItem('fungible-keys');
+  });
+
   it('search filters rows live', async () => {
     renderScreen(<Transactions />);
     await waitFor(() => expect(screen.getByText('9 transactions')).toBeTruthy());

--- a/tests/tui/screens.test.tsx
+++ b/tests/tui/screens.test.tsx
@@ -448,10 +448,60 @@ describe('Transactions', () => {
       expect(f).toMatch(/May 2026/);
     });
     r.stdin.write('\x1b');
-    await waitFor(() => expect(onNavigate).toHaveBeenCalledWith('dashboard'));
+    // Returns to the dashboard carrying the month we drilled from (anchor =
+    // the screen's current period start) so it doesn't snap to the latest month.
+    await waitFor(() => expect(onNavigate).toHaveBeenCalledWith('dashboard', expect.objectContaining({ anchor: '2026-05-01' })));
     // The drill's filter level was popped, not merely navigated away from
     await waitFor(() => expect(frame(r)).not.toContain('1 category'));
     expect(onNavigate).toHaveBeenCalledTimes(1);
+  });
+
+  it('Escape preserves the dashboard month (range + anchor) when reversing a drill-in', async () => {
+    const onNavigate = vi.fn();
+    // Simulates a drill from the dashboard while viewing May 2026 in month range.
+    const r = render(
+      <W>
+        <FilterProvider>
+          <PushFilters filters={[{ categories: ['Grocery'] }]} />
+          <Transactions
+            onNavigate={onNavigate}
+            showHints={false}
+            initialFilter={{ ...MAY_DATE_FILTER, range: 'month', anchor: '2026-05-15', drillFrom: 'dashboard' }}
+          />
+        </FilterProvider>
+      </W>,
+    );
+    await waitFor(() => expect(frame(r)).toMatch(/May 2026/));
+    r.stdin.write('\x1b');
+    // The month travels back via range + anchor; anchor is the period start the
+    // dashboard will land on (snapped to May 1), not the most recent month.
+    await waitFor(() =>
+      expect(onNavigate).toHaveBeenCalledWith('dashboard', { range: 'month', anchor: '2026-05-01' }),
+    );
+  });
+
+  it('Escape after stepping a month forward returns the dashboard to that month', async () => {
+    const onNavigate = vi.fn();
+    const r = render(
+      <W>
+        <FilterProvider>
+          <PushFilters filters={[{ categories: ['Grocery'] }]} />
+          <Transactions
+            onNavigate={onNavigate}
+            showHints={false}
+            initialFilter={{ from: '2026-04-01', to: '2026-04-30', range: 'month', anchor: '2026-04-15', drillFrom: 'dashboard' }}
+          />
+        </FilterProvider>
+      </W>,
+    );
+    await waitFor(() => expect(frame(r)).toMatch(/Apr 2026/));
+    r.stdin.write('\x1B[C'); // → step to May within Transactions
+    await waitFor(() => expect(frame(r)).toMatch(/May 2026/));
+    r.stdin.write('\x1b');
+    // "The month you were looking at" is the one on screen at Esc — May, not April.
+    await waitFor(() =>
+      expect(onNavigate).toHaveBeenCalledWith('dashboard', expect.objectContaining({ anchor: '2026-05-01' })),
+    );
   });
 
   it('shows a filter-summary label when the shared filter is active', async () => {

--- a/tui/Dashboard.tsx
+++ b/tui/Dashboard.tsx
@@ -227,6 +227,8 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
           onNavigate('transactions', {
             from: merchantDrill.from,
             to: merchantDrill.to,
+            range,
+            anchor: merchantDrill.from,
             search: row.merchant,
             drillFrom: 'dashboard',
           });
@@ -298,7 +300,7 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
           // Drill-in writes the sticky shared filter (replace those dimensions),
           // keeping the date range / search as transient nav params.
           setFilter({ ...sharedFilter, categories: [cat.category], ...(selectedAccount ? { accounts: [selectedAccount.id] } : {}) });
-          onNavigate('transactions', { from, to, ...(search ? { search } : {}), drillFrom: 'dashboard' });
+          onNavigate('transactions', { from, to, range, anchor: from, ...(search ? { search } : {}), drillFrom: 'dashboard' });
         }
         return;
       }
@@ -310,7 +312,7 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
         // drillFrom only when a filter level was actually pushed, so Esc's
         // pop doesn't eat an unrelated level.
         if (selectedAccount) setFilter({ ...sharedFilter, accounts: [selectedAccount.id] });
-        onNavigate('transactions', { from, to, ...(selectedAccount ? { drillFrom: 'dashboard' as const } : {}) });
+        onNavigate('transactions', { from, to, range, anchor: from, ...(selectedAccount ? { drillFrom: 'dashboard' as const } : {}) });
         return;
       }
     }
@@ -323,7 +325,7 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
         if (acct) {
           const { from, to } = getPeriodDates(range, anchor);
           setFilter({ ...sharedFilter, accounts: [acct.id] });
-          onNavigate('transactions', { from, to, drillFrom: 'dashboard' });
+          onNavigate('transactions', { from, to, range, anchor: from, drillFrom: 'dashboard' });
         }
         return;
       }
@@ -367,6 +369,7 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
       if (selectedAccount) setFilter({ ...sharedFilter, accounts: [selectedAccount.id] });
       onNavigate('transactions', {
         from, to,
+        range, anchor: from,
         ...(search ? { search } : {}),
       });
       return;

--- a/tui/Transactions.tsx
+++ b/tui/Transactions.tsx
@@ -317,13 +317,17 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
         // Arriving via a drill-in is reversed as a unit: pop the filter level
         // the drill pushed and return to its screen — date range, search and
         // all — rather than peeling those layers one keypress at a time.
-        if (initialFilter?.drillFrom) { popFilter(); onNavigate(initialFilter.drillFrom); return; }
+        if (initialFilter?.drillFrom) { popFilter(); onNavigate(initialFilter.drillFrom, { range: initialFilter.range, anchor: from ?? initialFilter.anchor }); return; }
         if (search) { setSearch(''); setSearchInput(''); return; }
         if (from) { setFrom(null); setTo(null); return; }
         // Step back one filter level per press rather than clearing all at once;
         // popFilter clears when the history is exhausted but a filter is active.
         if (canPop || isFilterActive(sharedFilter)) { popFilter(); return; }
-        onNavigate('dashboard', search ? { search } : undefined);
+        // Carry the period back so the dashboard reopens on the month we came
+        // from rather than re-defaulting to the latest one; omit when there's
+        // nothing to restore so a fresh entry still returns a bare navigate.
+        const back: TxFilter = { ...(initialFilter?.range ? { range: initialFilter.range } : {}), ...(initialFilter?.anchor ? { anchor: initialFilter.anchor } : {}) };
+        onNavigate('dashboard', Object.keys(back).length ? back : undefined);
         return;
       }
       if (key.leftArrow && from) {


### PR DESCRIPTION
Drilling from the dashboard into transactions and pressing Esc returned to the dashboard's default (most recent) month instead of the month being viewed. The period (range + anchor) is local Dashboard state re-initialized from the nav payload on mount, but the drill-in never round-tripped it.

Carry range + anchor through the drill (the period-start `from` doubles as the anchor) and hand them back on Esc, using the screen's current `from` so month navigation done within Transactions is honored. 

Fixes both the GUI and the TUI, which share this navigation model.