### PR TITLE
fix(mcp): re-evaluate transactions when the agent deletes a category rule

### DIFF
--- a/core/tools.ts
+++ b/core/tools.ts
@@ -17,6 +17,7 @@ import { getDriftWindows } from './dateUtils.js';
 import { getBalances, getFinancialHealth, getSpendingTrends } from './agent-context.js';
 import { getFinanceGuide, getFinanceTopicList, formatGuideSection, type GuideTopic } from './finance-guide.js';
 import { applyCategoriesToAll } from './categorize.js';
+import { deleteCategoryRule } from './rules.js';
 import { rebuildDisplayNames } from './rename.js';
 import { setTransactionCategory, clearTransactionOverride, setTransactionIgnored } from './transactions.js';
 import { addTagToTransaction, removeTagFromTransaction, getOrCreateTag } from './tags.js';
@@ -784,8 +785,11 @@ async function executeToolImpl(
       const ruleResult = await db.execute({ sql: 'SELECT pattern, category FROM category_rules WHERE id = ?', args: [num('id')] });
       const rule = ruleResult.rows[0] as unknown as { pattern: string; category: string } | undefined;
       if (!rule) return `No rule with id ${num('id')}.`;
-      await db.execute({ sql: 'DELETE FROM category_rules WHERE id = ?', args: [num('id')] });
-      return `Deleted rule: "${rule.pattern}" → ${rule.category}`;
+      // deleteCategoryRule deletes the row AND re-evaluates affected transactions
+      // (reverting orphans to Uncategorized / a lower-priority rule), matching the
+      // TUI/GUI. Raw DELETE here would leave stale categorizations behind.
+      const count = await deleteCategoryRule(num('id'));
+      return `Deleted rule: "${rule.pattern}" → ${rule.category}\nRecategorized ${count} transactions.`;
     }
 
     case 'add_name_rule': {

--- a/tests/rules.test.ts
+++ b/tests/rules.test.ts
@@ -7,6 +7,7 @@ vi.mock('../core/db.js', async () => {
 
 import { db } from '../core/db.js';
 import { deleteCategoryRule, saveCategoryRule } from '../core/rules.js';
+import { executeTool } from '../core/tools.js';
 
 let txId = 0;
 async function insertTx(name: string, manual_category?: string) {
@@ -70,5 +71,17 @@ describe('deleteCategoryRule re-evaluates transactions', () => {
     const count = await deleteCategoryRule(await ruleIdFor('Spotify'));
     expect(count).toBe(0);
     expect(await categoryOf(id)).toBe('Music');
+  });
+});
+
+describe('delete_rule MCP tool re-evaluates transactions', () => {
+  it('reverts a transaction to Uncategorized when the agent deletes its only matching rule', async () => {
+    const id = await insertTx('Spotify');
+    await saveCategoryRule({ pattern: 'Spotify', matchType: 'name', category: 'Entertainment', minAmount: null, maxAmount: null });
+    expect(await categoryOf(id)).toBe('Entertainment');
+
+    const out = await executeTool('delete_rule', { id: await ruleIdFor('Spotify') });
+    expect(out).toContain('Recategorized 1 transactions');
+    expect(await categoryOf(id)).toBe('Uncategorized');
   });
 });


### PR DESCRIPTION
## Summary

Found during the bug bash of #96 (dev → main).

The MCP `delete_rule` tool deleted the category-rule row with raw SQL and **never re-applied rules**, so every transaction the rule had categorized stayed stuck in its now-deleted category. PR #89 fixed exactly this for the TUI and GUI (by routing deletes through `deleteCategoryRule`, which runs `applyAll`), but the agent/MCP path was missed — leaving the surfaces inconsistent. Meanwhile the sibling `add_rule` tool *does* re-apply, so the asymmetry was agent-visible.

## Fix

Route the MCP handler through the same `deleteCategoryRule()` the TUI/GUI use, so orphaned transactions revert to `Uncategorized` (or fall back to a lower-priority rule), and report the recategorized count like `add_rule` already does.

> ⚠️ Subtlety: `applyCategoriesToAll()` (used by `add_rule`) is **not** the right tool for deletes — it only applies rules *forward* and skips reverting to `Uncategorized`, so it would not have un-stuck the orphaned transactions. Only `applyAll()` (via `deleteCategoryRule`) reverts.

## Test plan
- [x] New test: `delete_rule` MCP tool reverts a transaction to Uncategorized when the agent deletes its only matching rule
- [x] `npm run typecheck` clean
- [x] Full suite: 660 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
