### PR TITLE
test(gui): Electron launch/boot e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,29 @@ jobs:
 
       - run: node --no-warnings ./node_modules/.bin/vitest run
 
+  # Boot the real Electron app and assert it comes up. Complements the unit suite
+  # (which stubs window.__bridge entirely) by exercising what only a live process
+  # can: main-process boot, @libsql native-binding loading, the electron-vite
+  # build-output wiring, the sandboxed-preload contextBridge, and the real
+  # ipcRenderer→ipcMain serialization in gui/main/bridge.ts.
+  gui-e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - run: npm ci
+
+      # Electron's renderer is Chromium and needs the same system libraries; this
+      # installs that dependency set on the bare runner image.
+      - run: npx playwright install-deps chromium
+
+      # xvfb-run gives Electron the virtual X display the headless runner lacks.
+      - run: xvfb-run -a npm run test:e2e
+
   # Smoke-build the unpacked Electron app on each platform when something is
   # about to land on main — catches packaging regressions (missing deps,
   # broken file filters, native-binding paths) before a release tag is cut.
@@ -36,7 +59,7 @@ jobs:
   # on PRs that don't target main — treat skipped as passing so dev PRs still
   # merge with just test green.
   ci-all-passed:
-    needs: [test, gui-build]
+    needs: [test, gui-e2e, gui-build]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -44,6 +67,10 @@ jobs:
         run: |
           if [ "${{ needs.test.result }}" != "success" ]; then
             echo "::error::test job failed"
+            exit 1
+          fi
+          if [ "${{ needs.gui-e2e.result }}" != "success" ]; then
+            echo "::error::gui-e2e job failed"
             exit 1
           fi
           if [ "${{ needs.gui-build.result }}" != "success" ] && [ "${{ needs.gui-build.result }}" != "skipped" ]; then

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ scripts/seed-rules.ts
 .claude/
 out/
 release/
+test-results/
+playwright-report/

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "fungible": "bin/fungible"
       },
       "devDependencies": {
+        "@playwright/test": "^1.61.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
         "@types/node": "^25.9.1",
@@ -1695,6 +1696,21 @@
       },
       "engines": {
         "node": ">=14.18.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@reduxjs/toolkit": {
@@ -6891,6 +6907,50 @@
       },
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/plist": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "api": "node --import tsx/esm api/server.ts",
     "typecheck": "tsc --noEmit && tsc --noEmit -p gui/renderer",
     "test": "~/.nvm/versions/node/v22.22.3/bin/node ./node_modules/.bin/vitest run",
-    "test:watch": "~/.nvm/versions/node/v22.22.3/bin/node ./node_modules/.bin/vitest"
+    "test:watch": "~/.nvm/versions/node/v22.22.3/bin/node ./node_modules/.bin/vitest",
+    "test:e2e": "electron-vite build && playwright test"
   },
   "license": "MIT",
   "engines": {
@@ -50,6 +51,7 @@
     "@noble/hashes": "1.8.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
     "@types/node": "^25.9.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from '@playwright/test';
+
+// Electron launch / boot e2e tests. These launch the real packaged main process
+// (electron-vite build output in out/) — see tests/e2e/. Run serially: each test
+// boots its own Electron process against an isolated temp data dir and shares a
+// single display, so parallelism buys nothing and only adds flake.
+export default defineConfig({
+  testDir: './tests/e2e',
+  fullyParallel: false,
+  workers: 1,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [['github'], ['list']] : 'list',
+  timeout: 60_000,
+  expect: { timeout: 15_000 },
+});

--- a/tests/e2e/launch.spec.ts
+++ b/tests/e2e/launch.spec.ts
@@ -1,0 +1,84 @@
+import {
+  test,
+  expect,
+  _electron as electron,
+  type ElectronApplication,
+  type Page,
+} from '@playwright/test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// What this suite uniquely covers (the jsdom component tests can't): the real
+// main-process boot path, electron-vite build-output wiring, native module
+// loading (@libsql/* must load in the packaged main process — a broken binding
+// would crash boot), the sandboxed-preload contextBridge, and the real
+// ipcRenderer→ipcMain serialization in gui/main/bridge.ts. The jsdom tests stub
+// window.__bridge entirely, so none of that is exercised there.
+
+// Built main entry produced by `npm run gui:build` (electron-vite). The e2e npm
+// script runs the build first; running `playwright test` without it will fail
+// here with a missing-file error — that's the intended signal.
+const MAIN_ENTRY = fileURLToPath(new URL('../../out/main/index.js', import.meta.url));
+
+// The contextBridge shape the preload exposes on the renderer's window.
+type BridgeWindow = Window & {
+  __bridge: { call: (ns: string, fn: string, args: unknown[]) => Promise<unknown> };
+};
+
+let app: ElectronApplication;
+let win: Page;
+let dataDir: string;
+
+test.beforeEach(async () => {
+  // Isolate every on-disk side effect (DB, .env, gui-window.json, backups) in a
+  // throwaway dir so the e2e run never reads or writes the developer's real
+  // ~/.fungible data. We deliberately do NOT set FUNGIBLE_DEMO: gui/main/index.ts
+  // redirects the data dir to ~/.fungible-demo whenever it is set, which would
+  // defeat this isolation. An empty DB is enough — the schema is created on boot
+  // and every screen still renders through the real bridge.
+  dataDir = mkdtempSync(join(tmpdir(), 'fungible-e2e-'));
+  app = await electron.launch({
+    // --no-sandbox only on CI: GitHub's Linux runners don't ship the SUID
+    // chrome-sandbox helper, so the renderer process can't spawn without it.
+    // Local runs keep the sandbox (matching app.ts's webPreferences.sandbox).
+    args: [MAIN_ENTRY, ...(process.env.CI ? ['--no-sandbox'] : [])],
+    env: { ...process.env, FUNGIBLE_DATA_DIR: dataDir },
+  });
+  win = await app.firstWindow();
+});
+
+test.afterEach(async () => {
+  await app?.close();
+  if (dataDir) rmSync(dataDir, { recursive: true, force: true });
+});
+
+test('boots, opens exactly one window, and renders the Dashboard', async () => {
+  // A window resolved from firstWindow() means the main process booted without
+  // crashing (a DB/native-binding failure would dialog-and-quit before any window).
+  expect(app.windows()).toHaveLength(1);
+
+  // Renderer actually loaded its document.
+  expect(await win.title()).toBe('fungible');
+
+  // A known screen rendered all the way through the bridge/IPC path. If any bridge
+  // call had failed, useQuery re-throws and the ErrorBoundary would replace the
+  // Dashboard heading with "Something went wrong loading this screen."
+  await expect(win.getByRole('heading', { name: 'Dashboard', level: 1 })).toBeVisible();
+  await expect(win.getByText('Something went wrong')).toHaveCount(0);
+});
+
+test('completes a real bridge round-trip (preload contextBridge → main IPC → core/queries → DB)', async () => {
+  // Exercise the exact wiring the jsdom tests stub out: the contextBridge exposed
+  // in the sandboxed preload, ipcRenderer→ipcMain serialization in
+  // gui/main/bridge.ts, and a live core/queries call against the real (empty) DB.
+  const result = await win.evaluate(() =>
+    (window as unknown as BridgeWindow).__bridge.call('queries', 'getAccountsWithBalances', []),
+  );
+
+  // getAccountsWithBalances() returns { accounts, history }; an empty DB yields
+  // empty arrays. Getting a well-formed, serialized object back over IPC proves
+  // the round-trip end to end.
+  expect(result).toMatchObject({ accounts: [], history: [] });
+});


