### PR TITLE
feat(mcp): show excluded accounts to the agent as a carved-out section

### DIFF
--- a/core/agent-context.ts
+++ b/core/agent-context.ts
@@ -20,7 +20,6 @@ export type AccountWithBalance = {
   balance: number;
   isAsset: boolean;
   isLiability: boolean;
-  excluded: boolean;
 };
 
 export type BalanceSummary = {
@@ -86,20 +85,19 @@ export async function getBalances(): Promise<BalanceSummary> {
       END,
       bh.balance DESC
   `);
-  const rows = result.rows as unknown as (Omit<AccountWithBalance, 'isAsset' | 'isLiability' | 'excluded'> & { excluded: number })[];
+  const rows = result.rows as unknown as (Omit<AccountWithBalance, 'isAsset' | 'isLiability'> & { excluded: number })[];
 
-  const all: AccountWithBalance[] = rows.map((r) => ({
+  const toAccount = ({ excluded: _excluded, ...r }: typeof rows[number]): AccountWithBalance => ({
     ...r,
     balance: Number(r.balance),
     isAsset: isAssetAccount({ type: r.type, balance: Number(r.balance) }),
     isLiability: isLiabilityAccount(r),
-    excluded: Number(r.excluded) === 1,
-  }));
+  });
 
   // Net-worth totals are computed on the included set; excluded accounts stay
   // visible (carved-out section in the UI and MCP) but never affect the totals.
-  const accounts = all.filter((a) => !a.excluded);
-  const excludedAccounts = all.filter((a) => a.excluded);
+  const accounts = rows.filter((r) => r.excluded !== 1).map(toAccount);
+  const excludedAccounts = rows.filter((r) => r.excluded === 1).map(toAccount);
 
   const totalAssets = accounts
     .filter((a) => a.isAsset)

--- a/core/agent-context.ts
+++ b/core/agent-context.ts
@@ -20,10 +20,12 @@ export type AccountWithBalance = {
   balance: number;
   isAsset: boolean;
   isLiability: boolean;
+  excluded: boolean;
 };
 
 export type BalanceSummary = {
-  accounts: AccountWithBalance[];
+  accounts: AccountWithBalance[];          // counted toward net worth
+  excludedAccounts: AccountWithBalance[];  // visible but excluded from net worth
   totalAssets: number;
   totalLiabilities: number;
   netWorth: number;
@@ -69,12 +71,11 @@ export async function getBalances(): Promise<BalanceSummary> {
     SELECT
       a.id, COALESCE(a.nickname, a.name) as name, a.type, a.subtype,
       a.institution_name as institution,
-      a.mask,
+      a.mask, a.excluded,
       bh.balance
     FROM accounts a
     JOIN balance_history bh ON bh.account_id = a.id
-    WHERE a.excluded = 0
-      AND bh.date = (SELECT MAX(date) FROM balance_history WHERE account_id = a.id)
+    WHERE bh.date = (SELECT MAX(date) FROM balance_history WHERE account_id = a.id)
     ORDER BY
       CASE a.type
         WHEN 'depository'  THEN 0
@@ -85,14 +86,20 @@ export async function getBalances(): Promise<BalanceSummary> {
       END,
       bh.balance DESC
   `);
-  const rows = result.rows as unknown as (Omit<AccountWithBalance, 'isAsset' | 'isLiability'>)[];
+  const rows = result.rows as unknown as (Omit<AccountWithBalance, 'isAsset' | 'isLiability' | 'excluded'> & { excluded: number })[];
 
-  const accounts: AccountWithBalance[] = rows.map((r) => ({
+  const all: AccountWithBalance[] = rows.map((r) => ({
     ...r,
     balance: Number(r.balance),
     isAsset: isAssetAccount({ type: r.type, balance: Number(r.balance) }),
     isLiability: isLiabilityAccount(r),
+    excluded: Number(r.excluded) === 1,
   }));
+
+  // Net-worth totals are computed on the included set; excluded accounts stay
+  // visible (carved-out section in the UI and MCP) but never affect the totals.
+  const accounts = all.filter((a) => !a.excluded);
+  const excludedAccounts = all.filter((a) => a.excluded);
 
   const totalAssets = accounts
     .filter((a) => a.isAsset)
@@ -126,6 +133,7 @@ export async function getBalances(): Promise<BalanceSummary> {
 
   return {
     accounts,
+    excludedAccounts,
     totalAssets,
     totalLiabilities,
     netWorth: totalAssets - totalLiabilities,

--- a/core/tools.ts
+++ b/core/tools.ts
@@ -520,18 +520,21 @@ async function executeToolImpl(
 
     case 'list_accounts': {
       const result = await db.execute(
-        'SELECT COALESCE(nickname, name) as name, type, subtype, mask, institution_name FROM accounts'
+        'SELECT COALESCE(nickname, name) as name, type, subtype, mask, institution_name, excluded FROM accounts'
       );
       const rows = result.rows as unknown as {
-        name: string; type: string; subtype: string; mask: string | null; institution_name: string | null;
+        name: string; type: string; subtype: string; mask: string | null; institution_name: string | null; excluded: number;
       }[];
       if (!rows.length) return 'No accounts connected.';
-      return rows.map((a) => `${a.name} (${a.subtype ?? a.type}) ···${a.mask ?? '?'} — ${a.institution_name ?? 'Unknown'}`).join('\n');
+      return rows.map((a) =>
+        `${a.name} (${a.subtype ?? a.type}) ···${a.mask ?? '?'} — ${a.institution_name ?? 'Unknown'}`
+        + (Number(a.excluded) === 1 ? ' · excluded from net worth' : '')
+      ).join('\n');
     }
 
     case 'get_balances': {
       const b = await getBalances();
-      if (!b.accounts.length) return 'No balance data available. Sync accounts first.';
+      if (!b.accounts.length && !b.excludedAccounts.length) return 'No balance data available. Sync accounts first.';
       return [
         'Assets:',
         ...b.accounts.filter((a) => a.isAsset).map((a) => `  ${a.name}: ${fmt(a.balance)} (${a.subtype ?? a.type})`),
@@ -542,6 +545,10 @@ async function executeToolImpl(
         `Net worth: ${b.netWorth >= 0 ? '' : '-'}${fmt(b.netWorth)}`,
         `Cash (checking/savings): ${fmt(b.cash)}`,
         `Liquid (incl. brokerage): ${fmt(b.liquid)}`,
+        ...(b.excludedAccounts.length ? [
+          'Excluded (not in net worth):',
+          ...b.excludedAccounts.map((a) => `  ${a.name}: ${fmt(a.balance)} (${a.subtype ?? a.type})`),
+        ] : []),
       ].join('\n');
     }
 

--- a/core/tools.ts
+++ b/core/tools.ts
@@ -11,7 +11,7 @@ import { writeFileSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { notifyChange } from './refresh.js';
 import { DATA_DIR } from './paths.js';
-import { getRangeSummary, getMonthlySummary, getTagSummary, getCategoryDriftData, getMerchantSummary, getNetWorthHistory, type NetWorthGranularity } from './queries.js';
+import { getRangeSummary, getMonthlySummary, getTagSummary, getCategoryDriftData, getMerchantSummary, getNetWorthHistory, getLinkedAccounts, type NetWorthGranularity } from './queries.js';
 import { solveTVM } from './calculator.js';
 import { getDriftWindows } from './dateUtils.js';
 import { getBalances, getFinancialHealth, getSpendingTrends } from './agent-context.js';
@@ -519,16 +519,11 @@ async function executeToolImpl(
     }
 
     case 'list_accounts': {
-      const result = await db.execute(
-        'SELECT COALESCE(nickname, name) as name, type, subtype, mask, institution_name, excluded FROM accounts'
-      );
-      const rows = result.rows as unknown as {
-        name: string; type: string; subtype: string; mask: string | null; institution_name: string | null; excluded: number;
-      }[];
+      const rows = await getLinkedAccounts();
       if (!rows.length) return 'No accounts connected.';
       return rows.map((a) =>
-        `${a.name} (${a.subtype ?? a.type}) ···${a.mask ?? '?'} — ${a.institution_name ?? 'Unknown'}`
-        + (Number(a.excluded) === 1 ? ' · excluded from net worth' : '')
+        `${a.nickname ?? a.name} (${a.subtype ?? a.type}) ···${a.mask ?? '?'} — ${a.institution_name ?? 'Unknown'}`
+        + (a.excluded ? ' · excluded from net worth' : '')
       ).join('\n');
     }
 

--- a/tests/tools-balances.test.ts
+++ b/tests/tools-balances.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('../core/db.js', async () => {
+  const { makeTestDb } = await import('./helpers/makeTestDb.js');
+  return { db: await makeTestDb() };
+});
+
+import { db } from '../core/db.js';
+import { executeTool } from '../core/tools.js';
+import { getBalances } from '../core/agent-context.js';
+
+beforeEach(async () => {
+  await db.execute('DELETE FROM accounts');
+  await db.execute('DELETE FROM balance_history');
+  // A counted checking account and an excluded 529.
+  await db.execute("INSERT INTO accounts (id, name, type, subtype, institution_name, mask, excluded) VALUES ('chk', 'Test Checking', 'depository', 'checking', 'Test Bank', '0001', 0)");
+  await db.execute("INSERT INTO accounts (id, name, type, subtype, institution_name, mask, excluded) VALUES ('acct-529', 'College 529', 'investment', '529', 'Fidelity', '5290', 1)");
+  await db.execute("INSERT INTO balance_history (account_id, balance, date) VALUES ('chk', 5000.00, '2026-05-20')");
+  await db.execute("INSERT INTO balance_history (account_id, balance, date) VALUES ('acct-529', 60000.00, '2026-05-20')");
+});
+
+describe('getBalances with an excluded account', () => {
+  it('keeps the excluded account out of totals but returns it separately', async () => {
+    const b = await getBalances();
+    expect(b.accounts.map((a) => a.name)).toEqual(['Test Checking']);
+    expect(b.excludedAccounts.map((a) => a.name)).toEqual(['College 529']);
+    expect(b.totalAssets).toBe(5000);   // 529 not counted
+    expect(b.netWorth).toBe(5000);
+  });
+});
+
+describe('get_balances tool output', () => {
+  it('shows a carved-out "Excluded" section and leaves net worth untouched', async () => {
+    const out = await executeTool('get_balances', {});
+    expect(out).toContain('Total assets: $5,000.00');
+    expect(out).toContain('Net worth: $5,000.00');
+    expect(out).toContain('Excluded (not in net worth):');
+    expect(out).toContain('College 529: $60,000.00 (529)');
+    // The 529 must never roll into the headline ($65,000.00 would mean it leaked).
+    expect(out).not.toContain('$65,000.00');
+  });
+});
+
+describe('list_accounts tool output', () => {
+  it('tags excluded accounts, leaving counted ones unmarked', async () => {
+    const out = await executeTool('list_accounts', {});
+    const lines = out.split('\n');
+    expect(lines.find((l) => l.startsWith('College 529'))).toContain('· excluded from net worth');
+    expect(lines.find((l) => l.startsWith('Test Checking'))).not.toContain('excluded from net worth');
+  });
+});


### PR DESCRIPTION
## What

Follow-up to #93. That PR made the `excluded` flag drop accounts from net worth everywhere — including hiding them entirely from the agent's `get_balances`. But `list_accounts` still listed them **unlabeled**, so the agent got a contradictory picture and could miss balances it should reason about (e.g. "you have no college savings" when there's $120K in excluded 529s).

This makes the agent surfaces mirror the UI carve-out: the agent **sees** excluded accounts, clearly marked as not-in-net-worth, with totals still computed on the included set.

## Changes
- **`getBalances`** (`core/agent-context.ts`) — stops filtering excluded at the SQL level; returns them in a new `excludedAccounts` field. Net-worth totals (assets/liabilities/cash/liquid/retirement) are computed on the included set only, so every existing consumer is unaffected.
- **`get_balances`** tool (`core/tools.ts`) — renders an **"Excluded (not in net worth):"** section after the headline.
- **`list_accounts`** tool — tags excluded rows with `· excluded from net worth`.
- **Unchanged (correctly):** `get_net_worth_history` (pure totals time series) and the canvas "Net worth" headline still omit excluded accounts.

### Agent-facing output, before → after
```
list_accounts:
  College 529 (529) ···5290 — Fidelity                      →  … — Fidelity · excluded from net worth

get_balances:
  (529 invisible)                                           →  Excluded (not in net worth):
                                                                 College 529: $60,000.00 (529)
```

## Tests
New `tests/tools-balances.test.ts` (3):
- `getBalances` keeps the excluded account out of totals but returns it in `excludedAccounts`
- `get_balances` output shows the carved-out section and the headline net worth doesn't leak the excluded balance
- `list_accounts` tags excluded rows and leaves counted ones unmarked

Full suite: **659 passing**, typecheck clean (root + GUI renderer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)