### PR TITLE
test: pin outbound drill payloads carry range + anchor

### DIFF
--- a/tests/gui/dashboard.test.tsx
+++ b/tests/gui/dashboard.test.tsx
@@ -40,10 +40,13 @@ describe('GUI Dashboard', () => {
     renderScreen(<Dashboard />, { txFilter: MAY_FILTER, navigate });
     await waitFor(() => expect(screen.getByText('Grocery')).toBeTruthy());
     await userEvent.click(screen.getByText('Grocery'));
-    // The category lands in the shared filter; nav carries period + drillFrom.
+    // The category lands in the shared filter; nav carries period (range +
+    // anchor=from) and drillFrom so Esc can restore the same month.
     expect(navigate).toHaveBeenCalledWith(
       'transactions',
-      expect.objectContaining({ from: '2026-05-01', to: '2026-05-31', drillFrom: 'dashboard' }),
+      expect.objectContaining({
+        from: '2026-05-01', to: '2026-05-31', range: 'month', anchor: '2026-05-01', drillFrom: 'dashboard',
+      }),
     );
   });
 
@@ -54,5 +57,22 @@ describe('GUI Dashboard', () => {
     await waitFor(() => expect(screen.getByText('Fixed')).toBeTruthy());
     expect(screen.getByText('Flexible')).toBeTruthy();
     expect(screen.getByText('Discretionary')).toBeTruthy();
+  });
+
+  it('flex tier click outbound payload carries range + anchor', async () => {
+    const navigate = vi.fn();
+    renderScreen(<Dashboard />, { txFilter: MAY_FILTER, navigate });
+    await waitFor(() => expect(screen.getByText('Grocery')).toBeTruthy());
+    await userEvent.click(screen.getByRole('button', { name: 'Flexibility' }));
+    await waitFor(() => expect(screen.getByText('Flexible')).toBeTruthy());
+    await userEvent.click(screen.getByText('Flexible'));
+    // No selectedAccount → no drillFrom, but range/anchor still travel so
+    // Esc preserves the dashboard's month.
+    expect(navigate).toHaveBeenCalledWith(
+      'transactions',
+      expect.objectContaining({
+        from: '2026-05-01', to: '2026-05-31', range: 'month', anchor: '2026-05-01', flex: 'flexible',
+      }),
+    );
   });
 });

--- a/tests/tui/screens.test.tsx
+++ b/tests/tui/screens.test.tsx
@@ -269,6 +269,110 @@ describe('Dashboard', () => {
     expect(onNavigate).toHaveBeenCalledWith('trends');
   });
 