### PR DESCRIPTION
## What

Adds e2e tests that **launch the real Electron app** (the `electron-vite` build output) via Playwright's `_electron` and assert it boots.

`tests/e2e/launch.spec.ts` — two tests, each booting its own Electron process against an isolated temp `FUNGIBLE_DATA_DIR`:

1. **Boot smoke** — app boots → exactly one `BrowserWindow` opens → renderer document loads (`title === 'fungible'`) → the Dashboard `<h1>` renders, and the ErrorBoundary's "Something went wrong" is absent.
2. **Real bridge round-trip** — calls `window.__bridge.call('queries', 'getAccountsWithBalances', [])` from the renderer and asserts a well-formed `{ accounts: [], history: [] }` comes back.

## Why

The jsdom component suite stubs `window.__bridge` wholesale, so the entire main↔renderer boundary was untested. This covers what only a live process can:

- main-process boot (a crash dialog-and-quits before any window)
- `@libsql` native-binding loading under Electron's ABI (`npmRebuild: false` assumption)
- the sandboxed-preload contextBridge
- `ipcRenderer`→`ipcMain` serialization in `gui/main/bridge.ts`

## Notes

- **Isolation:** each test uses a throwaway temp `FUNGIBLE_DATA_DIR` (cleaned up after) — never touches real `~/.fungible`. Deliberately *not* `FUNGIBLE_DEMO`, since `gui/main/index.ts` redirects the data dir to `~/.fungible-demo` when that's set.
- **CI:** new `gui-e2e` job (`xvfb-run` + `playwright install-deps chromium` for Electron on Linux), wired as a required check in the `ci-all-passed` aggregator. `--no-sandbox` is passed only on CI (GitHub runners lack the SUID chrome-sandbox helper); local runs keep the sandbox.
- **Scope:** runs against the build output (`out/`), which confirms libsql is ABI-compatible with this Electron version but does **not** exercise the packaged `asarUnpack` native-binding path. Launching the actual packaged artifact is a natural follow-up (same spec, `executablePath`).

## Verification

- e2e: 2 passed (real Electron boot + render + IPC round-trip)
- unit suite: 615 passed (unaffected)
- `typecheck`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)