### PR TITLE
feat(gui): live preview of filter changes behind the panel

### DIFF
--- a/gui/renderer/src/components/FilterBar.tsx
+++ b/gui/renderer/src/components/FilterBar.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { api } from '../api.js';
 import { useFilter } from '../hooks/useFilter.js';
 import { Modal } from './Modal.js';
@@ -10,14 +10,21 @@ import {
   selectionFromDim,
   invertSelection,
   invertTagModes,
+  filtersEqual,
   type Filter,
   type TagPredicate,
 } from '../../../../core/filters.js';
 import type { FilterOptions } from '../../../../core/queries.js';
 import styles from './FilterBar.module.css';
 
+// Debounce window for publishing the live preview. Toggling many checkboxes in
+// quick succession (or hitting all/none/invert) mutates the draft repeatedly;
+// coalescing them collapses the burst into one query round-trip per pause
+// instead of one per keystroke. Mirrors PREVIEW_DEBOUNCE_MS in tui/FilterPanel.
+const PREVIEW_DEBOUNCE_MS = 120;
+
 export function FilterBar() {
-  const { filter, setFilter } = useFilter();
+  const { filter, committed, setFilter } = useFilter();
   const [open, setOpen] = useState(false);
   const active = isFilterActive(filter);
 
@@ -32,7 +39,13 @@ export function FilterBar() {
         </button>
       )}
       <span className={`dim ${styles.hint}`}>applies to Dashboard, Transactions & Trends</span>
-      {open && <FilterPanel filter={filter} onApply={(f) => { setFilter(f); setOpen(false); }} onClose={() => setOpen(false)} />}
+      {open && (
+        <FilterPanel
+          committed={committed}
+          onApply={(f) => { setFilter(f); setOpen(false); }}
+          onClose={() => setOpen(false)}
+        />
+      )}
     </div>
   );
 }