+  // Outbound drill payloads carry the period (range + anchor=from) so the
+  // dashboard can restore the same month when Esc reverses the drill. The
+  // Transactions-side tests check the return trip; these pin the originating
+  // payloads so a regression on the Dashboard side can't pass silently.
+  it('category drill outbound payload carries range + anchor', async () => {
+    const onNavigate = vi.fn();
+    const r = render(
+      <W>
+        <FilterProvider>
+          <Dashboard onNavigate={onNavigate} showHints={false} initialFilter={MAY_FILTER} />
+        </FilterProvider>
+      </W>,
+    );
+    await waitFor(() => expect(frame(r)).toContain('Grocery'));
+    r.stdin.write('\r'); // Enter on top category (Grocery)
+    await waitFor(() =>
+      expect(onNavigate).toHaveBeenCalledWith('transactions', expect.objectContaining({
+        from: '2026-05-01', to: '2026-05-31', range: 'month', anchor: '2026-05-01', drillFrom: 'dashboard',
+      })),
+    );
+  });
+
+  it('flex drill outbound payload carries range + anchor', async () => {
+    const onNavigate = vi.fn();
+    const r = render(
+      <W>
+        <FilterProvider>
+          <Dashboard onNavigate={onNavigate} showHints={false} initialFilter={MAY_FILTER} />
+        </FilterProvider>
+      </W>,
+    );
+    await waitFor(() => expect(frame(r)).toContain('Grocery'));
+    r.stdin.write('\t'); // → flex view
+    await waitFor(() => expect(frame(r)).toContain('SPENDING BY FLEXIBILITY'));
+    r.stdin.write('\r');
+    // No selectedAccount → no drillFrom, but range/anchor still travel.
+    await waitFor(() =>
+      expect(onNavigate).toHaveBeenCalledWith('transactions', expect.objectContaining({
+        from: '2026-05-01', to: '2026-05-31', range: 'month', anchor: '2026-05-01',
+      })),
+    );
+  });
+
+  it('account drill outbound payload carries range + anchor', async () => {
+    const onNavigate = vi.fn();
+    const r = render(
+      <W>
+        <FilterProvider>
+          <Dashboard onNavigate={onNavigate} showHints={false} initialFilter={MAY_FILTER} />
+        </FilterProvider>
+      </W>,
+    );
+    await waitFor(() => expect(frame(r)).toContain('Grocery'));
+    r.stdin.write('\t'); // flex
+    r.stdin.write('\t'); // account
+    await waitFor(() => expect(frame(r)).toContain('Test Checking'));
+    r.stdin.write('\r');
+    await waitFor(() =>
+      expect(onNavigate).toHaveBeenCalledWith('transactions', expect.objectContaining({
+        from: '2026-05-01', to: '2026-05-31', range: 'month', anchor: '2026-05-01', drillFrom: 'dashboard',
+      })),
+    );
+  });
+
+  it('merchant drill outbound payload carries range + anchor=merchantDrill.from', async () => {
+    const onNavigate = vi.fn();
+    const r = render(
+      <W>
+        <FilterProvider>
+          <Dashboard onNavigate={onNavigate} showHints={false} initialFilter={MAY_FILTER} />
+        </FilterProvider>
+      </W>,
+    );
+    await waitFor(() => expect(frame(r)).toContain('Grocery'));
+    r.stdin.write('m');
+    await waitFor(() => expect(frame(r)).toContain('Whole Foods'));
+    r.stdin.write('\r');
+    // The merchant drill site uniquely sources `anchor` from merchantDrill.from
+    // (the captured drill date) rather than the dashboard's current `from` —
+    // both land on '2026-05-01' here, but the variant is exercised.
+    await waitFor(() =>
+      expect(onNavigate).toHaveBeenCalledWith('transactions', expect.objectContaining({
+        from: '2026-05-01', to: '2026-05-31', range: 'month', anchor: '2026-05-01',
+        search: 'Whole Foods', drillFrom: 'dashboard',
+      })),
+    );
+  });
+
+  it("'2' shortcut outbound payload carries range + anchor", async () => {
+    const onNavigate = vi.fn();
+    const r = render(
+      <W>
+        <FilterProvider>
+          <Dashboard onNavigate={onNavigate} showHints={false} initialFilter={MAY_FILTER} />
+        </FilterProvider>
+      </W>,
+    );
+    await waitFor(() => expect(frame(r)).toContain('Grocery'));
+    r.stdin.write('2');
+    expect(onNavigate).toHaveBeenCalledWith('transactions', expect.objectContaining({
+      from: '2026-05-01', to: '2026-05-31', range: 'month', anchor: '2026-05-01',
+    }));
+  });
+
   it('shows period label for the anchored month', async () => {
     const r = dash();
     await waitFor(() => {


### PR DESCRIPTION
## Summary

Follow-up to #83. That PR fixes Esc preserving the dashboard month by threading `range` + `anchor` through every Dashboard drill site, but the tests only assert the *return* trip (Transactions → Dashboard). The six outbound drill sites had no direct coverage, so a regression on the Dashboard side would pass silently.

These tests pin the outbound payload for each site:

- **TUI Dashboard** (`tests/tui/screens.test.tsx`): category, flex, account, merchant, and `2`-shortcut drills
- **GUI Dashboard** (`tests/gui/dashboard.test.tsx`): extended the existing category-click test to assert `range, anchor`; added a flex-tier click test for the no-`selectedAccount` path

The merchant drill gets its own assertion because it's the only site sourcing `anchor` from `merchantDrill.from` rather than the dashboard's current period `from`.

## Test plan
- [x] `npx vitest run` — 636 / 636 passing locally
- [x] Each test uses `expect.objectContaining({ range, anchor })`, so dropping either field at any of the six call sites will fail the corresponding assertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)