### PR TITLE
fix: surface Uncategorized spending on the dashboard by separating uncategorized expenses from uncategorized income

### DIFF
--- a/core/queries.ts
+++ b/core/queries.ts
@@ -12,6 +12,35 @@ export type MerchantSummaryRow = {
   pct: number;
 };
 
+// The catch-all category. Unlike a real category, it legitimately mixes income
+// (e.g. an un-ruled paycheck) with spending, so we never net the two together —
+// see summarizeBuckets.
+const UNCATEGORIZED = 'Uncategorized';
+
+/**
+ * Turn per-category {outflow, inflow} buckets into an income/expense/byCategory
+ * summary. Real categories are NETTED (a refund reduces that category's spending);
+ * `Uncategorized` is SPLIT by flow (its outflows are spending, its inflows income)
+ * so a paycheck landing there can't erase the uncategorized spending total.
+ */
+function summarizeBuckets(rows: { category: string; outflow: number; inflow: number }[]): MonthlySummary {
+  let income = 0, expenses = 0;
+  const byCategory: CategorySummary[] = [];
+  for (const r of rows) {
+    const outflow = Number(r.outflow), inflow = Number(r.inflow);
+    if (r.category === UNCATEGORIZED) {
+      if (outflow > 0) { expenses += outflow; byCategory.push({ category: r.category, total: outflow }); }
+      income += inflow;
+    } else {
+      const net = outflow - inflow;
+      if (net > 0) { expenses += net; byCategory.push({ category: r.category, total: net }); }
+      else income += -net;
+    }
+  }
+  byCategory.sort((a, b) => b.total - a.total);
+  return { income, expenses, net: income - expenses, byCategory };
+}
+
 export async function getHiddenCategories(): Promise<Set<string>> {
   const result = await db.execute('SELECT category FROM hidden_categories');
   return new Set((result.rows as unknown as { category: string }[]).map((r) => r.category));
@@ -26,36 +55,32 @@ export async function getMonthlySummary(year: number, month: number): Promise<Mo
 export async function getRangeSummary(from: string, to: string, filter?: Filter): Promise<MonthlySummary> {
   const f = buildFilterClause(filter, 'transactions');
   const result = await db.execute({
-    sql: `SELECT category, SUM(amount) as total
+    sql: `SELECT category,
+            SUM(CASE WHEN amount > 0 THEN amount ELSE 0 END) as outflow,
+            SUM(CASE WHEN amount < 0 THEN -amount ELSE 0 END) as inflow
           FROM transactions
           WHERE date >= ? AND date <= ? AND pending = 0 AND ignored = 0${f.clause}
             AND category NOT IN (SELECT category FROM hidden_categories)
-          GROUP BY category ORDER BY total DESC`,
+          GROUP BY category`,
     args: [from, to, ...f.args],
   });
-  const rows = result.rows as unknown as { category: string; total: number }[];
-  const income   = rows.filter((r) => r.total < 0).reduce((s, r) => s + Math.abs(r.total), 0);
-  const expenses = rows.filter((r) => r.total > 0).reduce((s, r) => s + r.total, 0);
-  const byCategory = rows.filter((r) => r.total > 0).map((r) => ({ category: r.category, total: Number(r.total) }));
-  return { income, expenses, net: income - expenses, byCategory };
+  return summarizeBuckets(result.rows as unknown as { category: string; outflow: number; inflow: number }[]);
 }
 
 export async function getTagSummary(tagName: string): Promise<MonthlySummary> {
   const result = await db.execute({
-    sql: `SELECT t.category, SUM(t.amount) as total
+    sql: `SELECT t.category,
+            SUM(CASE WHEN t.amount > 0 THEN t.amount ELSE 0 END) as outflow,
+            SUM(CASE WHEN t.amount < 0 THEN -t.amount ELSE 0 END) as inflow
           FROM transactions t
           JOIN transaction_tags tt ON tt.transaction_id = t.id
           JOIN tags tg ON tg.id = tt.tag_id
           WHERE tg.name = ? AND t.ignored = 0
             AND t.category NOT IN (SELECT category FROM hidden_categories)
-          GROUP BY t.category ORDER BY total DESC`,
+          GROUP BY t.category`,
     args: [tagName],
   });
-  const rows = result.rows as unknown as { category: string; total: number }[];
-  const income     = rows.filter((r) => r.total < 0).reduce((s, r) => s + Math.abs(r.total), 0);
-  const expenses   = rows.filter((r) => r.total > 0).reduce((s, r) => s + r.total, 0);
-  const byCategory = rows.filter((r) => r.total > 0).map((r) => ({ category: r.category, total: Number(r.total) }));
-  return { income, expenses, net: income - expenses, byCategory };
+  return summarizeBuckets(result.rows as unknown as { category: string; outflow: number; inflow: number }[]);
 }
 
 export async function getMerchantSummary(
@@ -195,40 +220,47 @@ type Window = { from: string; to: string };
 
 async function queryCategoryTotals(from: string, to: string, filter?: Filter): Promise<Map<string, number>> {
   const f = buildFilterClause(filter, 'transactions');
+  // Per-category spending using the same rule as getRangeSummary (net real
+  // categories, split Uncategorized) so delta mode reconciles with the breakdown.
   const result = await db.execute({
-    sql: `SELECT category, SUM(amount) as total
+    sql: `SELECT category,
+            SUM(CASE WHEN amount > 0 THEN amount ELSE 0 END) as outflow,
+            SUM(CASE WHEN amount < 0 THEN -amount ELSE 0 END) as inflow
           FROM transactions
-          WHERE date >= ? AND date <= ?
-            AND amount > 0 AND pending = 0 AND ignored = 0
+          WHERE date >= ? AND date <= ? AND pending = 0 AND ignored = 0
             AND category NOT IN (SELECT category FROM hidden_categories)${f.clause}
-          GROUP BY category HAVING SUM(amount) > 0`,
+          GROUP BY category`,
     args: [from, to, ...f.args],
   });
-  const rows = result.rows as unknown as { category: string; total: number }[];
-  return new Map(rows.map((r) => [r.category, Number(r.total)]));
+  const { byCategory } = summarizeBuckets(result.rows as unknown as { category: string; outflow: number; inflow: number }[]);
+  return new Map(byCategory.map((c) => [c.category, c.total]));
 }
 
 async function queryFlexTotals(from: string, to: string, filter?: Filter): Promise<FlexSummary> {
   const f = buildFilterClause(filter, 't');
+  // Per-category outflow/inflow + its flex tier; spending is netted for real
+  // categories and outflow-only for Uncategorized (same rule as summarizeBuckets),
+  // then summed into tiers. Uncategorized has no flexibility, so it lands in 'untagged'.
   const result = await db.execute({
-    sql: `SELECT COALESCE(c.flexibility, 'untagged') as tier, SUM(cat_totals.total) as total
-          FROM (
-            SELECT t.category, SUM(t.amount) as total
-            FROM transactions t
-            WHERE t.date >= ? AND t.date <= ?
-              AND t.pending = 0 AND t.ignored = 0
-              AND t.category NOT IN (SELECT category FROM hidden_categories)${f.clause}
-            GROUP BY t.category HAVING SUM(t.amount) > 0
-          ) as cat_totals
-          LEFT JOIN categories c ON c.name = cat_totals.category
-          GROUP BY tier`,
+    sql: `SELECT t.category, COALESCE(c.flexibility, 'untagged') as tier,
+            SUM(CASE WHEN t.amount > 0 THEN t.amount ELSE 0 END) as outflow,
+            SUM(CASE WHEN t.amount < 0 THEN -t.amount ELSE 0 END) as inflow
+          FROM transactions t
+          LEFT JOIN categories c ON c.name = t.category
+          WHERE t.date >= ? AND t.date <= ?
+            AND t.pending = 0 AND t.ignored = 0
+            AND t.category NOT IN (SELECT category FROM hidden_categories)${f.clause}
+          GROUP BY t.category, c.flexibility`,
     args: [from, to, ...f.args],
   });
-  const rows = result.rows as unknown as { tier: string; total: number }[];
+  const rows = result.rows as unknown as { category: string; tier: string; outflow: number; inflow: number }[];
   const out: FlexSummary = { fixed: 0, flexible: 0, discretionary: 0, untagged: 0 };
   for (const r of rows) {
-    const t = r.tier as keyof FlexSummary;
-    if (t in out) out[t] = Number(r.total);
+    const outflow = Number(r.outflow), inflow = Number(r.inflow);
+    const spend = r.category === UNCATEGORIZED ? outflow : outflow - inflow;
+    if (spend <= 0) continue;
+    const tier = r.tier as keyof FlexSummary;
+    if (tier in out) out[tier] += spend;
   }
   return out;
 }
@@ -326,27 +358,36 @@ export async function getSearchFilteredData(
   const re = buildSearchRe(search);
   const matches = rows.filter((r) => re.test(r.display) || (r.merchant_name ? re.test(r.merchant_name) : false));
 
-  const catMap = new Map<string, { total: number; flex: string }>();
+  // Accumulate per-category outflow/inflow, then apply the hybrid rule: real
+  // categories net (refunds reduce them), Uncategorized splits by flow (outflow =
+  // spending, inflow = income). Mirrors summarizeBuckets / queryFlexTotals.
+  const catMap = new Map<string, { outflow: number; inflow: number; flex: string }>();
   for (const r of matches) {
-    const e = catMap.get(r.category);
-    if (!e) catMap.set(r.category, { total: Number(r.amount), flex: r.flex });
-    else e.total += Number(r.amount);
+    const amt = Number(r.amount);
+    const e = catMap.get(r.category) ?? { outflow: 0, inflow: 0, flex: r.flex };
+    if (amt > 0) e.outflow += amt;
+    else if (amt < 0) e.inflow += -amt;
+    catMap.set(r.category, e);
   }
 
   let income = 0, expenses = 0;
   const byCategory: { category: string; total: number }[] = [];
   const flexData: FlexSummary = { fixed: 0, flexible: 0, discretionary: 0, untagged: 0 };
-
-  for (const [category, { total, flex }] of catMap) {
-    if (total < 0) { income += Math.abs(total); }
-    else if (total > 0) {
-      expenses += total;
-      byCategory.push({ category, total });
-      if (flex === 'fixed') flexData.fixed += total;
-      else if (flex === 'flexible') flexData.flexible += total;
-      else if (flex === 'discretionary') flexData.discretionary += total;
-      else flexData.untagged += total;
+  for (const [category, { outflow, inflow, flex }] of catMap) {
+    let spend: number;
+    if (category === UNCATEGORIZED) { spend = outflow; income += inflow; }
+    else {
+      const net = outflow - inflow;
+      if (net < 0) { income += -net; continue; }
+      spend = net;
     }
+    if (spend <= 0) continue;
+    expenses += spend;
+    byCategory.push({ category, total: spend });
+    if (flex === 'fixed') flexData.fixed += spend;
+    else if (flex === 'flexible') flexData.flexible += spend;
+    else if (flex === 'discretionary') flexData.discretionary += spend;
+    else flexData.untagged += spend;
   }
 
   byCategory.sort((a, b) => b.total - a.total);

--- a/tests/drift.test.ts
+++ b/tests/drift.test.ts
@@ -205,6 +205,22 @@ describe('getCategoryDriftData', () => {
     expect(row.lastPeriodDelta).toBeCloseTo(100);
   });
 
+  it('nets refunds within a real category (consistent with the breakdown)', async () => {
+    await insertTx({ date: '2026-05-15', amount: 300, category: 'Travel' });
+    await insertTx({ date: '2026-05-16', amount: -100, category: 'Travel' });
+    const result = await getCategoryDriftData(current, lastPeriod, lastYear, rolling12);
+    const row = result.find((r) => r.category === 'Travel')!;
+    expect(row.current).toBeCloseTo(200);
+  });
+
+  it('uses Uncategorized outflow only, ignoring inflows', async () => {
+    await insertTx({ date: '2026-05-15', amount: 500, category: 'Uncategorized' });
+    await insertTx({ date: '2026-05-16', amount: -2000, category: 'Uncategorized' });
+    const result = await getCategoryDriftData(current, lastPeriod, lastYear, rolling12);
+    const row = result.find((r) => r.category === 'Uncategorized')!;
+    expect(row.current).toBeCloseTo(500);
+  });
+
   it('avg12m is average of rolling12 totals', async () => {
     const months = ['2026-04','2026-03','2026-02','2026-01','2025-12','2025-11',
                     '2025-10','2025-09','2025-08','2025-07','2025-06','2025-05'];

--- a/tests/gui/dashboard.test.tsx
+++ b/tests/gui/dashboard.test.tsx
@@ -75,4 +75,39 @@ describe('GUI Dashboard', () => {
       }),
     );
   });
+
+  it('Spending by category rows sum to the displayed Expenses total', async () => {
+    // Exercise the two cases that used to break reconciliation: a refund inside a
+    // real category (must NET to 200) and an income+spend mix inside Uncategorized
+    // (must SPLIT — the $500 spend shows, the $2000 inflow is income, not netted away).
+    await db.batch([
+      `INSERT INTO transactions (id, account_id, date, name, amount, category, pending, ignored)
+       VALUES ('tx-travel',        'test-credit',   '2026-05-04', 'United',        300.00, 'Travel', 0, 0)`,
+      `INSERT INTO transactions (id, account_id, date, name, amount, category, pending, ignored)
+       VALUES ('tx-travel-refund', 'test-credit',   '2026-05-05', 'United Refund', -100.00, 'Travel', 0, 0)`,
+      `INSERT INTO transactions (id, account_id, date, name, amount, category, pending, ignored)
+       VALUES ('tx-uncat-spend',   'test-credit',   '2026-05-07', 'Mystery Shop',  500.00, 'Uncategorized', 0, 0)`,
+      `INSERT INTO transactions (id, account_id, date, name, amount, category, pending, ignored)
+       VALUES ('tx-uncat-income',  'test-checking', '2026-05-02', 'Side Gig',     -2000.00, 'Uncategorized', 0, 0)`,
+    ], 'write');
+
+    renderScreen(<Dashboard />, { txFilter: MAY_FILTER });
+    await waitFor(() => expect(screen.getByText('Grocery')).toBeTruthy());
+
+    const parse = (t: string | null) => parseFloat((t ?? '').replace(/[^0-9.-]/g, ''));
+
+    // Expenses card: its label's card holds the value in a `.num` element.
+    const expensesCard = screen.getByText('Expenses').parentElement!;
+    const expenses = parse(expensesCard.querySelector('.num')!.textContent);
+
+    // Category rows: each row's amount cell is the global `td.num`.
+    const section = screen.getByText('Spending by category').closest('section')!;
+    expect(section.textContent).toContain('Uncategorized'); // the spend row must be present
+    const categoryTotal = [...section.querySelectorAll('tbody tr')]
+      .map((tr) => parse(tr.querySelector('td.num')!.textContent))
+      .reduce((sum, n) => sum + n, 0);
+
+    expect(expenses).toBeCloseTo(1088.99, 2);          // 388.99 seeded + 200 net Travel + 500 uncat
+    expect(categoryTotal).toBeCloseTo(expenses, 2);    // detailed lines reconcile to the total
+  });
 });

--- a/tests/queries.test.ts
+++ b/tests/queries.test.ts
@@ -120,23 +120,35 @@ describe('getRangeSummary', () => {
     expect(s.expenses).toBeCloseTo(100);
   });
 
-  it('nets refunds within a category before classifying as income/expense', async () => {
+  it('nets refunds within a real category before classifying as income/expense', async () => {
     await insertTx({ amount: 1000, category: 'Travel' });
     await insertTx({ amount: -800, category: 'Travel' });
     const s = await getRangeSummary('2025-01-01', '2025-01-31');
     expect(s.expenses).toBeCloseTo(200);
     expect(s.income).toBe(0);
-    expect(s.byCategory).toHaveLength(1);
-    expect(s.byCategory[0]).toEqual({ category: 'Travel', total: 200 });
+    expect(s.byCategory).toEqual([{ category: 'Travel', total: 200 }]);
   });
 
-  it('categories with net negative total count as income', async () => {
+  it('real categories with a net negative total count as income (not spending)', async () => {
     await insertTx({ amount: 100, category: 'Rewards' });
     await insertTx({ amount: -200, category: 'Rewards' });
     const s = await getRangeSummary('2025-01-01', '2025-01-31');
     expect(s.income).toBeCloseTo(100);
     expect(s.expenses).toBe(0);
     expect(s.byCategory).toHaveLength(0);
+  });
+
+  it('does NOT net Uncategorized: splits its outflows (spending) from inflows (income)', async () => {
+    // Regression: a paycheck landing in the Uncategorized catch-all used to net the
+    // bucket negative, hiding all uncategorized spending from byCategory. Uncategorized
+    // is split by flow; the spending row stays labeled "Uncategorized".
+    await insertTx({ amount: 1850, category: 'Uncategorized', name: 'Rent Payment' });
+    await insertTx({ amount: 63.8, category: 'Uncategorized', name: 'Whole Foods Market' });
+    await insertTx({ amount: -4200, category: 'Uncategorized', name: 'Direct Deposit' });
+    const s = await getRangeSummary('2025-01-01', '2025-01-31');
+    expect(s.expenses).toBeCloseTo(1913.8);
+    expect(s.income).toBeCloseTo(4200);
+    expect(s.byCategory).toEqual([{ category: 'Uncategorized', total: 1913.8 }]);
   });
 
   it('aggregates multiple categories correctly', async () => {
@@ -190,7 +202,7 @@ describe('getFlexSummary', () => {
     expect(s.untagged).toBeCloseTo(125);
   });
 
-  it('nets out refunds before bucketing — no tier inflation (regression)', async () => {
+  it('nets out refunds in a real category before bucketing — no tier inflation (regression)', async () => {
     await insertCat('Travel', 'discretionary');
     await insertTx({ amount: 10000, category: 'Travel' });
     await insertTx({ amount: -8000, category: 'Travel' });
@@ -200,12 +212,21 @@ describe('getFlexSummary', () => {
     expect(s.flexible).toBe(0);
   });
 
-  it('excludes categories where net is negative (refund-heavy categories)', async () => {
+  it('excludes a real category whose net is negative (refund-heavy)', async () => {
     await insertCat('Travel', 'discretionary');
     await insertTx({ amount: 100, category: 'Travel' });
     await insertTx({ amount: -500, category: 'Travel' });
     const s = await getFlexSummary('2025-01-01', '2025-01-31');
     expect(s.discretionary).toBe(0);
+  });
+
+  it('buckets Uncategorized outflow into untagged even when it holds a larger inflow', async () => {
+    // Uncategorized has no flexibility tag → untagged tier; its spending must show
+    // even though the bucket nets negative from an inflow (e.g. a paycheck).
+    await insertTx({ amount: 200, category: 'Uncategorized' });
+    await insertTx({ amount: -5000, category: 'Uncategorized' });
+    const s = await getFlexSummary('2025-01-01', '2025-01-31');
+    expect(s.untagged).toBeCloseTo(200);
   });
 
   it('fixed + flexible + discretionary + untagged == total expenses', async () => {

--- a/tests/tui/screens.test.tsx
+++ b/tests/tui/screens.test.tsx
@@ -123,6 +123,35 @@ describe('Dashboard', () => {
     await waitFor(() => expect(frame(r)).toContain('SPENDING BY CATEGORY'));
   });
 
+  it('SPENDING BY CATEGORY lines sum to the displayed Expenses total', async () => {
+    // Exercise the two cases that used to break reconciliation: a refund inside a
+    // real category (must NET to 200, not show 300) and an income+spend mix inside
+    // Uncategorized (must SPLIT — the $500 spend shows, the $2000 inflow is income).
+    await db.batch([
+      `INSERT INTO transactions (id, account_id, date, name, amount, category, pending, ignored)
+       VALUES ('tx-travel',        'test-credit',   '2026-05-04', 'United',        300.00, 'Travel', 0, 0)`,
+      `INSERT INTO transactions (id, account_id, date, name, amount, category, pending, ignored)
+       VALUES ('tx-travel-refund', 'test-credit',   '2026-05-05', 'United Refund', -100.00, 'Travel', 0, 0)`,
+      `INSERT INTO transactions (id, account_id, date, name, amount, category, pending, ignored)
+       VALUES ('tx-uncat-spend',   'test-credit',   '2026-05-07', 'Mystery Shop',  500.00, 'Uncategorized', 0, 0)`,
+      `INSERT INTO transactions (id, account_id, date, name, amount, category, pending, ignored)
+       VALUES ('tx-uncat-income',  'test-checking', '2026-05-02', 'Side Gig',     -2000.00, 'Uncategorized', 0, 0)`,
+    ], 'write');
+
+    const r = dash();
+    await waitFor(() => expect(frame(r)).toContain('Uncategorized'));
+
+    const [statRegion, catRegion] = frame(r).split('SPENDING BY CATEGORY');
+    const money = (s: string) =>
+      [...s.matchAll(/[-+]?\$[\d,]+\.\d{2}/g)].map((m) => parseFloat(m[0].replace(/[$,+]/g, '')));
+    // Stat cards render in order Income · Expenses · Net, so Expenses is the 2nd $ token.
+    const expenses = money(statRegion)[1];
+    const categoryTotal = money(catRegion).reduce((sum, n) => sum + n, 0);
+
+    expect(expenses).toBeCloseTo(1088.99, 2);          // 388.99 seeded + 200 net Travel + 500 uncat
+    expect(categoryTotal).toBeCloseTo(expenses, 2);    // detailed lines reconcile to the total
+  });
+
   it('Tab cycles to flex view', async () => {
     const r = dash();
     await waitFor(() => expect(frame(r)).toContain('Income'));


### PR DESCRIPTION
getRangeSummary netted income against expenses per category, so the Uncategorized catch-all — which mixes an un-ruled paycheck with real spending — collapsed to a negative total and was dropped from "spending by category" entirely, also understating headline Income/Expenses.

Use a hybrid rule (in a shared summarizeBuckets helper): net real categories so refunds still reduce them, but split Uncategorized by flow (outflows are spending, inflows are income). Applied consistently across getRangeSummary, getTagSummary, queryFlexTotals, getSearchFilteredData, and queryCategoryTotals (delta mode), so every view reconciles. Net is unchanged.

Tests: range/flex behavior, delta-mode alignment, and TUI+GUI dashboard reconciliation invariants (category lines sum to the Expenses total).