### PR TITLE
fix(tui): pluralize "recategorized N transaction(s)" in Rules status

### DIFF
--- a/tests/tui/screens.test.tsx
+++ b/tests/tui/screens.test.tsx
@@ -1359,6 +1359,30 @@ describe('Rules', () => {
     });
   });
 
+  it('[x] deletes the rule and surfaces the recategorized count in the status', async () => {
+    // Self-contained: clear seeded transactions/rules so the count pins to exactly 1.
+    // Mirrors the GUI delete test (tests/gui/rules.test.tsx) and locks the singular
+    // pluralization of the status message ("1 transaction", not "1 transactions").
+    await db.execute('DELETE FROM category_rules');
+    await db.execute('DELETE FROM transactions');
+    await db.execute(
+      `INSERT INTO transactions (id, account_id, date, name, amount, category, pending, ignored)
+       VALUES ('tx-tj', 'test-credit', '2026-05-15', 'Trader Joes', 50.00, 'Grocery', 0, 0)`,
+    );
+    await db.execute(
+      "INSERT INTO category_rules (priority, match_type, pattern, category) VALUES (10, 'name', 'Trader Joes', 'Grocery')",
+    );
+
+    const r = rules();
+    await waitFor(() => expect(frame(r)).toContain('Trader Joes'));
+    r.stdin.write('x');
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).toMatch(/Rule deleted · recategorized 1 transaction\b/); // \b rejects trailing 's'
+      expect(f).not.toContain('Trader Joes'); // rule gone from the list
+    });
+  });
+
   it('[a] in Name Rules section opens new name rule form', async () => {
     const r = rules();
     await waitFor(() => expect(frame(r)).toContain('Category Rules'));

--- a/tui/Rules.tsx
+++ b/tui/Rules.tsx
@@ -102,7 +102,7 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
 
   async function handleDeleteRule(id: number) {
     const count = await deleteCategoryRule(id);
-    showStatus(`Rule deleted · recategorized ${count} transactions`, 3000);
+    showStatus(`Rule deleted · recategorized ${count} transaction${count === 1 ? '' : 's'}`, 3000);
     load();
   }
 
@@ -122,7 +122,7 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
       editingId: editingRuleId,
     });
     setEditingRuleId(null);
-    showStatus(`Rule saved · recategorized ${count} transactions`, 3000);
+    showStatus(`Rule saved · recategorized ${count} transaction${count === 1 ? '' : 's'}`, 3000);
     setNewPattern('');
     setMode('list');
     load();


### PR DESCRIPTION
## Summary

Follow-up to #88/#89.

- **tui Rules plural fix.** TUI hardcoded `transactions` in both the save and delete rule status toasts, so a single-transaction recategorization read "recategorized 1 transactions". The GUI already pluralizes correctly — mirror that conditional.
  - Drive-by: same bug existed pre-#89 in the **save** path (`tui/Rules.tsx:125`); fixed both for consistency since the change is identical.
- **Close the TUI test parity gap from #89.** `tests/gui/rules.test.tsx` covered the delete-rule recategorized-count flow on the GUI side; no equivalent TUI test existed. Adds one to `tests/tui/screens.test.tsx` that seeds exactly one matching transaction — pinning the count to 1 also locks the singular pluralization above as a regression test.

## Test plan

- [x] `npx vitest run tests/tui/screens.test.tsx -t "Rules"` — 13/13 pass, including the new "[x] deletes the rule and surfaces the recategorized count in the status" test
- [ ] Manually trigger a rule save/delete that recategorizes exactly 1 transaction in the TUI → toast reads "recategorized 1 transaction"
- [ ] Same with 0 or 2+ → "recategorized N transactions"
- [ ] GUI tests (`tests/gui/rules.test.tsx`) already use a `transactions?` regex so they continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)