### PR TITLE
fix(tui): preserve cursor on rule when Esc clears search filter

### DIFF
--- a/tests/tui/screens.test.tsx
+++ b/tests/tui/screens.test.tsx
@@ -1359,6 +1359,37 @@ describe('Rules', () => {
     });
   });
 
+  it('Esc from search preserves cursor on the highlighted rule (not the unfiltered top)', async () => {
+    // Regression: pressing Esc in search used to reset cursor to its pre-search
+    // numeric index, so the highlighted (filtered) rule could differ from what
+    // 'x' then deleted. Now the cursor re-anchors to that rule by id.
+    await db.execute('DELETE FROM category_rules');
+    await db.batch([
+      "INSERT INTO category_rules (priority, match_type, pattern, category) VALUES (10, 'name', 'Aaa Coffee', 'Dining')",
+      "INSERT INTO category_rules (priority, match_type, pattern, category) VALUES (10, 'name', 'Bbb Diner',  'Dining')",
+      "INSERT INTO category_rules (priority, match_type, pattern, category) VALUES (10, 'name', 'Zzz Lounge', 'Dining')",
+    ], 'write');
+
+    const r = rules();
+    await waitFor(() => expect(frame(r)).toContain('Aaa Coffee'));
+    r.stdin.write('/');
+    await waitFor(() => expect(frame(r)).toContain('Esc clear')); // search bar visible
+    for (const ch of 'Zzz') r.stdin.write(ch);
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).toContain('Zzz Lounge');
+      expect(f).not.toContain('Aaa Coffee'); // filter is active
+    });
+    r.stdin.write('\x1b');         // Esc clears search
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).toContain('Aaa Coffee'); // full list back
+      // ▶ cursor marker should sit on the Zzz row, not the top.
+      const zzzLine = f.split('\n').find((l) => l.includes('Zzz Lounge'))!;
+      expect(zzzLine.includes('▶')).toBe(true);
+    });
+  });
+
   it('[x] deletes the rule and surfaces the recategorized count in the status', async () => {
     // Self-contained: clear seeded transactions/rules so the count pins to exactly 1.
     // Mirrors the GUI delete test (tests/gui/rules.test.tsx) and locks the singular

--- a/tui/Rules.tsx
+++ b/tui/Rules.tsx
@@ -146,9 +146,28 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
     load();
   }
 
+  // Clearing the search filter shifts which rule sits under a given numeric
+  // cursor index, so re-anchor the cursor to the rule the user was looking at
+  // (by id) — otherwise Esc-then-'x' deletes the wrong rule.
+  function clearSearchPreservingCursor() {
+    if (section === 'rules' && filteredRules[cursor]) {
+      const id = filteredRules[cursor].id;
+      const idx = rules.findIndex((r) => r.id === id);
+      setSearch('');
+      if (idx >= 0) setCursor(idx);
+    } else if (section === 'names' && filteredNameRules[nameCursor]) {
+      const id = filteredNameRules[nameCursor].id;
+      const idx = nameRules.findIndex((r) => r.id === id);
+      setSearch('');
+      if (idx >= 0) setNameCursor(idx);
+    } else {
+      setSearch('');
+    }
+  }
+
   useInput((input, key) => {
     if (mode === 'search') {
-      if (key.escape) { setSearch(''); setMode('list'); return; }
+      if (key.escape) { clearSearchPreservingCursor(); setMode('list'); return; }
       if (key.return) { setMode('list'); return; }
       if (key.backspace || key.delete) { setSearch((s) => s.slice(0, -1)); return; }
       if (input && !key.ctrl && !key.meta) setSearch((s) => s + input);
@@ -158,7 +177,7 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
     if (mode === 'list') {
       if (handleNavKey(input, 'rules', onNavigate)) return;
       if (key.escape) {
-        if (search) { setSearch(''); return; }
+        if (search) { clearSearchPreservingCursor(); return; }
         onNavigate('dashboard');
         return;
       }


### PR DESCRIPTION
## Summary

Follow-up to #91, addressing one of two findings from manual verification.

**Esc-from-search cursor pitfall.** In TUI Rules, pressing Esc to exit the search filter left the numeric cursor index unchanged. So if you typed `/Foo` to find a rule near the bottom, then Esc, the cursor would snap back to whatever index it was at *before* search — usually the top of the list. Hitting `x` would then delete the wrong rule. Now the cursor re-anchors to the rule that was highlighted in the filtered view (by id). Same applied to the name-rules section.

Adds a regression test (`tests/tui/screens.test.tsx`) that seeds three alphabetically-ordered rules, searches for the last one, presses Esc, and verifies the ▶ cursor stays on the right row.

## Not included (and why)

The other verify-finding (`seedDemo` calling `applyAll` to prevent the "recategorized 50 transactions" first-action surprise) doesn't have a clean small fix. The seeded demo rules in `core/seed-rules.ts` have **zero overlap** with the demo transaction names — every common merchant in the demo (Whole Foods, Sweetgreen, Con Edison, Spotify, Verizon, Acme, Amazon, …) has no matching seeded rule. So any real `applyAll` would push ~45 demo txns to Uncategorized, which is worse than the current quirk. Real options are deeper: (a) mark all demo txns `manual_category`-pinned (changes demo behavior — user-added rules wouldn't recategorize demo data), or (b) audit demo rules to match demo merchants. Worth a separate ticket — leaving as-is for now.

## Test plan

- [x] `npx vitest run tests/tui/screens.test.tsx -t "Rules"` → 14/14 pass, including the new regression
- [ ] Manual: launch TUI on a throwaway dir, navigate to Rules, `/Ramen`, Esc, observe ▶ stays on Ramen Nagi row

🤖 Generated with [Claude Code](https://claude.com/claude-code)