@@ -40,14 +53,15 @@ export function FilterBar() {
 type TagMode = 'has' | 'lacks' | null;
 
 function FilterPanel({
-  filter,
+  committed,
   onApply,
   onClose,
 }: {
-  filter: Filter;
+  committed: Filter;
   onApply: (f: Filter) => void;
   onClose: () => void;
 }) {
+  const { setPreview } = useFilter();
   const [opts, setOpts] = useState<FilterOptions | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
 
@@ -58,34 +72,59 @@ function FilterPanel({
 
   // Load universes via getFilterOptions (same source as the TUI panel), then
   // hydrate drafts: an absent dimension means "everything selected" (no
-  // constraint) per core/filters.ts semantics.
+  // constraint) per core/filters.ts semantics. We hydrate from `committed`,
+  // not the live `filter` (== preview ?? committed) — reading the live value
+  // would re-seed the draft from the panel's own preview, a feedback loop.
   useEffect(() => {
     void api.queries.getFilterOptions().then((o) => {
       setOpts(o);
-      setSelCats(selectionFromDim(filter.categories, o.categories));
-      setSelAccts(selectionFromDim(filter.accounts, o.accounts.map((a) => a.id)));
-      setSelOwners(selectionFromDim(filter.owners, o.owners));
-      setTagModes(new Map((filter.tags ?? []).map((t: TagPredicate) => [t.name, t.mode])));
+      setSelCats(selectionFromDim(committed.categories, o.categories));
+      setSelAccts(selectionFromDim(committed.accounts, o.accounts.map((a) => a.id)));
+      setSelOwners(selectionFromDim(committed.owners, o.owners));
+      setTagModes(new Map((committed.tags ?? []).map((t: TagPredicate) => [t.name, t.mode])));
     }).catch((e: unknown) => {
       setLoadError(e instanceof Error ? e.message : String(e));
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  function apply() {
-    if (!opts) return;
+  // Serialized draft, recomputed as the user adjusts selections. Published as
+  // a live preview below, and committed verbatim by apply() on Apply.
+  const draftFilter = useMemo<Filter | null>(() => {
+    if (!opts) return null;
     const tags: TagPredicate[] = [...tagModes.entries()]
       .filter(([, mode]) => mode !== null)
       .map(([name, mode]) => ({ name, mode: mode as 'has' | 'lacks' }));
     const cats = selectionToDim(selCats, opts.categories);
     const accts = selectionToDim(selAccts, opts.accounts.map((a) => a.id));
     const owners = selectionToDim(selOwners, opts.owners);
-    onApply({
+    return {
       ...(cats !== undefined ? { categories: cats } : {}),
       ...(accts !== undefined ? { accounts: accts } : {}),
       ...(owners !== undefined ? { owners } : {}),
       ...(tags.length ? { tags } : {}),
-    });
+    };
+  }, [opts, selCats, selAccts, selOwners, tagModes]);
+
+  // Publish the draft as a live preview (debounced), collapsing back to "no
+  // preview" once the draft matches the committed filter so the bar reverts.
+  useEffect(() => {
+    if (!draftFilter) return;
+    const id = setTimeout(() => {
+      setPreview(filtersEqual(draftFilter, committed) ? null : draftFilter);
+    }, PREVIEW_DEBOUNCE_MS);
+    return () => clearTimeout(id);
+  }, [draftFilter, committed, setPreview]);
+
+  // On unmount (Apply or Cancel), force the preview back to null so screens
+  // fall back to the committed filter. Distinct from the debounce cleanup
+  // above: that only cancels a pending timer, which would otherwise strand a
+  // previously-published (non-null) preview if we close before it fires.
+  useEffect(() => () => setPreview(null), [setPreview]);
+
+  function apply() {
+    if (!opts || !draftFilter) return;
+    onApply(draftFilter);
   }
 
   function toggle<T>(set: Set<T>, value: T, update: (s: Set<T>) => void) {

--- a/gui/renderer/src/hooks/useFilter.tsx
+++ b/gui/renderer/src/hooks/useFilter.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useCallback, useContext, useState } from 'react';
+import React, { createContext, useCallback, useContext, useMemo, useState } from 'react';
 import {
   EMPTY_FILTER,
   pushFilter,
@@ -11,30 +11,47 @@ import {
 // the GUI counterpart of tui/FilterContext.tsx. Not persisted; resets per session.
 // Every setFilter pushes the previous value onto a bounded history stack so
 // popFilter can step back one level at a time (Esc in Transactions).
+//
+// `preview` lets the FilterPanel show live results as the user adjusts the
+// draft, without touching history: `filter` is `preview ?? committed`, while
+// `committed` (== history's current) is what the panel hydrates from and what
+// `setFilter` ultimately replaces.
 
 type FilterCtx = {
   filter: Filter;
+  committed: Filter;
   setFilter: (f: Filter) => void;
+  setPreview: (f: Filter | null) => void;
   popFilter: () => void;
   canPop: boolean;
 };
 
 const Ctx = createContext<FilterCtx>({
   filter: EMPTY_FILTER,
+  committed: EMPTY_FILTER,
   setFilter: () => {},
+  setPreview: () => {},
   popFilter: () => {},
   canPop: false,
 });
 
 export function FilterProvider({ initial, children }: { initial?: Filter; children: React.ReactNode }) {
   const [hist, setHist] = useState<FilterHistory>({ current: initial ?? EMPTY_FILTER, stack: [] });
+  const [preview, setPreview] = useState<Filter | null>(null);
   const setFilter = useCallback((f: Filter) => setHist((h) => pushFilter(h, f)), []);
   const popFilter = useCallback(() => setHist(popFilterCore), []);
-  return (
-    <Ctx.Provider value={{ filter: hist.current, setFilter, popFilter, canPop: hist.stack.length > 0 }}>
-      {children}
-    </Ctx.Provider>
+  const value = useMemo<FilterCtx>(
+    () => ({
+      filter: preview ?? hist.current,
+      committed: hist.current,
+      setFilter,
+      setPreview,
+      popFilter,
+      canPop: hist.stack.length > 0,
+    }),
+    [preview, hist, setFilter, popFilter],
   );
+  return <Ctx.Provider value={value}>{children}</Ctx.Provider>;
 }
 
 export function useFilter(): FilterCtx {

--- a/tests/gui/navigation.test.tsx
+++ b/tests/gui/navigation.test.tsx
@@ -107,6 +107,35 @@ describe('GUI App navigation', () => {
     await waitFor(() => expect(screen.getByText('9 transactions')).toBeTruthy());
   });
 
+  it('toggling a category in the panel live-previews the screen behind it', async () => {
+    render(<App />);
+    await waitFor(() => expect(screen.getByRole('heading', { name: 'Dashboard' })).toBeTruthy());
+    await userEvent.click(screen.getByRole('button', { name: 'Transactions' }));
+    await waitFor(() => expect(screen.getByText('9 transactions')).toBeTruthy());
+    await userEvent.click(screen.getByText(/⚲ Filter/));
+    await waitFor(() => expect(screen.getByRole('checkbox', { name: 'Grocery' })).toBeTruthy());
+    // Toggle Grocery off — the underlying transaction list should repaint
+    // before Apply is clicked (debounce is 120ms, well under waitFor's window).
+    await userEvent.click(screen.getByRole('checkbox', { name: 'Grocery' }));
+    await waitFor(() => expect(screen.getByText('6 transactions')).toBeTruthy());
+    expect(screen.queryByText('Trader Joes')).toBeNull();
+  });
+
+  it('Cancel reverts the live preview without committing', async () => {
+    render(<App />);
+    await waitFor(() => expect(screen.getByRole('heading', { name: 'Dashboard' })).toBeTruthy());
+    await userEvent.click(screen.getByRole('button', { name: 'Transactions' }));
+    await waitFor(() => expect(screen.getByText('9 transactions')).toBeTruthy());
+    await userEvent.click(screen.getByText(/⚲ Filter/));
+    await waitFor(() => expect(screen.getByRole('checkbox', { name: 'Grocery' })).toBeTruthy());
+    await userEvent.click(screen.getByRole('checkbox', { name: 'Grocery' }));
+    await waitFor(() => expect(screen.getByText('6 transactions')).toBeTruthy());
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    // Preview clears on unmount → list reverts to the committed (empty) filter.
+    await waitFor(() => expect(screen.getByText('9 transactions')).toBeTruthy());
+    expect(screen.queryByText(/Filter: \d+ categories/)).toBeNull();
+  });
+
   it('agent drawer collapsed bar shows no-key state and expands', async () => {
     render(<App />);
     await waitFor(() => expect(screen.getByText(/no API key set/)).toBeTruthy());


### PR DESCRIPTION
## Summary

GUI parity for the TUI live filter preview from #76. As the user toggles categories/accounts/owners/tags in the filter panel, the Dashboard/Transactions/Trends screens behind the modal repaint with the draft filter in real time. Cancel reverts; Apply commits.

Mechanism mirrors the TUI:

- `useFilter` gains a `preview: Filter | null` slot and a `committed` getter. `filter` returns `preview ?? committed`, so all three consumer screens gain preview without any changes (they already read `useFilter().filter`).
- `FilterPanel` extracts the draft into a memoized `draftFilter` and publishes it via `setPreview`, debounced at 120ms (matches `tui/FilterPanel`). The effect collapses back to `null` when the draft equals committed so the bar reverts. An unmount cleanup forces `setPreview(null)` so Cancel/X/Apply all fall back to the committed filter.
- The panel hydrates from `committed`, not the live `filter` — reading the live value would re-seed the draft from the panel's own preview (the same feedback-loop subtlety called out in #76).

Race-safety is already handled: `useQuery` cancels stale results via its `alive` flag, so the load-guard hazard the TUI PR addressed doesn't apply here (already confirmed in the #76 review thread; #78 ported the guard for the one non-`useQuery` site).

## Test plan

- [x] `npm run typecheck` clean
- [x] Full suite: 617/617 pass
- [x] New tests in `tests/gui/navigation.test.tsx`:
  - toggling Grocery off updates `9 transactions` → `6 transactions` **before** Apply (live preview)
  - clicking Cancel reverts the list and leaves no `Filter: …` chip in the bar (preview cleared, committed untouched)
- [ ] Manual: open the panel from each of Dashboard, Transactions, Trends; flip checkboxes and watch the screen behind the modal update; Cancel reverts; Apply commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)