### PR TITLE
feat: account-scoped category & name rules (#20)

### DIFF
--- a/core/accounts.ts
+++ b/core/accounts.ts
@@ -48,6 +48,8 @@ export async function deleteAccount(id: string): Promise<void> {
     { sql: 'DELETE FROM transaction_tags WHERE transaction_id IN (SELECT id FROM transactions WHERE account_id = ?)', args: [id] },
     { sql: 'DELETE FROM transactions WHERE account_id = ?', args: [id] },
     { sql: 'DELETE FROM balance_history WHERE account_id = ?', args: [id] },
+    { sql: 'DELETE FROM category_rules WHERE account_id = ?', args: [id] },
+    { sql: 'DELETE FROM name_rules WHERE account_id = ?', args: [id] },
     { sql: 'DELETE FROM accounts WHERE id = ?', args: [id] },
   ], 'write');
 }
@@ -85,7 +87,7 @@ export async function importCsvTransactions(
     }
     if (!rawDate || !name || isNaN(amount)) { skipped++; continue; }
     const date = parseDate(rawDate);
-    const category = categorizeWithRules(rules, name, null, null);
+    const category = categorizeWithRules(rules, name, null, null, amount, account.id);
     const id = generateTxId(account.mask ?? account.id, date, name, amount);
     const result = await db.execute({
       sql: 'INSERT OR IGNORE INTO transactions (id, account_id, date, name, amount, category, raw_category, pending) VALUES (?, ?, ?, ?, ?, ?, NULL, 0)',

--- a/core/categorize.ts
+++ b/core/categorize.ts
@@ -7,6 +7,7 @@ type Rule = {
   category: string;
   min_amount: number | null;
   max_amount: number | null;
+  account_id: string | null;
 };
 
 // Plaid's personal_finance_category → our simplified categories
@@ -50,11 +51,13 @@ export function categorizeWithRules(
   merchant: string | null,
   plaidCategory: string | null,
   amount?: number,
+  accountId?: string | null,
 ): string {
   const haystacks = [name.toLowerCase()];
   if (merchant && merchant.toLowerCase() !== name.toLowerCase()) haystacks.push(merchant.toLowerCase());
 
   for (const rule of rules) {
+    if (rule.account_id !== null && rule.account_id !== accountId) continue;
     if (!inAmountRange(amount, rule.min_amount, rule.max_amount)) continue;
     if (matchesPattern(rule.pattern, rule.match_type, haystacks)) return rule.category;
   }
@@ -69,7 +72,7 @@ export function categorizeWithRules(
 /** Load category rules from DB. */
 export async function loadCategoryRules(): Promise<Rule[]> {
   const result = await db.execute(
-    'SELECT match_type, pattern, category, min_amount, max_amount FROM category_rules ORDER BY priority DESC'
+    'SELECT match_type, pattern, category, min_amount, max_amount, account_id FROM category_rules ORDER BY priority DESC, (account_id IS NULL) ASC, id ASC'
   );
   return result.rows as unknown as Rule[];
 }
@@ -80,9 +83,10 @@ export async function categorize(
   merchant: string | null,
   plaidCategory: string | null,
   amount?: number,
+  accountId?: string | null,
 ): Promise<string> {
   const rules = await loadCategoryRules();
-  return categorizeWithRules(rules, name, merchant, plaidCategory, amount);
+  return categorizeWithRules(rules, name, merchant, plaidCategory, amount, accountId);
 }
 
 /** Re-categorize all transactions without a manual override. Returns count updated. */
@@ -90,16 +94,16 @@ export async function applyCategoriesToAll(): Promise<number> {
   const rules = await loadCategoryRules();
 
   const txRes = await db.execute(
-    'SELECT id, name, merchant_name, raw_category, amount, category FROM transactions WHERE manual_category IS NULL'
+    'SELECT id, account_id, name, merchant_name, raw_category, amount, category FROM transactions WHERE manual_category IS NULL'
   );
   const rows = txRes.rows as unknown as {
-    id: string; name: string; merchant_name: string | null;
+    id: string; account_id: string; name: string; merchant_name: string | null;
     raw_category: string | null; amount: number; category: string;
   }[];
 
   const updates: { sql: string; args: (string | number | null)[] }[] = [];
   for (const tx of rows) {
-    const cat = categorizeWithRules(rules, tx.name, tx.merchant_name, tx.raw_category, tx.amount);
+    const cat = categorizeWithRules(rules, tx.name, tx.merchant_name, tx.raw_category, tx.amount, tx.account_id);
     if (cat !== 'Uncategorized' && cat !== tx.category) {
       updates.push({ sql: 'UPDATE transactions SET category = ? WHERE id = ?', args: [cat, tx.id] });
     }

--- a/core/db.ts
+++ b/core/db.ts
@@ -109,6 +109,8 @@ export async function initDb() {
     'ALTER TABLE accounts ADD COLUMN nickname TEXT',
     'ALTER TABLE accounts ADD COLUMN owner TEXT',
     'ALTER TABLE accounts ADD COLUMN apr REAL',
+    'ALTER TABLE category_rules ADD COLUMN account_id TEXT',
+    'ALTER TABLE name_rules ADD COLUMN account_id TEXT',
   ];
   for (const sql of migrations) {
     try {

--- a/core/queries.ts
+++ b/core/queries.ts
@@ -353,17 +353,17 @@ export async function getSearchFilteredData(
   return { summary: { income, expenses, net: income - expenses, byCategory }, flexData };
 }
 
-export type Rule = { id: number; priority: number; match_type: string; pattern: string; category: string; min_amount: number | null; max_amount: number | null };
-export type NameRule = { id: number; match_type: string; pattern: string; replacement: string; min_amount: number | null; max_amount: number | null };
+export type Rule = { id: number; priority: number; match_type: string; pattern: string; category: string; min_amount: number | null; max_amount: number | null; account_id: string | null };
+export type NameRule = { id: number; match_type: string; pattern: string; replacement: string; min_amount: number | null; max_amount: number | null; account_id: string | null };
 export type CategoryDetail = { name: string; flexibility: 'fixed' | 'flexible' | 'discretionary' | null };
 
 export async function getAllRules(): Promise<Rule[]> {
-  const result = await db.execute('SELECT id, priority, match_type, pattern, category, min_amount, max_amount FROM category_rules ORDER BY priority DESC, id ASC');
+  const result = await db.execute('SELECT id, priority, match_type, pattern, category, min_amount, max_amount, account_id FROM category_rules ORDER BY priority DESC, (account_id IS NULL) ASC, id ASC');
   return result.rows as unknown as Rule[];
 }
 
 export async function getAllNameRules(): Promise<NameRule[]> {
-  const result = await db.execute('SELECT id, match_type, pattern, replacement, min_amount, max_amount FROM name_rules ORDER BY id ASC');
+  const result = await db.execute('SELECT id, match_type, pattern, replacement, min_amount, max_amount, account_id FROM name_rules ORDER BY (account_id IS NULL) ASC, id ASC');
   return result.rows as unknown as NameRule[];
 }
 

--- a/core/rename.ts
+++ b/core/rename.ts
@@ -7,18 +7,20 @@ type NameRule = {
   replacement: string;
   min_amount: number | null;
   max_amount: number | null;
+  account_id: string | null;
 };
 
 export async function loadNameRules(): Promise<NameRule[]> {
   const result = await db.execute(
-    'SELECT match_type, pattern, replacement, min_amount, max_amount FROM name_rules ORDER BY id ASC'
+    'SELECT match_type, pattern, replacement, min_amount, max_amount, account_id FROM name_rules ORDER BY (account_id IS NULL) ASC, id ASC'
   );
   return result.rows as unknown as NameRule[];
 }
 
 /** Pure sync name application using pre-loaded rules. */
-export function applyNameRulesWithRules(rules: NameRule[], name: string, amount?: number): string {
+export function applyNameRulesWithRules(rules: NameRule[], name: string, amount?: number, accountId?: string | null): string {
   for (const rule of rules) {
+    if (rule.account_id !== null && rule.account_id !== accountId) continue;
     if (!inAmountRange(amount, rule.min_amount, rule.max_amount)) continue;
     if (matchesPattern(rule.pattern, rule.match_type, [name.toLowerCase()])) return rule.replacement;
   }
@@ -26,23 +28,23 @@ export function applyNameRulesWithRules(rules: NameRule[], name: string, amount?
 }
 
 /** Returns the display name for a transaction (loads rules from DB). */
-export async function applyNameRules(name: string, amount?: number): Promise<string> {
+export async function applyNameRules(name: string, amount?: number, accountId?: string | null): Promise<string> {
   const rules = await loadNameRules();
-  return applyNameRulesWithRules(rules, name, amount);
+  return applyNameRulesWithRules(rules, name, amount, accountId);
 }
 
 /** Re-apply all name rules to every transaction and update display_name. */
 export async function rebuildDisplayNames(): Promise<number> {
   const rules = await loadNameRules();
 
-  const txRes = await db.execute('SELECT id, name, amount, display_name FROM transactions');
+  const txRes = await db.execute('SELECT id, account_id, name, amount, display_name FROM transactions');
   const rows = txRes.rows as unknown as {
-    id: string; name: string; amount: number; display_name: string | null;
+    id: string; account_id: string; name: string; amount: number; display_name: string | null;
   }[];
 
   const updates: { sql: string; args: (string | number | null)[] }[] = [];
   for (const tx of rows) {
-    const display = applyNameRulesWithRules(rules, tx.name, tx.amount);
+    const display = applyNameRulesWithRules(rules, tx.name, tx.amount, tx.account_id);
     const newVal = display !== tx.name ? display : null;
     if (newVal !== tx.display_name) {
       updates.push({ sql: 'UPDATE transactions SET display_name = ? WHERE id = ?', args: [newVal, tx.id] });

--- a/core/rules.ts
+++ b/core/rules.ts
@@ -5,16 +5,16 @@ import { rebuildDisplayNames } from './rename.js';
 async function applyAll(): Promise<number> {
   const rules = await loadCategoryRules();
   const txRes = await db.execute(
-    'SELECT id, name, merchant_name, raw_category, amount, category FROM transactions WHERE manual_category IS NULL'
+    'SELECT id, account_id, name, merchant_name, raw_category, amount, category FROM transactions WHERE manual_category IS NULL'
   );
   const rows = txRes.rows as unknown as {
-    id: string; name: string; merchant_name: string | null;
+    id: string; account_id: string; name: string; merchant_name: string | null;
     raw_category: string | null; amount: number; category: string;
   }[];
 
   const updates: { sql: string; args: (string | number | null)[] }[] = [];
   for (const tx of rows) {
-    const cat = categorizeWithRules(rules, tx.name, tx.merchant_name, tx.raw_category, tx.amount);
+    const cat = categorizeWithRules(rules, tx.name, tx.merchant_name, tx.raw_category, tx.amount, tx.account_id);
     if (cat !== tx.category) {
       updates.push({ sql: 'UPDATE transactions SET category = ? WHERE id = ?', args: [cat, tx.id] });
     }
@@ -43,20 +43,21 @@ export type SaveCategoryRuleOpts = {
   category: string;
   minAmount: number | null;
   maxAmount: number | null;
+  accountId?: string | null;
   editingId?: number | null;
 };
 
 export async function saveCategoryRule(opts: SaveCategoryRuleOpts): Promise<number> {
-  const { pattern, matchType, category, minAmount, maxAmount, editingId } = opts;
+  const { pattern, matchType, category, minAmount, maxAmount, accountId = null, editingId } = opts;
   if (editingId != null) {
     await db.execute({
-      sql: 'UPDATE category_rules SET match_type = ?, pattern = ?, category = ?, min_amount = ?, max_amount = ? WHERE id = ?',
-      args: [matchType, pattern, category, minAmount, maxAmount, editingId],
+      sql: 'UPDATE category_rules SET match_type = ?, pattern = ?, category = ?, min_amount = ?, max_amount = ?, account_id = ? WHERE id = ?',
+      args: [matchType, pattern, category, minAmount, maxAmount, accountId, editingId],
     });
   } else {
     const existing = await db.execute({
-      sql: 'SELECT id FROM category_rules WHERE match_type = ? AND pattern = ?',
-      args: [matchType, pattern],
+      sql: 'SELECT id FROM category_rules WHERE match_type = ? AND pattern = ? AND account_id IS ?',
+      args: [matchType, pattern, accountId],
     });
     if (existing.rows.length > 0) {
       const id = (existing.rows[0] as unknown as { id: number }).id;
@@ -66,8 +67,8 @@ export async function saveCategoryRule(opts: SaveCategoryRuleOpts): Promise<numb
       });
     } else {
       await db.execute({
-        sql: 'INSERT INTO category_rules (priority, match_type, pattern, category, min_amount, max_amount) VALUES (10, ?, ?, ?, ?, ?)',
-        args: [matchType, pattern, category, minAmount, maxAmount],
+        sql: 'INSERT INTO category_rules (priority, match_type, pattern, category, min_amount, max_amount, account_id) VALUES (10, ?, ?, ?, ?, ?, ?)',
+        args: [matchType, pattern, category, minAmount, maxAmount, accountId],
       });
     }
   }
@@ -80,20 +81,21 @@ export type SaveNameRuleOpts = {
   replacement: string;
   minAmount: number | null;
   maxAmount: number | null;
+  accountId?: string | null;
   editingId?: number | null;
 };
 
 export async function saveNameRule(opts: SaveNameRuleOpts): Promise<void> {
-  const { pattern, matchType, replacement, minAmount, maxAmount, editingId } = opts;
+  const { pattern, matchType, replacement, minAmount, maxAmount, accountId = null, editingId } = opts;
   if (editingId != null) {
     await db.execute({
-      sql: 'UPDATE name_rules SET match_type = ?, pattern = ?, replacement = ?, min_amount = ?, max_amount = ? WHERE id = ?',
-      args: [matchType, pattern, replacement, minAmount, maxAmount, editingId],
+      sql: 'UPDATE name_rules SET match_type = ?, pattern = ?, replacement = ?, min_amount = ?, max_amount = ?, account_id = ? WHERE id = ?',
+      args: [matchType, pattern, replacement, minAmount, maxAmount, accountId, editingId],
     });
   } else {
     await db.execute({
-      sql: 'INSERT INTO name_rules (match_type, pattern, replacement, min_amount, max_amount) VALUES (?, ?, ?, ?, ?)',
-      args: [matchType, pattern, replacement, minAmount, maxAmount],
+      sql: 'INSERT INTO name_rules (match_type, pattern, replacement, min_amount, max_amount, account_id) VALUES (?, ?, ?, ?, ?, ?)',
+      args: [matchType, pattern, replacement, minAmount, maxAmount, accountId],
     });
   }
   await rebuildDisplayNames();

--- a/core/seed-rules.ts
+++ b/core/seed-rules.ts
@@ -71,17 +71,17 @@ export async function seedRules(): Promise<{ rules: number; recategorized: numbe
   );
 
   const uncategorizedResult = await db.execute({
-    sql: 'SELECT id, name, merchant_name, raw_category, amount FROM transactions WHERE category = ? AND manual_category IS NULL',
+    sql: 'SELECT id, account_id, name, merchant_name, raw_category, amount FROM transactions WHERE category = ? AND manual_category IS NULL',
     args: ['Uncategorized'],
   });
   const uncategorized = uncategorizedResult.rows as unknown as {
-    id: string; name: string; merchant_name: string | null; raw_category: string | null; amount: number;
+    id: string; account_id: string; name: string; merchant_name: string | null; raw_category: string | null; amount: number;
   }[];
 
   let recategorized = 0;
   const updates: { sql: string; args: (string | number | null)[] }[] = [];
   for (const tx of uncategorized) {
-    const cat = await categorize(tx.name, tx.merchant_name, tx.raw_category, tx.amount);
+    const cat = await categorize(tx.name, tx.merchant_name, tx.raw_category, tx.amount, tx.account_id);
     if (cat !== 'Uncategorized') {
       updates.push({ sql: 'UPDATE transactions SET category = ? WHERE id = ?', args: [cat, tx.id] });
       recategorized++;

--- a/core/sync.ts
+++ b/core/sync.ts
@@ -64,8 +64,8 @@ export async function syncTransactions(accessToken: string, itemId: string) {
     await db.batch(
       [...added, ...modified].map((tx) => {
         const rawCategory = tx.personal_finance_category?.primary ?? null;
-        const category = categorizeWithRules(catRules, tx.name, tx.merchant_name ?? null, rawCategory, tx.amount);
-        const displayName = applyNameRulesWithRules(nameRules, tx.name, tx.amount);
+        const category = categorizeWithRules(catRules, tx.name, tx.merchant_name ?? null, rawCategory, tx.amount, tx.account_id);
+        const displayName = applyNameRulesWithRules(nameRules, tx.name, tx.amount, tx.account_id);
         return {
           sql: `INSERT INTO transactions (id, account_id, date, name, merchant_name, amount, category, raw_category, pending, display_name)
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)

--- a/core/tools.ts
+++ b/core/tools.ts
@@ -266,6 +266,7 @@ export const TOOL_DEFS: ToolDef[] = [
         priority:   { type: 'integer', description: 'Higher priority runs first (default 10)' },
         min_amount: { type: 'number', description: 'Minimum transaction amount (optional)' },
         max_amount: { type: 'number', description: 'Maximum transaction amount (optional)' },
+        account_id: { type: 'string', description: 'Optional account ID to scope the rule to a single account; omit for a global rule. Use list_accounts for IDs.' },
       },
       required: ['pattern', 'match_type', 'category'],
     },
@@ -292,6 +293,7 @@ export const TOOL_DEFS: ToolDef[] = [
         replacement: { type: 'string', description: 'Display name to show instead' },
         min_amount:  { type: 'number', description: 'Minimum transaction amount (optional)' },
         max_amount:  { type: 'number', description: 'Maximum transaction amount (optional)' },
+        account_id:  { type: 'string', description: 'Optional account ID to scope the rule to a single account; omit for a global rule. Use list_accounts for IDs.' },
       },
       required: ['pattern', 'match_type', 'replacement'],
     },
@@ -422,6 +424,7 @@ async function executeToolImpl(
   const num  = (k: string, def = 0)  => Number(input[k] ?? def);
   const bool = (k: string)            => Boolean(input[k]);
   const opt  = (k: string)            => input[k] !== undefined ? Number(input[k]) : null;
+  const optStr = (k: string)          => input[k] !== undefined && input[k] !== null ? String(input[k]) : null;
 
   switch (name) {
 
@@ -614,11 +617,15 @@ async function executeToolImpl(
 
     case 'list_rules': {
       const result = await db.execute(
-        'SELECT id, priority, match_type, pattern, category, min_amount, max_amount FROM category_rules ORDER BY priority DESC, id ASC'
+        `SELECT cr.id, cr.priority, cr.match_type, cr.pattern, cr.category, cr.min_amount, cr.max_amount,
+                cr.account_id, COALESCE(a.nickname, a.name) AS account_name
+         FROM category_rules cr LEFT JOIN accounts a ON a.id = cr.account_id
+         ORDER BY cr.priority DESC, (cr.account_id IS NULL) ASC, cr.id ASC`
       );
       const rules = result.rows as unknown as {
         id: number; priority: number; match_type: string; pattern: string;
         category: string; min_amount: number | null; max_amount: number | null;
+        account_id: string | null; account_name: string | null;
       }[];
       if (!rules.length) return 'No rules defined.';
       return rules.map((r) => {
@@ -626,22 +633,28 @@ async function executeToolImpl(
           ? ` [$${r.min_amount}–$${r.max_amount}]`
           : r.min_amount != null ? ` [≥$${r.min_amount}]`
           : r.max_amount != null ? ` [≤$${r.max_amount}]` : '';
-        return `[${r.id}] pri=${r.priority} ${r.match_type.padEnd(5)} "${r.pattern}"${amt} → ${r.category}`;
+        const scope = r.account_id ? ` @${r.account_name ?? r.account_id}` : '';
+        return `[${r.id}] pri=${r.priority} ${r.match_type.padEnd(5)} "${r.pattern}"${amt} → ${r.category}${scope}`;
       }).join('\n');
     }
 
     case 'list_name_rules': {
       const result = await db.execute(
-        'SELECT id, match_type, pattern, replacement, min_amount, max_amount FROM name_rules ORDER BY id ASC'
+        `SELECT nr.id, nr.match_type, nr.pattern, nr.replacement, nr.min_amount, nr.max_amount,
+                nr.account_id, COALESCE(a.nickname, a.name) AS account_name
+         FROM name_rules nr LEFT JOIN accounts a ON a.id = nr.account_id
+         ORDER BY (nr.account_id IS NULL) ASC, nr.id ASC`
       );
       const rules = result.rows as unknown as {
         id: number; match_type: string; pattern: string;
         replacement: string; min_amount: number | null; max_amount: number | null;
+        account_id: string | null; account_name: string | null;
       }[];
       if (!rules.length) return 'No name rules defined.';
       return rules.map((r) => {
         const amt = r.min_amount != null ? ` [≥$${r.min_amount}]` : r.max_amount != null ? ` [≤$${r.max_amount}]` : '';
-        return `[${r.id}] ${r.match_type.padEnd(5)} "${r.pattern}"${amt} → "${r.replacement}"`;
+        const scope = r.account_id ? ` @${r.account_name ?? r.account_id}` : '';
+        return `[${r.id}] ${r.match_type.padEnd(5)} "${r.pattern}"${amt} → "${r.replacement}"${scope}`;
       }).join('\n');
     }
 
@@ -771,8 +784,8 @@ async function executeToolImpl(
     case 'add_rule': {
       if (str('match_type') === 'regex') validateRegex(str('pattern'));
       await db.execute({
-        sql: 'INSERT INTO category_rules (priority, match_type, pattern, category, min_amount, max_amount) VALUES (?, ?, ?, ?, ?, ?)',
-        args: [input['priority'] ? num('priority') : 10, str('match_type'), str('pattern'), str('category'), opt('min_amount'), opt('max_amount')],
+        sql: 'INSERT INTO category_rules (priority, match_type, pattern, category, min_amount, max_amount, account_id) VALUES (?, ?, ?, ?, ?, ?, ?)',
+        args: [input['priority'] ? num('priority') : 10, str('match_type'), str('pattern'), str('category'), opt('min_amount'), opt('max_amount'), optStr('account_id')],
       });
       const count = await applyCategoriesToAll();
       return `Rule added: "${str('pattern')}" → ${str('category')}\nRecategorized ${count} transactions.`;
@@ -789,8 +802,8 @@ async function executeToolImpl(
     case 'add_name_rule': {
       if (str('match_type') === 'regex') validateRegex(str('pattern'));
       await db.execute({
-        sql: 'INSERT INTO name_rules (match_type, pattern, replacement, min_amount, max_amount) VALUES (?, ?, ?, ?, ?)',
-        args: [str('match_type'), str('pattern'), str('replacement'), opt('min_amount'), opt('max_amount')],
+        sql: 'INSERT INTO name_rules (match_type, pattern, replacement, min_amount, max_amount, account_id) VALUES (?, ?, ?, ?, ?, ?)',
+        args: [str('match_type'), str('pattern'), str('replacement'), opt('min_amount'), opt('max_amount'), optStr('account_id')],
       });
       const count = await rebuildDisplayNames();
       return `Name rule added: "${str('pattern')}" → "${str('replacement')}"\nUpdated ${count} transactions.`;

--- a/gui/renderer/src/screens/Rules.tsx
+++ b/gui/renderer/src/screens/Rules.tsx
@@ -6,7 +6,7 @@ import { Modal } from '../components/Modal.js';
 import { useScreenKeys } from '../hooks/useScreenKeys.js';
 import { KeyHints } from '../components/KeyHints.js';
 import { fmt } from '../../../../core/fmt.js';
-import type { Rule, NameRule } from '../../../../core/queries.js';
+import type { Rule, NameRule, LinkedAccount } from '../../../../core/queries.js';
 import styles from './Rules.module.css';
 
 type Tab = 'rules' | 'names' | 'categories';
@@ -33,6 +33,12 @@ export function Rules() {
   const catDetails = useQuery(() => api.rules.getCategoryDetails(), [reloadKey]) ?? [];
   const hiddenSet = useQuery(() => api.queries.getHiddenCategorySet(), [reloadKey]);
   const uncategorized = useQuery(() => api.rules.getTotalUncategorizedCount(), [reloadKey]) ?? 0;
+  const accounts = useQuery(() => api.queries.getLinkedAccounts(), [reloadKey]) ?? [];
+  const accountLabel = (id: string | null): string => {
+    if (!id) return '';
+    const a = accounts.find((x) => x.id === id);
+    return a ? (a.nickname ?? a.name) : id;
+  };
 
   const [ruleForm, setRuleForm] = useState<{ editing: Rule | null } | null>(null);
   const [nameRuleForm, setNameRuleForm] = useState<{ editing: NameRule | null } | null>(null);
@@ -120,6 +126,7 @@ export function Rules() {
                   <th className={styles.th}>Amount</th>
                   <th className={styles.th}>Category</th>
                   <th className={styles.th}>Priority</th>
+                  <th className={styles.th}>Scope</th>
                   <th className={styles.th} />
                 </tr>
               </thead>
@@ -131,6 +138,7 @@ export function Rules() {
                     <td className="num dim">{amountLabel(r.min_amount, r.max_amount)}</td>
                     <td className="accent">{r.category}</td>
                     <td className="num dim">{r.priority}</td>
+                    <td className="dim">{r.account_id ? accountLabel(r.account_id) : 'All'}</td>
                     <td className={styles.tdActions}>
                       <button
                         className={`${styles.rowBtn} ${styles.rowBtnDanger}`}
@@ -164,6 +172,7 @@ export function Rules() {
                   <th className={styles.th}>Pattern</th>
                   <th className={styles.th}>Amount</th>
                   <th className={styles.th}>Display name</th>
+                  <th className={styles.th}>Scope</th>
                   <th className={styles.th} />
                 </tr>
               </thead>
@@ -174,6 +183,7 @@ export function Rules() {
                     <td className={styles.tdPattern}>{r.pattern}</td>
                     <td className="num dim">{amountLabel(r.min_amount, r.max_amount)}</td>
                     <td className="warn">{r.replacement}</td>
+                    <td className="dim">{r.account_id ? accountLabel(r.account_id) : 'All'}</td>
                     <td className={styles.tdActions}>
                       <button
                         className={`${styles.rowBtn} ${styles.rowBtnDanger}`}
@@ -281,6 +291,7 @@ export function Rules() {
         <RuleFormModal
           editing={ruleForm.editing}
           categories={categories}
+          accounts={accounts}
           onClose={() => setRuleForm(null)}
           onSaved={(count) => {
             setRuleForm(null);
@@ -293,6 +304,7 @@ export function Rules() {
       {nameRuleForm && (
         <NameRuleFormModal
           editing={nameRuleForm.editing}
+          accounts={accounts}
           onClose={() => setNameRuleForm(null)}
           onSaved={() => {
             setNameRuleForm(null);
@@ -340,11 +352,13 @@ export function Rules() {
 function RuleFormModal({
   editing,
   categories,
+  accounts,
   onClose,
   onSaved,
 }: {
   editing: Rule | null;
   categories: string[];
+  accounts: LinkedAccount[];
   onClose: () => void;
   onSaved: (count: number) => void;
 }) {
@@ -353,6 +367,7 @@ function RuleFormModal({
   const [minAmount, setMinAmount] = useState(editing?.min_amount !== null && editing ? String(editing.min_amount) : '');
   const [maxAmount, setMaxAmount] = useState(editing?.max_amount !== null && editing ? String(editing.max_amount) : '');
   const [category, setCategory] = useState(editing?.category ?? categories[0] ?? '');
+  const [accountId, setAccountId] = useState<string | null>(editing?.account_id ?? null);
   const [matchCount, setMatchCount] = useState(0);
   const [error, setError] = useState('');
 
@@ -376,6 +391,7 @@ function RuleFormModal({
         category,
         minAmount: minAmount.trim() ? parseFloat(minAmount) : null,
         maxAmount: maxAmount.trim() ? parseFloat(maxAmount) : null,
+        accountId,
         editingId: editing?.id ?? null,
       });
       onSaved(count);
@@ -406,6 +422,15 @@ function RuleFormModal({
             </option>
           ))}
         </select>
+        <label>Account</label>
+        <select value={accountId ?? ''} onChange={(e) => setAccountId(e.target.value || null)}>
+          <option value="">All accounts</option>
+          {accounts.map((a) => (
+            <option key={a.id} value={a.id}>
+              {a.nickname ?? a.name}
+            </option>
+          ))}
+        </select>
       </div>
       {pattern.trim() && (
         <p className={styles.matchHint}>
@@ -430,10 +455,12 @@ function RuleFormModal({
 
 function NameRuleFormModal({
   editing,
+  accounts,
   onClose,
   onSaved,
 }: {
   editing: NameRule | null;
+  accounts: LinkedAccount[];
   onClose: () => void;
   onSaved: () => void;
 }) {
@@ -442,6 +469,7 @@ function NameRuleFormModal({
   const [minAmount, setMinAmount] = useState(editing?.min_amount !== null && editing ? String(editing.min_amount) : '');
   const [maxAmount, setMaxAmount] = useState(editing?.max_amount !== null && editing ? String(editing.max_amount) : '');
   const [replacement, setReplacement] = useState(editing?.replacement ?? '');
+  const [accountId, setAccountId] = useState<string | null>(editing?.account_id ?? null);
   const [matchCount, setMatchCount] = useState(0);
   const [error, setError] = useState('');
 
@@ -465,6 +493,7 @@ function NameRuleFormModal({
         replacement: replacement.trim(),
         minAmount: minAmount.trim() ? parseFloat(minAmount) : null,
         maxAmount: maxAmount.trim() ? parseFloat(maxAmount) : null,
+        accountId,
         editingId: editing?.id ?? null,
       });
       onSaved();
@@ -489,6 +518,15 @@ function NameRuleFormModal({
         <input value={maxAmount} onChange={(e) => setMaxAmount(e.target.value.replace(/[^\d.\-]/g, ''))} />
         <label>Display name</label>
         <input value={replacement} onChange={(e) => setReplacement(e.target.value)} placeholder="e.g. Amazon" />
+        <label>Account</label>
+        <select value={accountId ?? ''} onChange={(e) => setAccountId(e.target.value || null)}>
+          <option value="">All accounts</option>
+          {accounts.map((a) => (
+            <option key={a.id} value={a.id}>
+              {a.nickname ?? a.name}
+            </option>
+          ))}
+        </select>
       </div>
       {pattern.trim() && (
         <p className={styles.matchHint}>

--- a/mcp/create-server.ts
+++ b/mcp/create-server.ts
@@ -116,6 +116,7 @@ export function createMcpServer(opts: { afterWrite?: () => void } = {}): McpServ
       priority:   z.number().int().default(10).describe('Higher priority rules run first (default 10)'),
       min_amount: z.number().optional().describe('Minimum transaction amount (optional)'),
       max_amount: z.number().optional().describe('Maximum transaction amount (optional)'),
+      account_id: z.string().optional().describe('Scope the rule to a single account ID (from list_accounts); omit for a global rule'),
     },
     (input) => run('add_rule', input),
   );
@@ -151,6 +152,7 @@ export function createMcpServer(opts: { afterWrite?: () => void } = {}): McpServ
       replacement: z.string().describe('Display name to show instead'),
       min_amount:  z.number().optional().describe('Minimum transaction amount (optional)'),
       max_amount:  z.number().optional().describe('Maximum transaction amount (optional)'),
+      account_id:  z.string().optional().describe('Scope the rule to a single account ID (from list_accounts); omit for a global rule'),
     },
     (input) => run('add_name_rule', input),
   );

--- a/tests/account-scoped-rules.test.ts
+++ b/tests/account-scoped-rules.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('../core/db.js', async () => {
+  const { makeTestDb } = await import('./helpers/makeTestDb.js');
+  return { db: await makeTestDb() };
+});
+
+import { db } from '../core/db.js';
+import { saveCategoryRule, saveNameRule } from '../core/rules.js';
+import { deleteAccount, importCsvTransactions } from '../core/accounts.js';
+
+beforeEach(async () => {
+  await db.execute('DELETE FROM category_rules');
+  await db.execute('DELETE FROM name_rules');
+  await db.execute('DELETE FROM transactions');
+  await db.execute('DELETE FROM accounts');
+});
+
+describe('saveCategoryRule with account scope', () => {
+  it('persists account_id on insert', async () => {
+    await saveCategoryRule({ pattern: 'amazon', matchType: 'name', category: 'Business Expenses', minAmount: null, maxAmount: null, accountId: 'work' });
+    const row = (await db.execute('SELECT account_id, category FROM category_rules')).rows[0] as unknown as { account_id: string | null; category: string };
+    expect(row.account_id).toBe('work');
+    expect(row.category).toBe('Business Expenses');
+  });
+
+  it('allows the same pattern both globally and scoped (distinct rows)', async () => {
+    await saveCategoryRule({ pattern: 'amazon', matchType: 'name', category: 'Shopping', minAmount: null, maxAmount: null, accountId: null });
+    await saveCategoryRule({ pattern: 'amazon', matchType: 'name', category: 'Business Expenses', minAmount: null, maxAmount: null, accountId: 'work' });
+    const rows = (await db.execute('SELECT account_id, category FROM category_rules ORDER BY account_id IS NULL')).rows as unknown as { account_id: string | null; category: string }[];
+    expect(rows).toHaveLength(2);
+    expect(rows.find((r) => r.account_id === 'work')?.category).toBe('Business Expenses');
+    expect(rows.find((r) => r.account_id === null)?.category).toBe('Shopping');
+  });
+
+  it('updates the existing global rule rather than inserting a duplicate', async () => {
+    await saveCategoryRule({ pattern: 'amazon', matchType: 'name', category: 'Shopping', minAmount: null, maxAmount: null, accountId: null });
+    await saveCategoryRule({ pattern: 'amazon', matchType: 'name', category: 'Online', minAmount: null, maxAmount: null, accountId: null });
+    const rows = (await db.execute('SELECT category FROM category_rules')).rows as unknown as { category: string }[];
+    expect(rows).toHaveLength(1);
+    expect(rows[0].category).toBe('Online');
+  });
+});
+
+describe('deleteAccount removes its scoped rules', () => {
+  it('deletes scoped category and name rules but leaves global ones', async () => {
+    await db.execute({ sql: "INSERT INTO accounts (id, name, type) VALUES ('work', 'Work Card', 'credit')", args: [] });
+    await saveCategoryRule({ pattern: 'amazon', matchType: 'name', category: 'Business Expenses', minAmount: null, maxAmount: null, accountId: 'work' });
+    await saveCategoryRule({ pattern: 'amazon', matchType: 'name', category: 'Shopping', minAmount: null, maxAmount: null, accountId: null });
+    await saveNameRule({ pattern: 'amazon', matchType: 'name', replacement: 'Amazon Biz', minAmount: null, maxAmount: null, accountId: 'work' });
+
+    await deleteAccount('work');
+
+    const cat = (await db.execute('SELECT account_id FROM category_rules')).rows as unknown as { account_id: string | null }[];
+    expect(cat).toHaveLength(1);
+    expect(cat[0].account_id).toBeNull();
+    const names = (await db.execute('SELECT account_id FROM name_rules')).rows as unknown as { account_id: string | null }[];
+    expect(names).toHaveLength(0);
+  });
+});
+
+describe('importCsvTransactions honors account-scoped rules', () => {
+  it('applies a rule scoped to the imported account', async () => {
+    await saveCategoryRule({ pattern: 'amazon', matchType: 'name', category: 'Shopping', minAmount: null, maxAmount: null, accountId: null });
+    await saveCategoryRule({ pattern: 'amazon', matchType: 'name', category: 'Business Expenses', minAmount: null, maxAmount: null, accountId: 'work' });
+
+    const rows = [['2025-01-01', 'AMAZON.COM', '25.00']];
+    const result = await importCsvTransactions(rows, { id: 'work', name: 'Work Card', mask: null }, {
+      amountMode: 'single', dateCol: 0, nameCol: 1, amountCol: 2, debitCol: null, creditCol: null, positiveIsInflow: false,
+    });
+    expect(result.imported).toBe(1);
+    const tx = (await db.execute("SELECT category FROM transactions WHERE account_id = 'work'")).rows[0] as unknown as { category: string };
+    expect(tx.category).toBe('Business Expenses');
+  });
+});

--- a/tests/categorize.test.ts
+++ b/tests/categorize.test.ts
@@ -211,3 +211,48 @@ describe('applyCategoriesToAll', () => {
     expect(count).toBe(0);
   });
 });
+
+// ──────────────────────────────────────────────────────────────────────
+describe('account-scoped rules', () => {
+  async function insertScopedRule(priority: number, match_type: string, pattern: string, category: string, account_id: string | null) {
+    await db.execute({
+      sql: 'INSERT INTO category_rules (priority, match_type, pattern, category, min_amount, max_amount, account_id) VALUES (?, ?, ?, ?, NULL, NULL, ?)',
+      args: [priority, match_type, pattern, category, account_id],
+    });
+  }
+
+  it('account-scoped rule beats global rule at the same priority for its account', async () => {
+    await insertScopedRule(10, 'name', 'amazon', 'Shopping', null);
+    await insertScopedRule(10, 'name', 'amazon', 'Business Expenses', 'work');
+    expect(await categorize('AMAZON.COM', null, null, undefined, 'work')).toBe('Business Expenses');
+  });
+
+  it('global rule applies when no scoped rule matches the account', async () => {
+    await insertScopedRule(10, 'name', 'amazon', 'Shopping', null);
+    await insertScopedRule(10, 'name', 'amazon', 'Business Expenses', 'work');
+    expect(await categorize('AMAZON.COM', null, null, undefined, 'personal')).toBe('Shopping');
+  });
+
+  it('higher-priority global rule still beats a lower-priority scoped rule', async () => {
+    await insertScopedRule(5, 'name', 'amazon', 'Business Expenses', 'work');
+    await insertScopedRule(10, 'name', 'amazon', 'Shopping', null);
+    expect(await categorize('AMAZON.COM', null, null, undefined, 'work')).toBe('Shopping');
+  });
+
+  it('rule scoped to a different account is ignored', async () => {
+    await insertScopedRule(10, 'name', 'amazon', 'Business Expenses', 'work');
+    expect(await categorize('AMAZON.COM', null, null, undefined, 'personal')).toBe('Uncategorized');
+    expect(await categorize('AMAZON.COM', null, null, undefined, undefined)).toBe('Uncategorized');
+  });
+
+  it('applyCategoriesToAll applies scoped rules only to matching accounts', async () => {
+    await insertScopedRule(10, 'name', 'amazon', 'Business Expenses', 'work');
+    await db.execute({ sql: "INSERT INTO transactions (id, account_id, date, name, amount, category, pending, ignored) VALUES ('w1','work','2025-01-01','AMAZON',10,'Uncategorized',0,0)" });
+    await db.execute({ sql: "INSERT INTO transactions (id, account_id, date, name, amount, category, pending, ignored) VALUES ('p1','personal','2025-01-01','AMAZON',10,'Uncategorized',0,0)" });
+    await applyCategoriesToAll();
+    const w = (await db.execute({ sql: 'SELECT category FROM transactions WHERE id = ?', args: ['w1'] })).rows[0] as unknown as { category: string };
+    const p = (await db.execute({ sql: 'SELECT category FROM transactions WHERE id = ?', args: ['p1'] })).rows[0] as unknown as { category: string };
+    expect(w.category).toBe('Business Expenses');
+    expect(p.category).toBe('Uncategorized');
+  });
+});

--- a/tests/helpers/makeTestDb.ts
+++ b/tests/helpers/makeTestDb.ts
@@ -35,7 +35,8 @@ const SCHEMA = `
     pattern TEXT NOT NULL,
     category TEXT NOT NULL,
     min_amount REAL,
-    max_amount REAL
+    max_amount REAL,
+    account_id TEXT
   );
 
   CREATE TABLE name_rules (
@@ -44,7 +45,8 @@ const SCHEMA = `
     pattern TEXT NOT NULL,
     replacement TEXT NOT NULL,
     min_amount REAL,
-    max_amount REAL
+    max_amount REAL,
+    account_id TEXT
   );
 
   CREATE TABLE hidden_categories (category TEXT PRIMARY KEY);

--- a/tests/rename.test.ts
+++ b/tests/rename.test.ts
@@ -110,6 +110,32 @@ describe('applyNameRules', () => {
   });
 });
 
+describe('account-scoped name rules', () => {
+  async function insertScopedRule(match_type: string, pattern: string, replacement: string, account_id: string | null) {
+    await db.execute({
+      sql: 'INSERT INTO name_rules (match_type, pattern, replacement, min_amount, max_amount, account_id) VALUES (?, ?, ?, NULL, NULL, ?)',
+      args: [match_type, pattern, replacement, account_id],
+    });
+  }
+
+  it('scoped rule beats a global rule for its account (scoped ordered first)', async () => {
+    await insertScopedRule('name', 'amazon', 'Amazon', null);
+    await insertScopedRule('name', 'amazon', 'Amazon Business', 'work');
+    expect(await applyNameRules('AMAZON.COM', undefined, 'work')).toBe('Amazon Business');
+  });
+
+  it('global rule applies when no scoped rule matches the account', async () => {
+    await insertScopedRule('name', 'amazon', 'Amazon', null);
+    await insertScopedRule('name', 'amazon', 'Amazon Business', 'work');
+    expect(await applyNameRules('AMAZON.COM', undefined, 'personal')).toBe('Amazon');
+  });
+
+  it('rule scoped to a different account is ignored', async () => {
+    await insertScopedRule('name', 'amazon', 'Amazon Business', 'work');
+    expect(await applyNameRules('AMAZON.COM', undefined, 'personal')).toBe('AMAZON.COM');
+  });
+});
+
 describe('rebuildDisplayNames', () => {
   async function insertTx(id: string, name: string, amount: number) {
     await db.execute({

--- a/tui/Rules.tsx
+++ b/tui/Rules.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Box, Text, useInput } from 'ink';
-import { getAllRules, getAllNameRules, getAllCategories, getCategoryDetails, getHiddenCategorySet, toggleHiddenCategory, type Rule, type NameRule, type CategoryDetail } from '../core/queries.js';
+import { getAllRules, getAllNameRules, getAllCategories, getCategoryDetails, getHiddenCategorySet, toggleHiddenCategory, getLinkedAccounts, type Rule, type NameRule, type CategoryDetail, type LinkedAccount } from '../core/queries.js';
 import {
   getUncategorizedCount, deleteCategoryRule, deleteNameRule,
   saveCategoryRule, saveNameRule, setCategoryFlexibility,
@@ -18,10 +18,10 @@ type Flexibility = 'fixed' | 'flexible' | 'discretionary' | null;
 const FLEX_CYCLE: Flexibility[] = [null, 'fixed', 'flexible', 'discretionary'];
 type Mode = 'list' | 'search' | 'rule-form' | 'name-rule-form' | 'add-category-name' | 'edit-category';
 type CatEditField = 'name' | 'flexibility' | 'hidden';
-type RuleField = 'pattern' | 'type' | 'min' | 'max' | 'category';
-type NameRuleField = 'pattern' | 'type' | 'min' | 'max' | 'replacement';
-const RULE_FIELDS: RuleField[] = ['pattern', 'type', 'min', 'max', 'category'];
-const NAME_RULE_FIELDS: NameRuleField[] = ['pattern', 'type', 'min', 'max', 'replacement'];
+type RuleField = 'pattern' | 'type' | 'min' | 'max' | 'category' | 'account';
+type NameRuleField = 'pattern' | 'type' | 'min' | 'max' | 'replacement' | 'account';
+const RULE_FIELDS: RuleField[] = ['pattern', 'type', 'min', 'max', 'category', 'account'];
+const NAME_RULE_FIELDS: NameRuleField[] = ['pattern', 'type', 'min', 'max', 'replacement', 'account'];
 type Section = 'rules' | 'names' | 'categories';
 
 const SECTIONS: Section[] = ['rules', 'names', 'categories'];
@@ -56,6 +56,10 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
   const [newNameMinAmount, setNewNameMinAmount] = useState('');
   const [newNameMaxAmount, setNewNameMaxAmount] = useState('');
   const [newReplacement, setNewReplacement] = useState('');
+
+  // Account scoping (shared by both rule forms; only one is active at a time)
+  const [accounts, setAccounts] = useState<LinkedAccount[]>([]);
+  const [accountCursor, setAccountCursor] = useState(0); // 0 = All accounts; i>0 → accounts[i-1]
 
   // Editing
   const [editingRuleId, setEditingRuleId] = useState<number | null>(null);
@@ -96,7 +100,20 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
     void getHiddenCategorySet().then(setHiddenSet);
     void getAllCategories().then(setCategories);
     void getCategoryDetails().then(setCatDetails);
+    void getLinkedAccounts().then(setAccounts);
   }
+
+  // Account picker options: index 0 = "All accounts" (global), then one per account.
+  const accountOptions: (string | null)[] = [null, ...accounts.map((a) => a.id)];
+  const accountLabel = (id: string | null): string => {
+    if (id === null) return 'All accounts';
+    const a = accounts.find((x) => x.id === id);
+    return a ? (a.nickname ?? a.name) : id;
+  };
+  const accountCursorFor = (id: string | null): number => {
+    const i = accountOptions.indexOf(id);
+    return i >= 0 ? i : 0;
+  };
 
   useEffect(() => { load(); }, [refreshKey]);
 
@@ -119,6 +136,7 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
     const count = await saveCategoryRule({
       pattern: newPattern, matchType: newType, category,
       minAmount: minAmt, maxAmount: maxAmt,
+      accountId: accountOptions[accountCursor] ?? null,
       editingId: editingRuleId,
     });
     setEditingRuleId(null);
@@ -134,6 +152,7 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
     await saveNameRule({
       pattern: newNamePattern, matchType: newNameType, replacement: newReplacement,
       minAmount: minAmt, maxAmount: maxAmt,
+      accountId: accountOptions[accountCursor] ?? null,
       editingId: editingNameRuleId,
     });
     setEditingNameRuleId(null);
@@ -178,7 +197,7 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
         if (key.upArrow) setCursor((c) => Math.max(0, c - 1));
         if (key.downArrow) setCursor((c) => Math.min(filteredRules.length - 1, c + 1));
         if (input === 'a') {
-          setEditingRuleId(null); setNewPattern(''); setNewType('name'); setNewMinAmount(''); setNewMaxAmount(''); setCatCursor(0);
+          setEditingRuleId(null); setNewPattern(''); setNewType('name'); setNewMinAmount(''); setNewMaxAmount(''); setCatCursor(0); setAccountCursor(0);
           setRuleField('pattern'); setMode('rule-form');
         }
         if (input === 'x' && filteredRules[cursor]) { handleDeleteRule(filteredRules[cursor].id); }
@@ -190,13 +209,14 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
           setNewMinAmount(r.min_amount !== null ? String(r.min_amount) : '');
           setNewMaxAmount(r.max_amount !== null ? String(r.max_amount) : '');
           setCatCursor(Math.max(0, categories.indexOf(r.category)));
+          setAccountCursor(accountCursorFor(r.account_id));
           setRuleField('pattern'); setMode('rule-form');
         }
       } else if (section === 'names') {
         if (key.upArrow) setNameCursor((c) => Math.max(0, c - 1));
         if (key.downArrow) setNameCursor((c) => Math.min(filteredNameRules.length - 1, c + 1));
         if (input === 'a') {
-          setEditingNameRuleId(null); setNewNamePattern(''); setNewNameType('name'); setNewNameMinAmount(''); setNewNameMaxAmount(''); setNewReplacement('');
+          setEditingNameRuleId(null); setNewNamePattern(''); setNewNameType('name'); setNewNameMinAmount(''); setNewNameMaxAmount(''); setNewReplacement(''); setAccountCursor(0);
           setNameRuleField('pattern'); setMode('name-rule-form');
         }
         if (input === 'x' && filteredNameRules[nameCursor]) { handleDeleteNameRule(filteredNameRules[nameCursor].id); }
@@ -208,6 +228,7 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
           setNewNameMinAmount(r.min_amount !== null ? String(r.min_amount) : '');
           setNewNameMaxAmount(r.max_amount !== null ? String(r.max_amount) : '');
           setNewReplacement(r.replacement);
+          setAccountCursor(accountCursorFor(r.account_id));
           setNameRuleField('pattern'); setMode('name-rule-form');
         }
       } else if (section === 'categories') {
@@ -305,6 +326,9 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
       } else if (ruleField === 'category') {
         if (key.leftArrow) { setCatCursor((c) => Math.max(0, c - 1)); return; }
         if (key.rightArrow) { setCatCursor((c) => Math.min(categories.length - 1, c + 1)); return; }
+      } else if (ruleField === 'account') {
+        if (key.leftArrow) { setAccountCursor((c) => Math.max(0, c - 1)); return; }
+        if (key.rightArrow) { setAccountCursor((c) => Math.min(accountOptions.length - 1, c + 1)); return; }
       }
     } else if (mode === 'name-rule-form') {
       if (key.escape) { setEditingNameRuleId(null); setMode('list'); return; }
@@ -325,6 +349,9 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
       } else if (nameRuleField === 'replacement') {
         if (key.backspace || key.delete) { setNewReplacement((p) => p.slice(0, -1)); return; }
         if (input && !key.ctrl && !key.meta) { setNewReplacement((p) => p + input); return; }
+      } else if (nameRuleField === 'account') {
+        if (key.leftArrow) { setAccountCursor((c) => Math.max(0, c - 1)); return; }
+        if (key.rightArrow) { setAccountCursor((c) => Math.min(accountOptions.length - 1, c + 1)); return; }
       }
     } else if (mode === 'add-category-name') {
       if (key.escape) { setMode('list'); return; }
@@ -407,6 +434,7 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
                 {amtLabel ? <Text color={C_MANUAL} dimColor={!isSelected}>{truncate(amtLabel, 10).padEnd(10)}</Text> : <Text>{' '.repeat(10)}</Text>}
                 <Text color={C_ACCENT} dimColor={!isSelected}>{rule.category.length > ruleCatW ? rule.category.slice(0, ruleCatW - 1) + '…' : rule.category.padEnd(ruleCatW)}</Text>
                 <Text dimColor>{rule.priority}</Text>
+                {rule.account_id && <Text color={C_MANUAL} dimColor={!isSelected}>@{accountLabel(rule.account_id)}</Text>}
               </SelectableRow>
             );
           })}
@@ -447,6 +475,7 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
                       ? <Text color={C_MANUAL} dimColor={!isSelected}>{truncate(amtLabel, 12).padEnd(12)}</Text>
                       : <Text>{' '.repeat(12)}</Text>}
                     <Text color={C_POSITIVE} dimColor={!isSelected}>{rule.replacement.length > nameReplW ? rule.replacement.slice(0, nameReplW - 1) + '…' : rule.replacement}</Text>
+                    {rule.account_id && <Text color={C_MANUAL} dimColor={!isSelected}>@{accountLabel(rule.account_id)}</Text>}
                   </SelectableRow>
                 );
               })}
@@ -519,6 +548,7 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
             <EditTextField label="Min $" active={ruleField === 'min'} value={newMinAmount} color={C_WARNING} placeholder="optional" />
             <EditTextField label="Max $" active={ruleField === 'max'} value={newMaxAmount} color={C_WARNING} placeholder="optional" />
             <EditToggleField label="Category" active={ruleField === 'category'} value={categories[catCursor] ?? '—'} />
+            <EditToggleField label="Account" active={ruleField === 'account'} value={accountLabel(accountOptions[accountCursor] ?? null)} />
           </Box>
           <Box marginTop={1}><Text dimColor>↑↓ field  ·  ← → change  ·  Enter save  ·  Esc cancel</Text></Box>
         </ModalPanel>
@@ -532,6 +562,7 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
             <EditTextField label="Min $" active={nameRuleField === 'min'} value={newNameMinAmount} color={C_WARNING} placeholder="optional" />
             <EditTextField label="Max $" active={nameRuleField === 'max'} value={newNameMaxAmount} color={C_WARNING} placeholder="optional" />
             <EditTextField label="Replace with" active={nameRuleField === 'replacement'} value={newReplacement} color={C_POSITIVE} placeholder="display name" emptyText="empty" />
+            <EditToggleField label="Account" active={nameRuleField === 'account'} value={accountLabel(accountOptions[accountCursor] ?? null)} />
           </Box>
           <Box marginTop={1}><Text dimColor>↑↓ field  ·  ← → change  ·  Enter save  ·  Esc cancel</Text></Box>
         </ModalPanel>


### PR DESCRIPTION
Add an optional account_id to category_rules and name_rules. When set, a rule only fires for transactions on that account; rules with account_id NULL remain global fallbacks. Account-scoped rules take precedence over global rules at the same priority level, achieved via a per-call account filter plus ORDER BY priority DESC, (account_id IS NULL) ASC, id ASC.

accountId is threaded through every call site (sync, CSV import, applyCategoriesToAll, rebuildDisplayNames, seedRules, single-shot categorize/applyNameRules). CSV import now also passes amount so amount-filtered rules behave consistently with Plaid sync.

- TUI/GUI Rules screens: account picker in both rule forms + scope badge
- MCP add_rule/add_name_rule accept account_id; list_rules surfaces scope
- deleteAccount removes that account's scoped rules
- Tests cover precedence, scoping, CRUD dedupe, deletion, CSV import

Closes #20 