### PR TITLE
fix: re-evaluate transactions when a category rule is deleted

### DIFF
--- a/core/rules.ts
+++ b/core/rules.ts
@@ -28,8 +28,9 @@ export async function getUncategorizedCount(): Promise<number> {
   return Number((result.rows[0] as unknown as { c: number }).c);
 }
 
-export async function deleteCategoryRule(id: number): Promise<void> {
+export async function deleteCategoryRule(id: number): Promise<number> {
   await db.execute({ sql: 'DELETE FROM category_rules WHERE id = ?', args: [id] });
+  return applyAll();
 }
 
 export async function deleteNameRule(id: number): Promise<void> {

--- a/gui/renderer/src/screens/Rules.tsx
+++ b/gui/renderer/src/screens/Rules.tsx
@@ -136,8 +136,8 @@ export function Rules() {
                         className={`${styles.rowBtn} ${styles.rowBtnDanger}`}
                         onClick={async (e) => {
                           e.stopPropagation();
-                          await api.rules.deleteCategoryRule(r.id);
-                          showStatus('Rule deleted');
+                          const count = await api.rules.deleteCategoryRule(r.id);
+                          showStatus(`Rule deleted · recategorized ${count} transaction${count === 1 ? '' : 's'}`, 3000);
                           reload();
                         }}
                       >

--- a/tests/gui/rules.test.tsx
+++ b/tests/gui/rules.test.tsx
@@ -52,7 +52,7 @@ describe('GUI Rules', () => {
     await waitFor(() => expect(screen.getByText('Whole Foods')).toBeTruthy());
     const row = screen.getByText('Whole Foods').closest('tr')!;
     await userEvent.click(Array.from(row.querySelectorAll('button')).find((b) => b.textContent === 'delete')!);
-    await waitFor(() => expect(screen.getByText('Rule deleted')).toBeTruthy());
+    await waitFor(() => expect(screen.getByText(/Rule deleted · recategorized \d+ transactions?/)).toBeTruthy());
     expect(screen.getByRole('button', { name: 'Category rules (0)' })).toBeTruthy();
   });
 

--- a/tests/rules.test.ts
+++ b/tests/rules.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('../core/db.js', async () => {
+  const { makeTestDb } = await import('./helpers/makeTestDb.js');
+  return { db: await makeTestDb() };
+});
+
+import { db } from '../core/db.js';
+import { deleteCategoryRule, saveCategoryRule } from '../core/rules.js';
+
+let txId = 0;
+async function insertTx(name: string, manual_category?: string) {
+  txId++;
+  const id = `tx${txId}`;
+  await db.execute({
+    sql: `INSERT INTO transactions (id, account_id, date, name, amount, category, manual_category, pending, ignored)
+          VALUES (?, 'a', '2025-01-01', ?, 10, 'Uncategorized', ?, 0, 0)`,
+    args: [id, name, manual_category ?? null],
+  });
+  return id;
+}
+
+async function categoryOf(id: string) {
+  const row = (await db.execute({ sql: 'SELECT category FROM transactions WHERE id = ?', args: [id] }))
+    .rows[0] as unknown as { category: string };
+  return row.category;
+}
+
+async function ruleIdFor(pattern: string) {
+  const row = (await db.execute({ sql: 'SELECT id FROM category_rules WHERE pattern = ?', args: [pattern] }))
+    .rows[0] as unknown as { id: number };
+  return row.id;
+}
+
+beforeEach(async () => {
+  txId = 0;
+  await db.execute('DELETE FROM category_rules');
+  await db.execute('DELETE FROM transactions');
+});
+
+describe('deleteCategoryRule re-evaluates transactions', () => {
+  it('reverts a transaction to Uncategorized when its only matching rule is deleted', async () => {
+    const id = await insertTx('Spotify');
+    await saveCategoryRule({ pattern: 'Spotify', matchType: 'name', category: 'Entertainment', minAmount: null, maxAmount: null });
+    expect(await categoryOf(id)).toBe('Entertainment');
+
+    const count = await deleteCategoryRule(await ruleIdFor('Spotify'));
+    expect(count).toBe(1);
+    expect(await categoryOf(id)).toBe('Uncategorized');
+  });
+
+  it('falls back to a lower-priority rule when the matching rule is deleted', async () => {
+    const id = await insertTx('VENMO PAYMENT');
+    await saveCategoryRule({ pattern: 'venmo', matchType: 'name', category: 'Transfer', minAmount: null, maxAmount: null });
+    // Raise the first rule's priority so it wins, then add a fallback.
+    await db.execute("UPDATE category_rules SET priority = 20 WHERE pattern = 'venmo'");
+    await saveCategoryRule({ pattern: 'payment', matchType: 'name', category: 'Bills & Utilities', minAmount: null, maxAmount: null });
+    expect(await categoryOf(id)).toBe('Transfer');
+
+    await deleteCategoryRule(await ruleIdFor('venmo'));
+    expect(await categoryOf(id)).toBe('Bills & Utilities');
+  });
+
+  it('leaves manually pinned transactions untouched', async () => {
+    const id = await insertTx('Spotify', 'Music');
+    await db.execute({ sql: 'UPDATE transactions SET category = ? WHERE id = ?', args: ['Music', id] });
+    await saveCategoryRule({ pattern: 'Spotify', matchType: 'name', category: 'Entertainment', minAmount: null, maxAmount: null });
+    expect(await categoryOf(id)).toBe('Music');
+
+    const count = await deleteCategoryRule(await ruleIdFor('Spotify'));
+    expect(count).toBe(0);
+    expect(await categoryOf(id)).toBe('Music');
+  });
+});

--- a/tui/Rules.tsx
+++ b/tui/Rules.tsx
@@ -100,9 +100,9 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
 
   useEffect(() => { load(); }, [refreshKey]);
 
-  function handleDeleteRule(id: number) {
-    deleteCategoryRule(id);
-    showStatus('Rule deleted');
+  async function handleDeleteRule(id: number) {
+    const count = await deleteCategoryRule(id);
+    showStatus(`Rule deleted · recategorized ${count} transactions`, 3000);
     load();
   }
 
@@ -181,7 +181,7 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
           setEditingRuleId(null); setNewPattern(''); setNewType('name'); setNewMinAmount(''); setNewMaxAmount(''); setCatCursor(0);
           setRuleField('pattern'); setMode('rule-form');
         }
-        if (input === 'x' && filteredRules[cursor]) { handleDeleteRule(filteredRules[cursor].id); }
+        if (input === 'x' && filteredRules[cursor]) { void handleDeleteRule(filteredRules[cursor].id); }
         if (key.return && filteredRules[cursor]) {
           const r = filteredRules[cursor];
           setEditingRuleId(r.id);


### PR DESCRIPTION
deleteCategoryRule previously only removed the row, leaving transactions with categories assigned by the deleted rule until the next save/sync. It now runs applyAll() like saveCategoryRule, so affected transactions fall back to a lower-priority rule or revert to Uncategorized. The TUI and GUI surface the recategorized count.