### PR TITLE
Spending scorecard: trailing 30d range, median baseline, bucketed drift view

### DIFF
--- a/core/dateUtils.ts
+++ b/core/dateUtils.ts
@@ -1,8 +1,13 @@
-export type Range = 'week' | 'month' | 'quarter' | 'year' | 'alltime';
-export const RANGES: Range[] = ['week', 'month', 'quarter', 'year', 'alltime'];
+export type Range = 'week' | 'month' | 'last30' | 'quarter' | 'year' | 'alltime';
+export const RANGES: Range[] = ['week', 'month', 'last30', 'quarter', 'year', 'alltime'];
 export const RANGE_LABELS: Record<Range, string> = {
-  week: 'Week', month: 'Month', quarter: 'Quarter', year: 'Year', alltime: 'All',
+  week: 'Week', month: 'Month', last30: '30 Days', quarter: 'Quarter', year: 'Year', alltime: 'All',
 };
+
+// last30 is a trailing 30-day window; the anchor is the window START (today−29
+// when anchored to now), keeping the anchor-is-period-start convention of the
+// other ranges. Unlike calendar ranges it never has unelapsed days.
+export const LAST30_DAYS = 30;
 
 export const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
 
@@ -19,6 +24,12 @@ export function getPeriodStart(range: Range, d: Date): Date {
       return monday;
     }
     case 'month':   return new Date(d.getFullYear(), d.getMonth(), 1);
+    case 'last30': {
+      const start = new Date(d);
+      start.setDate(d.getDate() - (LAST30_DAYS - 1));
+      start.setHours(0, 0, 0, 0);
+      return start;
+    }
     case 'quarter': return new Date(d.getFullYear(), Math.floor(d.getMonth() / 3) * 3, 1);
     case 'year':    return new Date(d.getFullYear(), 0, 1);
     case 'alltime': return new Date(2000, 0, 1);
@@ -31,6 +42,7 @@ export function getPeriodDates(range: Range, anchor: Date): { from: string; to: 
   let end: Date;
   switch (range) {
     case 'week':    end = new Date(anchor); end.setDate(anchor.getDate() + 6); break;
+    case 'last30':  end = new Date(anchor); end.setDate(anchor.getDate() + (LAST30_DAYS - 1)); break;
     case 'month':   end = new Date(anchor.getFullYear(), anchor.getMonth() + 1, 0); break;
     case 'quarter': end = new Date(anchor.getFullYear(), anchor.getMonth() + 3, 0); break;
     case 'year':    end = new Date(anchor.getFullYear(), 11, 31); break;
@@ -42,6 +54,7 @@ export function navigatePeriod(range: Range, anchor: Date, delta: -1 | 1): Date 
   const d = new Date(anchor);
   switch (range) {
     case 'week':    d.setDate(d.getDate() + delta * 7); break;
+    case 'last30':  d.setDate(d.getDate() + delta * LAST30_DAYS); break;
     case 'month':   d.setMonth(d.getMonth() + delta); break;
     case 'quarter': d.setMonth(d.getMonth() + delta * 3); break;
     case 'year':    d.setFullYear(d.getFullYear() + delta); break;
@@ -175,15 +188,23 @@ export function getDriftWindows(range: Range, anchor: Date, today: Date): DriftW
   return { current: { from, to: effectiveTo }, lastPeriod, lastYear, rolling12 };
 }
 
+function spanLabel(start: Date, end: Date): string {
+  const sameYear = start.getFullYear() === end.getFullYear();
+  const sameMonth = start.getMonth() === end.getMonth();
+  if (sameMonth && sameYear) return `${MONTHS[start.getMonth()]} ${start.getDate()}–${end.getDate()}, ${start.getFullYear()}`;
+  if (sameYear)  return `${MONTHS[start.getMonth()]} ${start.getDate()} – ${MONTHS[end.getMonth()]} ${end.getDate()}, ${start.getFullYear()}`;
+  return `${MONTHS[start.getMonth()]} ${start.getDate()} – ${MONTHS[end.getMonth()]} ${end.getDate()}, ${end.getFullYear()}`;
+}
+
 export function formatPeriodLabel(range: Range, anchor: Date): string {
   switch (range) {
     case 'week': {
       const end = new Date(anchor); end.setDate(anchor.getDate() + 6);
-      const sameYear = anchor.getFullYear() === end.getFullYear();
-      const sameMonth = anchor.getMonth() === end.getMonth();
-      if (sameMonth) return `${MONTHS[anchor.getMonth()]} ${anchor.getDate()}–${end.getDate()}, ${anchor.getFullYear()}`;
-      if (sameYear)  return `${MONTHS[anchor.getMonth()]} ${anchor.getDate()} – ${MONTHS[end.getMonth()]} ${end.getDate()}, ${anchor.getFullYear()}`;
-      return `${MONTHS[anchor.getMonth()]} ${anchor.getDate()} – ${MONTHS[end.getMonth()]} ${end.getDate()}, ${end.getFullYear()}`;
+      return spanLabel(anchor, end);
+    }
+    case 'last30': {
+      const end = new Date(anchor); end.setDate(anchor.getDate() + (LAST30_DAYS - 1));
+      return spanLabel(anchor, end);
     }
     case 'month':   return `${MONTHS[anchor.getMonth()]} ${anchor.getFullYear()}`;
     case 'quarter': return `Q${Math.floor(anchor.getMonth() / 3) + 1} ${anchor.getFullYear()}`;

--- a/core/queries.ts
+++ b/core/queries.ts
@@ -212,7 +212,13 @@ export async function getOwnerRows(from: string, to: string, filter?: Filter): P
 
 // ── Drift ──────────────────────────────────────────────────────────────────────
 
-export type DriftSlice    = { current: number; lastPeriodDelta: number; lastYearDelta: number; avg12mDelta: number; avg12m: number };
+export type DriftSlice    = {
+  current: number; lastPeriodDelta: number; lastYearDelta: number;
+  avg12mDelta: number; avg12m: number;
+  // Median of the rolling windows — robust to one-off spikes (a single $7K
+  // medical month shouldn't inflate the "typical" baseline the way a mean does).
+  median12m: number; medianDelta: number;
+};
 export type CategoryDrift = { category: string } & DriftSlice;
 export type FlexDriftData = Record<keyof FlexSummary, DriftSlice>;
 export type AccountDrift  = { id: string; name: string; subtype: string | null } & DriftSlice;
@@ -282,17 +288,35 @@ async function queryAccountSpending(from: string, to: string): Promise<Map<strin
 
 function sliceFor(current: number, last: number, year: number, rolling: number[]): DriftSlice {
   const avg12m = rolling.length > 0 ? rolling.reduce((s, v) => s + v, 0) / rolling.length : 0;
-  return { current, lastPeriodDelta: current - last, lastYearDelta: current - year, avg12mDelta: current - avg12m, avg12m };
+  let median12m = 0;
+  if (rolling.length > 0) {
+    const sorted = [...rolling].sort((a, b) => a - b);
+    const mid = Math.floor(sorted.length / 2);
+    median12m = sorted.length % 2 === 1 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+  }
+  return {
+    current, lastPeriodDelta: current - last, lastYearDelta: current - year,
+    avg12mDelta: current - avg12m, avg12m,
+    median12m, medianDelta: current - median12m,
+  };
+}
+
+// Rolling windows from before the first transaction contribute phantom zeros
+// that drag baselines down (e.g. 3 months of history averaged over 12 windows).
+async function clampToHistory(windows: Window[]): Promise<Window[]> {
+  const { minDate } = await getDataBounds();
+  return windows.filter((w) => w.to >= minDate);
 }
 
 export async function getCategoryDriftData(
   currentWin: Window, lastPeriodWin: Window, lastYearWin: Window, rolling12: Window[], filter?: Filter,
 ): Promise<CategoryDrift[]> {
+  const rolling = await clampToHistory(rolling12);
   const [cur, last, yr, ...rolls] = await Promise.all([
     queryCategoryTotals(currentWin.from, currentWin.to, filter),
     queryCategoryTotals(lastPeriodWin.from, lastPeriodWin.to, filter),
     queryCategoryTotals(lastYearWin.from, lastYearWin.to, filter),
-    ...rolling12.map((w) => queryCategoryTotals(w.from, w.to, filter)),
+    ...rolling.map((w) => queryCategoryTotals(w.from, w.to, filter)),
   ]);
   return [...cur.entries()]
     .map(([category, currentAmt]) => ({
@@ -305,11 +329,12 @@ export async function getCategoryDriftData(
 export async function getFlexDriftData(
   currentWin: Window, lastPeriodWin: Window, lastYearWin: Window, rolling12: Window[], filter?: Filter,
 ): Promise<FlexDriftData> {
+  const rolling = await clampToHistory(rolling12);
   const [cur, last, yr, ...rolls] = await Promise.all([
     queryFlexTotals(currentWin.from, currentWin.to, filter),
     queryFlexTotals(lastPeriodWin.from, lastPeriodWin.to, filter),
     queryFlexTotals(lastYearWin.from, lastYearWin.to, filter),
-    ...rolling12.map((w) => queryFlexTotals(w.from, w.to, filter)),
+    ...rolling.map((w) => queryFlexTotals(w.from, w.to, filter)),
   ]);
   const tiers: (keyof FlexSummary)[] = ['fixed', 'flexible', 'discretionary', 'untagged'];
   return Object.fromEntries(
@@ -326,11 +351,12 @@ export async function getAccountDriftData(
   );
   const accounts = acctRes.rows as unknown as { id: string; name: string; subtype: string | null }[];
 
+  const rolling = await clampToHistory(rolling12);
   const [cur, last, yr, ...rolls] = await Promise.all([
     queryAccountSpending(currentWin.from, currentWin.to),
     queryAccountSpending(lastPeriodWin.from, lastPeriodWin.to),
     queryAccountSpending(lastYearWin.from, lastYearWin.to),
-    ...rolling12.map((w) => queryAccountSpending(w.from, w.to)),
+    ...rolling.map((w) => queryAccountSpending(w.from, w.to)),
   ]);
 
   return accounts.map((acct) => ({

--- a/core/scorecard.ts
+++ b/core/scorecard.ts
@@ -1,0 +1,45 @@
+import type { CategoryDrift } from './queries.js';
+
+// Pure bucketing of drift rows into a scorecard verdict. Kept free of DB and
+// UI imports so the GUI renderer can import it directly (no bridge needed).
+
+export type Scorecard = {
+  over: CategoryDrift[];    // significantly above baseline, worst first
+  typical: CategoryDrift[]; // within the noise band, input order preserved
+  under: CategoryDrift[];   // significantly below baseline, biggest saving last
+  net: number;              // sum of medianDelta across ALL rows (incl. typical)
+};
+
+// A delta only counts as signal when it clears both an absolute floor and a
+// share of the category's own baseline — $40 over on a $60 baseline matters,
+// $40 over on a $4,000 baseline doesn't.
+export const SIGNIFICANCE_FLOOR = 50;
+export const SIGNIFICANCE_SHARE = 0.15;
+
+export function isSignificantDelta(delta: number, baseline: number): boolean {
+  return Math.abs(delta) >= Math.max(SIGNIFICANCE_FLOOR, SIGNIFICANCE_SHARE * baseline);
+}
+
+/** "4.2x" multiplier vs baseline; "new" when there is no baseline to compare. */
+export function ratioLabel(current: number, baseline: number): string {
+  if (baseline <= 0) return current > 0 ? 'new' : '';
+  return `${(current / baseline).toFixed(1)}x`;
+}
+
+export function bucketDrift(rows: CategoryDrift[]): Scorecard {
+  const over: CategoryDrift[] = [];
+  const typical: CategoryDrift[] = [];
+  const under: CategoryDrift[] = [];
+  let net = 0;
+  for (const row of rows) {
+    net += row.medianDelta;
+    if (!isSignificantDelta(row.medianDelta, row.median12m)) typical.push(row);
+    else if (row.medianDelta > 0) over.push(row);
+    else under.push(row);
+  }
+  over.sort((a, b) => b.medianDelta - a.medianDelta);
+  // Ascending magnitude so the biggest saving sits last — extremes at the
+  // visual edges of the OVER…UNDER stack.
+  under.sort((a, b) => b.medianDelta - a.medianDelta);
+  return { over, typical, under, net };
+}

--- a/tests/dateUtils.test.ts
+++ b/tests/dateUtils.test.ts
@@ -91,6 +91,22 @@ describe('getPeriodStart', () => {
     });
   });
 
+  describe('last30', () => {
+    it('returns 29 days before the given date (trailing window start)', () => {
+      const start = getPeriodStart('last30', d(2026, 7, 3));
+      expect(start.getFullYear()).toBe(2026);
+      expect(start.getMonth()).toBe(5); // June
+      expect(start.getDate()).toBe(4);
+    });
+
+    it('crosses year boundaries', () => {
+      const start = getPeriodStart('last30', d(2026, 1, 10));
+      expect(start.getFullYear()).toBe(2025);
+      expect(start.getMonth()).toBe(11); // December
+      expect(start.getDate()).toBe(12);
+    });
+  });
+
   describe('alltime', () => {
     it('returns year 2000', () => {
       const start = getPeriodStart('alltime', d(2025, 1, 1));
@@ -169,6 +185,20 @@ describe('getPeriodDates', () => {
       expect(dates.to).toBe('2025-12-31');
     });
   });
+
+  describe('last30', () => {
+    it('returns a 30-day range starting at the anchor', () => {
+      const dates = getPeriodDates('last30', d(2026, 6, 4));
+      expect(dates.from).toBe('2026-06-04');
+      expect(dates.to).toBe('2026-07-03');
+    });
+
+    it('spans month and year boundaries', () => {
+      const dates = getPeriodDates('last30', d(2025, 12, 15));
+      expect(dates.from).toBe('2025-12-15');
+      expect(dates.to).toBe('2026-01-13');
+    });
+  });
 });
 
 describe('navigatePeriod', () => {
@@ -243,6 +273,20 @@ describe('navigatePeriod', () => {
     });
   });
 
+  describe('last30 navigation', () => {
+    it('moves backward 30 days', () => {
+      const prev = navigatePeriod('last30', d(2026, 6, 4), -1);
+      expect(prev.getMonth()).toBe(4); // May
+      expect(prev.getDate()).toBe(5);
+    });
+
+    it('moves forward 30 days', () => {
+      const next = navigatePeriod('last30', d(2026, 6, 4), 1);
+      expect(next.getMonth()).toBe(6); // July
+      expect(next.getDate()).toBe(4);
+    });
+  });
+
   describe('alltime navigation', () => {
     it('does not move (alltime is fixed)', () => {
       const anchor = d(2025, 6, 15);
@@ -283,6 +327,18 @@ describe('formatPeriodLabel', () => {
 
   it('formats year label', () => {
     expect(formatPeriodLabel('year', d(2025, 6, 15))).toBe('2025');
+  });
+
+  it('formats last30 label spanning months', () => {
+    expect(formatPeriodLabel('last30', d(2026, 6, 4))).toBe('Jun 4 – Jul 3, 2026');
+  });
+
+  it('formats last30 label within one month', () => {
+    expect(formatPeriodLabel('last30', d(2026, 1, 1))).toBe('Jan 1–30, 2026');
+  });
+
+  it('formats last30 label spanning years', () => {
+    expect(formatPeriodLabel('last30', d(2025, 12, 15))).toBe('Dec 15 – Jan 13, 2026');
   });
 
   it('formats alltime label', () => {

--- a/tests/drift.test.ts
+++ b/tests/drift.test.ts
@@ -117,6 +117,41 @@ describe('getDriftWindows', () => {
     });
   });
 
+  describe('last30 range', () => {
+    const anchor = d(2026, 6, 4);  // trailing window Jun 4 – Jul 3
+    const today  = d(2026, 7, 3);
+
+    it('current window is the full trailing 30 days', () => {
+      const w = getDriftWindows('last30', anchor, today)!;
+      expect(w.current.from).toBe('2026-06-04');
+      expect(w.current.to).toBe('2026-07-03');
+    });
+
+    it('lastPeriod is the contiguous prior 30 days', () => {
+      const w = getDriftWindows('last30', anchor, today)!;
+      expect(w.lastPeriod.from).toBe('2026-05-05');
+      expect(w.lastPeriod.to).toBe('2026-06-03');
+    });
+
+    it('lastYear is the same 30-day window a year earlier', () => {
+      const w = getDriftWindows('last30', anchor, today)!;
+      expect(w.lastYear.from).toBe('2025-06-04');
+      expect(w.lastYear.to).toBe('2025-07-03');
+    });
+
+    it('rolling12 is 12 contiguous 30-day windows', () => {
+      const w = getDriftWindows('last30', anchor, today)!;
+      expect(w.rolling12).toHaveLength(12);
+      expect(w.rolling12[0]).toEqual({ from: '2026-05-05', to: '2026-06-03' });
+      // each window ends the day before the next one starts
+      for (let i = 1; i < 12; i++) {
+        const next = new Date(w.rolling12[i].to + 'T12:00:00');
+        next.setDate(next.getDate() + 1);
+        expect(next.toISOString().slice(0, 10)).toBe(w.rolling12[i - 1].from);
+      }
+    });
+  });
+
   describe('week range', () => {
     const anchor = d(2025, 5, 19);
     const today  = d(2025, 5, 22);
@@ -242,6 +277,36 @@ describe('getCategoryDriftData', () => {
     const row = result.find((r) => r.category === 'BrandNew')!;
     expect(row.avg12m).toBe(0);
     expect(row.avg12mDelta).toBeCloseTo(100);
+  });
+
+  it('median12m resists a one-off spike that inflates the mean', async () => {
+    const months = ['2026-04','2026-03','2026-02','2026-01','2025-12','2025-11',
+                    '2025-10','2025-09','2025-08','2025-07','2025-06'];
+    for (const ym of months) {
+      await insertTx({ date: `${ym}-15`, amount: 100, category: 'Medical' });
+    }
+    await insertTx({ date: '2025-05-15', amount: 5000, category: 'Medical' }); // spike
+    await insertTx({ date: '2026-05-15', amount: 150, category: 'Medical' });
+
+    const result = await getCategoryDriftData(current, lastPeriod, lastYear, rolling12);
+    const row = result.find((r) => r.category === 'Medical')!;
+    expect(row.median12m).toBeCloseTo(100);
+    expect(row.medianDelta).toBeCloseTo(50);
+    expect(row.avg12m).toBeGreaterThan(500); // the mean is distorted by the spike
+  });
+
+  it('drops rolling windows that predate the first transaction', async () => {
+    // Only 3 months of history — phantom zero windows must not drag the baseline
+    await insertTx({ date: '2026-04-15', amount: 100, category: 'Food' });
+    await insertTx({ date: '2026-03-15', amount: 100, category: 'Food' });
+    await insertTx({ date: '2026-02-10', amount: 100, category: 'Food' });
+    await insertTx({ date: '2026-05-15', amount: 200, category: 'Food' });
+
+    const result = await getCategoryDriftData(current, lastPeriod, lastYear, rolling12);
+    const row = result.find((r) => r.category === 'Food')!;
+    expect(row.avg12m).toBeCloseTo(100);    // not 300/12
+    expect(row.median12m).toBeCloseTo(100);
+    expect(row.medianDelta).toBeCloseTo(100);
   });
 
   it('excludes hidden categories', async () => {

--- a/tests/gui-bridge-parity.test.ts
+++ b/tests/gui-bridge-parity.test.ts
@@ -37,6 +37,11 @@ const EXPECTED_UNBRIDGED: Record<string, string> = {
   fmtValue: 'renderer imports pure core/canvas-spec.ts directly',
   fmtDialValue: 'renderer imports pure core/canvas-spec.ts directly',
 
+  // Pure scorecard helpers — renderer imports core/scorecard.ts directly (GUI PR2)
+  bucketDrift: 'renderer imports pure core/scorecard.ts directly',
+  isSignificantDelta: 'renderer imports pure core/scorecard.ts directly',
+  ratioLabel: 'renderer imports pure core/scorecard.ts directly',
+
   // Electron-side bridge namespaces live in gui/main/bridge.ts (not registry.ts)
   getDefaultDaysRequested: 'bridge plaid namespace (gui/main/bridge.ts)',
 };

--- a/tests/scorecard.test.ts
+++ b/tests/scorecard.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { bucketDrift, isSignificantDelta, ratioLabel, SIGNIFICANCE_FLOOR } from '../core/scorecard.js';
+import type { CategoryDrift } from '../core/queries.js';
+
+// Minimal CategoryDrift with only the fields the scorecard cares about filled
+// meaningfully; the vs-prev/vs-year deltas are irrelevant to bucketing.
+const row = (category: string, current: number, median12m: number): CategoryDrift => ({
+  category, current,
+  lastPeriodDelta: 0, lastYearDelta: 0,
+  avg12m: median12m, avg12mDelta: current - median12m,
+  median12m, medianDelta: current - median12m,
+});
+
+describe('isSignificantDelta', () => {
+  it('requires the absolute floor on small baselines', () => {
+    expect(isSignificantDelta(49, 0)).toBe(false);
+    expect(isSignificantDelta(SIGNIFICANCE_FLOOR, 0)).toBe(true);
+    expect(isSignificantDelta(-49, 100)).toBe(false);
+    expect(isSignificantDelta(-60, 100)).toBe(true);
+  });
+
+  it('requires a share of the baseline on large baselines', () => {
+    // $100 over a $4,000 baseline is noise (needs $600)
+    expect(isSignificantDelta(100, 4000)).toBe(false);
+    expect(isSignificantDelta(700, 4000)).toBe(true);
+  });
+});
+
+describe('ratioLabel', () => {
+  it('formats a multiplier vs baseline', () => {
+    expect(ratioLabel(626, 149)).toBe('4.2x');
+    expect(ratioLabel(291, 762)).toBe('0.4x');
+  });
+
+  it('labels new spending with no baseline', () => {
+    expect(ratioLabel(100, 0)).toBe('new');
+    expect(ratioLabel(0, 0)).toBe('');
+  });
+});
+
+describe('bucketDrift', () => {
+  it('splits rows into over / typical / under', () => {
+    const { over, typical, under } = bucketDrift([
+      row('Transportation', 626, 149),   // +477, way over
+      row('Bills', 4112, 4132),          // -20, noise on a big baseline
+      row('Grocery', 291, 762),          // -471, well under
+    ]);
+    expect(over.map((r) => r.category)).toEqual(['Transportation']);
+    expect(typical.map((r) => r.category)).toEqual(['Bills']);
+    expect(under.map((r) => r.category)).toEqual(['Grocery']);
+  });
+
+  it('buckets zero-baseline new spending as over once past the floor', () => {
+    const { over, typical } = bucketDrift([
+      row('NewSub', 80, 0),
+      row('TinyNew', 20, 0),
+    ]);
+    expect(over.map((r) => r.category)).toEqual(['NewSub']);
+    expect(typical.map((r) => r.category)).toEqual(['TinyNew']);
+  });
+
+  it('sorts over worst-first and under biggest-saving-last', () => {
+    const { over, under } = bucketDrift([
+      row('Shopping', 1277, 1081),  // +196
+      row('Travel', 1471, 1011),    // +460
+      row('Grocery', 291, 762),     // -471
+      row('Dining', 633, 784),      // -151
+    ]);
+    expect(over.map((r) => r.category)).toEqual(['Travel', 'Shopping']);
+    expect(under.map((r) => r.category)).toEqual(['Dining', 'Grocery']);
+  });
+
+  it('nets deltas across all rows including typical ones', () => {
+    const { net } = bucketDrift([
+      row('Travel', 1471, 1011),  // +460
+      row('Grocery', 291, 762),   // -471
+      row('Bills', 4112, 4132),   // -20 (typical, still counted)
+    ]);
+    expect(net).toBeCloseTo(460 - 471 - 20);
+  });
+
+  it('preserves input order within typical', () => {
+    const { typical } = bucketDrift([
+      row('Bills', 4112, 4132),
+      row('Insurance', 162, 160),
+      row('Home', 271, 302),
+    ]);
+    expect(typical.map((r) => r.category)).toEqual(['Bills', 'Insurance', 'Home']);
+  });
+});

--- a/tests/tui/screens.test.tsx
+++ b/tests/tui/screens.test.tsx
@@ -279,11 +279,11 @@ describe('Dashboard', () => {
     }, 2000);
   });
 
-  it('d key toggles delta mode label', async () => {
+  it('s key toggles scorecard mode label', async () => {
     const r = dash();
     await waitFor(() => expect(frame(r)).toContain('Income'));
-    r.stdin.write('d');
-    await waitFor(() => expect(frame(r)).toContain('delta'));
+    r.stdin.write('s');
+    await waitFor(() => expect(frame(r)).toContain('scorecard'));
   });
 
   it('pressing a nav number calls onNavigate', async () => {

--- a/tui/Dashboard.tsx
+++ b/tui/Dashboard.tsx
@@ -4,8 +4,9 @@ import {
   getRangeSummary, getFlexSummary, getUncategorizedCount, getDataBounds, getAccountRows, getOwnerRows,
   getCategoryDriftData, getFlexDriftData, getAccountDriftData, countSearchMatches, getSearchFilteredData, getMerchantSummary,
   type MonthlySummary, type FlexSummary, type AccountRow, type OwnerRow,
-  type CategoryDrift, type FlexDriftData, type AccountDrift, type MerchantSummaryRow,
+  type CategoryDrift, type FlexDriftData, type AccountDrift, type MerchantSummaryRow, type DriftSlice,
 } from '../core/queries.js';
+import { bucketDrift, isSignificantDelta, ratioLabel } from '../core/scorecard.js';
 import {
   getPeriodStart, getPeriodDates, navigatePeriod, formatPeriodLabel,
   getDriftWindows,
@@ -31,14 +32,16 @@ function pct(part: number, total: number) {
   return `${Math.round((part / total) * 100)}%`;
 }
 
-/** Heat-map color based on current spend vs 12-month rolling average. */
-function driftColor(current: number, avg12m: number): string {
-  if (current === 0) return C_NEUTRAL;
-  if (avg12m === 0) return C_NEGATIVE;     // new spending with no history
-  const ratio = current / avg12m;
-  if (ratio <= 1.10) return C_POSITIVE;   // within 10% of average
-  if (ratio <= 1.30) return C_WARNING;    // creeping (10–30% over)
-  return C_NEGATIVE;                      // spiked (>30% over)
+/**
+ * Heat-map color vs the median baseline, gated on significance: rows inside
+ * the noise band stay neutral so only deltas worth acting on get color.
+ */
+function driftColor(slice: Pick<DriftSlice, 'current' | 'median12m' | 'medianDelta'>): string {
+  if (slice.current === 0 && slice.median12m === 0) return C_NEUTRAL;
+  if (!isSignificantDelta(slice.medianDelta, slice.median12m)) return C_NEUTRAL;
+  if (slice.medianDelta < 0) return C_POSITIVE;                    // meaningfully under
+  if (slice.median12m === 0) return C_NEGATIVE;                    // new spending, no history
+  return slice.current / slice.median12m >= 1.3 ? C_NEGATIVE : C_WARNING;
 }
 
 /** Format a drift delta value compactly (no cents). */
@@ -78,7 +81,8 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
   const [view, setView] = useState<DashView>('categories');
   const [bounds, setBounds] = useState<{ minDate: string; maxDate: string }>({ minDate: '2000-01-01', maxDate: '2099-12-31' });
   useEffect(() => { void getDataBounds().then(setBounds); }, []);
-  const [driftMode, setDriftMode] = useState(false);
+  const [scorecardMode, setScorecardMode] = useState(false);
+  const [detailMode, setDetailMode] = useState(false); // 'x': per-baseline delta columns
   const [catDrift,  setCatDrift]  = useState<CategoryDrift[] | null>(null);
   const [flexDrift, setFlexDrift] = useState<FlexDriftData  | null>(null);
   const [acctDrift, setAcctDrift] = useState<AccountDrift[] | null>(null);
@@ -146,7 +150,7 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
   }, [range, anchor.toISOString().slice(0, 10), queryFilter, refreshKey]);
 
   useEffect(() => {
-    if (!driftMode) { setCatDrift(null); setFlexDrift(null); setAcctDrift(null); return; }
+    if (!scorecardMode) { setCatDrift(null); setFlexDrift(null); setAcctDrift(null); return; }
     const windows = getDriftWindows(range, anchor, new Date());
     if (!windows) { setCatDrift(null); setFlexDrift(null); setAcctDrift(null); return; }
     const { current, lastPeriod, lastYear, rolling12 } = windows;
@@ -155,7 +159,7 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
     void getCategoryDriftData(current, lastPeriod, lastYear, rolling12, queryFilter).then(ok(setCatDrift));
     void getFlexDriftData(current, lastPeriod, lastYear, rolling12, queryFilter).then(ok(setFlexDrift));
     void getAccountDriftData(current, lastPeriod, lastYear, rolling12).then(ok(setAcctDrift));
-  }, [driftMode, range, anchor.toISOString().slice(0, 10), queryFilter]);
+  }, [scorecardMode, range, anchor.toISOString().slice(0, 10), queryFilter]);
 
   const setTyping = useSetTyping();
   useEffect(() => { setTyping(searchMode); }, [searchMode]);
@@ -188,7 +192,7 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
     setMerchantDrill(null);
     setMerchantRows([]);
     setMerchantCursor(0);
-  }, [queryFilter, search, driftMode, view]);
+  }, [queryFilter, search, scorecardMode, view]);
 
   // Re-fetch merchant data when period or range changes while drill is active
   useEffect(() => {
@@ -213,6 +217,29 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
 
   const categories = summary?.byCategory ?? [];
 
+  const scorecard = useMemo(() => (catDrift ? bucketDrift(catDrift) : null), [catDrift]);
+  // Flat render order (over → typical → under) shared by the cursor and Enter.
+  const scoreRows = useMemo(
+    () => (scorecard ? [...scorecard.over, ...scorecard.typical, ...scorecard.under] : []),
+    [scorecard],
+  );
+  const maxScoreDelta = Math.max(1, ...scoreRows.map((r) => Math.abs(r.medianDelta)));
+  const scoreTotal = scoreRows.reduce((s, r) => s + r.current, 0);
+  // Buckets with their starting offset in scoreRows, so each row knows its
+  // global index for cursor selection.
+  const scoreBuckets = useMemo(() => {
+    if (!scorecard) return [];
+    const defs = [
+      { key: 'over' as const,    label: 'OVER',    rows: scorecard.over },
+      { key: 'typical' as const, label: 'TYPICAL', rows: scorecard.typical },
+      { key: 'under' as const,   label: 'UNDER',   rows: scorecard.under },
+    ];
+    let start = 0;
+    return defs
+      .filter((d) => d.rows.length > 0)
+      .map((d) => { const b = { ...d, start }; start += d.rows.length; return b; });
+  }, [scorecard]);
+
   const termW = useTerminalWidth();
   const inner = Math.max(60, termW) - 4;
   // Normal categories: [sel+name] gap [amount=10] gap [bar] — 2 gaps of 2 = 16 reserved
@@ -225,9 +252,13 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
   // means an owner exists regardless of whether they spent anything this period.
   const hasOwners = ownerRows.some((r) => r.owner !== 'Unassigned');
   const maxOwnerSpend = ownerRows[0]?.spending ?? 1;
-  // Drift categories: 3 delta cols × 9 chars + 4 gaps of 2 = 27+8=35 for cols; plus amount(10)+gaps
+  // Drift detail: 3 delta cols × 9 chars + 4 gaps of 2 = 27+8=35 for cols; plus amount(10)+gaps
   // total fixed = 2(cursor) + 10(amt) + 4(gaps to amt) + 27(3×9) + 4(gaps between deltas) = 47
   const driftCatNameW = Math.max(12, inner - 47);
+  // Scorecard: [sel=2] [name] [amount=10] [delta=9] [bar] [ratio=5] with 5 gaps of 2 = 36 fixed
+  const scoreFlex  = Math.max(18, inner - 36);
+  const scoreNameW = Math.max(12, Math.min(20, Math.floor(scoreFlex * 0.55)));
+  const scoreBarW  = Math.max(6,  Math.min(14, scoreFlex - scoreNameW));
   // Normal flex: [label=18] gap [amount=10] gap [pct=4] gap [bar] — 3 gaps of 2
   const dashFlexBarW  = Math.max(8, inner - 38);
   // Account: [sel=2] gap [name] gap [col1=10] gap [col2=10] — 3 gaps of 2
@@ -307,10 +338,14 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
     }
 
     if (view === 'categories') {
-      const displayCats = displaySummary?.byCategory ?? [];
+      // Cursor and Enter track whatever list is actually rendered: scorecard
+      // buckets, drift detail rows, or the plain category breakdown.
+      const displayCats: Array<{ category: string }> = scorecardMode
+        ? (detailMode ? (catDrift ?? []) : scoreRows)
+        : (displaySummary?.byCategory ?? []);
       if (key.upArrow)   { setCatCursor((c) => Math.max(0, c - 1)); return; }
       if (key.downArrow) { setCatCursor((c) => Math.min(displayCats.length - 1, c + 1)); return; }
-      if (input === 'm' && !driftMode) {
+      if (input === 'm' && !scorecardMode) {
         const cat = displayCats[catCursor];
         if (cat) {
           const { from, to } = getPeriodDates(range, anchor);
@@ -373,7 +408,8 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
       return;
     }
 
-    if (input === 'd') { setDriftMode((m) => !m); return; }
+    if (input === 's') { setScorecardMode((m) => !m); setCatCursor(0); return; }
+    if (input === 'x' && scorecardMode) { setDetailMode((t) => !t); setCatCursor(0); return; }
 
     if (input === '/') {
       setSearchInput(search); // pre-fill with current search
@@ -420,12 +456,12 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
         : <Text dimColor>
             {showHints
               ? (view === 'account'
-                  ? `[/] search  ·  ← → period  ·  ↑↓ select  ·  Enter txns  ·  Space ${selectedAccount ? 'unfilter' : 'filter'}  ·  [c] clear  ·  [Tab] view  ·  [d] delta`
+                  ? `[/] search  ·  ← → period  ·  ↑↓ select  ·  Enter txns  ·  Space ${selectedAccount ? 'unfilter' : 'filter'}  ·  [c] clear  ·  [Tab] view  ·  [s] scorecard`
                   : view === 'categories'
-                    ? `[/] search  ·  ← → period  ·  ↑↓ select  ·  Enter txns${driftMode ? '' : '  ·  [m] merchants'}  ·  [Tab] view  ·  [d] delta`
+                    ? `[/] search  ·  ← → period  ·  ↑↓ select  ·  Enter txns${scorecardMode ? `  ·  [x] ${detailMode ? 'compact' : 'columns'}` : '  ·  [m] merchants'}  ·  [Tab] view  ·  [s] scorecard`
                     : view === 'owner'
                       ? '← → period  ·  [r] range  ·  [Tab] view'
-                      : '[/] search  ·  ← → period  ·  Enter txns  ·  [Tab] view  ·  [d] delta')
+                      : '[/] search  ·  ← → period  ·  Enter txns  ·  [Tab] view  ·  [s] scorecard')
               : '[/] search'}
           </Text>
       }
@@ -445,7 +481,7 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
             : <Text bold>{formatPeriodLabel(range, anchor)}</Text>
           }
           {selectedAccount && <Text color={C_WARNING}>{selectedAccount.name}</Text>}
-          {driftMode && <Text color={C_MANUAL} bold>delta</Text>}
+          {scorecardMode && <Text color={C_MANUAL} bold>{detailMode ? 'scorecard · columns' : 'scorecard'}</Text>}
           <Text dimColor>
             {merchantDrill ? `merchants · ${merchantDrill.category}` : view === 'categories' ? 'categories' : view === 'flex' ? 'flex' : view === 'account' ? 'account' : 'owner'}
           </Text>
@@ -482,15 +518,15 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
         <Box flexDirection="column" marginTop={1}>
           {accountRows.length === 0 ? (
             <Text dimColor>No accounts linked. [8] accounts → link a bank.</Text>
-          ) : driftMode && range === 'alltime' ? (
-            <Text dimColor>Delta not available for All Time range.</Text>
+          ) : scorecardMode && range === 'alltime' ? (
+            <Text dimColor>Scorecard not available for All Time range.</Text>
           ) : (
             <>
               <Box marginBottom={0}>
                 <Text dimColor>{'  '}</Text>
                 <Box gap={2}>
                   <Text dimColor>{'Account'.padEnd(dashAcctNameW)}</Text>
-                  {driftMode
+                  {scorecardMode
                     ? <Text dimColor>{'vs prev'.padStart(10)}</Text>
                     : <Text dimColor>{'Income'.padStart(10)}</Text>}
                   <Text dimColor>{'Expenses'.padStart(10)}</Text>
@@ -499,19 +535,19 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
               {accountRows.map((acct, i) => {
                 const isSelected = i === acctCursor;
                 const isFiltered = selectedAccount?.id === acct.id;
-                const drift = driftMode ? acctDrift?.find((d) => d.id === acct.id) : undefined;
-                const spendColor = drift ? driftColor(drift.current, drift.avg12m) : C_NEGATIVE;
+                const drift = scorecardMode ? acctDrift?.find((d) => d.id === acct.id) : undefined;
+                const spendColor = drift ? driftColor(drift) : C_NEGATIVE;
                 return (
                   <SelectableRow key={acct.id} selected={isSelected}>
                     <Text color={isFiltered ? C_WARNING : isSelected ? C_ACCENT : undefined} dimColor={!isSelected && !isFiltered}>
                       {(acct.name.length > dashAcctNameW ? acct.name.slice(0, dashAcctNameW - 1) + '…' : acct.name).padEnd(dashAcctNameW)}
                     </Text>
-                    {driftMode
+                    {scorecardMode
                       ? <Text color={drift ? spendColor : C_NEUTRAL} dimColor={!drift}>
                           {drift ? fmtDelta(drift.lastPeriodDelta).padStart(10) : '—'.padStart(10)}
                         </Text>
                       : <Text color={C_POSITIVE} dimColor={acct.income === 0}>{(acct.income > 0 ? fmt(acct.income) : '—').padStart(10)}</Text>}
-                    <Text color={driftMode ? spendColor : C_NEGATIVE} dimColor={acct.spending === 0}>
+                    <Text color={scorecardMode ? spendColor : C_NEGATIVE} dimColor={acct.spending === 0}>
                       {(acct.spending > 0 ? fmt(acct.spending) : '—').padStart(10)}
                     </Text>
                     {isFiltered && <Text color={C_WARNING}>  ●</Text>}
@@ -557,7 +593,13 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
 
           {view === 'categories' ? (
             <Box flexDirection="column" marginTop={1}>
-              <SectionHeader>{merchantDrill ? `TOP MERCHANTS · ${merchantDrill.category}` : 'SPENDING BY CATEGORY'}</SectionHeader>
+              <SectionHeader>
+                {merchantDrill
+                  ? `TOP MERCHANTS · ${merchantDrill.category}`
+                  : scorecardMode && !detailMode
+                    ? 'SPENDING BY CATEGORY · VS TYPICAL (12M MEDIAN)'
+                    : 'SPENDING BY CATEGORY'}
+              </SectionHeader>
               {merchantDrill ? (
                 <Box flexDirection="column" marginTop={1}>
                   {merchantRows.length === 0 ? (
@@ -579,9 +621,9 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
                   )}
                   {showHints && <Box marginTop={1}><Text dimColor>[Enter] transactions  ·  [Esc] back</Text></Box>}
                 </Box>
-              ) : driftMode && range === 'alltime' ? (
-                <Box marginTop={1}><Text dimColor>Delta not available for All Time range.</Text></Box>
-              ) : driftMode ? (
+              ) : scorecardMode && range === 'alltime' ? (
+                <Box marginTop={1}><Text dimColor>Scorecard not available for All Time range.</Text></Box>
+              ) : scorecardMode && detailMode ? (
                 <Box flexDirection="column" marginTop={1}>
                   {/* column headers */}
                   <Box>
@@ -599,7 +641,7 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
                   ) : (
                     (catDrift ?? []).map((row, i) => {
                       const isSelected = catCursor === i;
-                      const color = driftColor(row.current, row.avg12m);
+                      const color = driftColor(row);
                       const nameW = driftCatNameW;
                       return (
                         <SelectableRow key={`${row.category}-${i}`} selected={isSelected}>
@@ -613,6 +655,73 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
                         </SelectableRow>
                       );
                     })
+                  )}
+                </Box>
+              ) : scorecardMode ? (
+                <Box flexDirection="column" marginTop={1}>
+                  {scoreRows.length === 0 ? (
+                    <Text dimColor>No expense data for this period.</Text>
+                  ) : (
+                    <>
+                      <Box>
+                        <Text dimColor>{'  '}</Text>
+                        <Box gap={2}>
+                          <Text dimColor>{''.padEnd(scoreNameW)}</Text>
+                          <Text dimColor>{'amount'.padStart(10)}</Text>
+                          <Text dimColor>{'Δ typical'.padStart(9)}</Text>
+                        </Box>
+                      </Box>
+                      {scoreBuckets.map((bucket) => (
+                        <Box key={bucket.key} flexDirection="column">
+                          <Box>
+                            <Text
+                              bold
+                              color={bucket.key === 'over' ? C_NEGATIVE : bucket.key === 'under' ? C_POSITIVE : undefined}
+                              dimColor={bucket.key === 'typical'}
+                            >
+                              {'  '}{bucket.label}
+                            </Text>
+                            <Text dimColor> {'─'.repeat(Math.max(4, inner - bucket.label.length - 5))}</Text>
+                          </Box>
+                          {bucket.rows.map((row, i) => {
+                            const globalIdx = bucket.start + i;
+                            const isSelected = catCursor === globalIdx;
+                            const isTypical = bucket.key === 'typical';
+                            const color = isTypical ? undefined : driftColor(row);
+                            return (
+                              <SelectableRow key={row.category} selected={isSelected}>
+                                <Text color={isSelected ? C_ACCENT : color} dimColor={isTypical && !isSelected}>
+                                  {truncate(row.category, scoreNameW).padEnd(scoreNameW)}
+                                </Text>
+                                <Text color={C_NEUTRAL} dimColor={isTypical}>{fmt(row.current).padStart(10)}</Text>
+                                <Text color={color} dimColor={isTypical}>{fmtDelta(row.medianDelta).padStart(9)}</Text>
+                                {!isTypical && (
+                                  <>
+                                    <Text color={color}>{bar(Math.abs(row.medianDelta), maxScoreDelta, scoreBarW).padEnd(scoreBarW)}</Text>
+                                    <Text dimColor>{ratioLabel(row.current, row.median12m).padStart(5)}</Text>
+                                  </>
+                                )}
+                              </SelectableRow>
+                            );
+                          })}
+                        </Box>
+                      ))}
+                      <Box><Text dimColor>{'  '}{'─'.repeat(Math.max(4, inner - 2))}</Text></Box>
+                      <Box>
+                        <Text>{'  '}</Text>
+                        <Box gap={2}>
+                          <Text bold>{'NET'.padEnd(scoreNameW)}</Text>
+                          <Text color={C_NEUTRAL}>{fmt(scoreTotal).padStart(10)}</Text>
+                          <Text
+                            bold
+                            color={(scorecard?.net ?? 0) <= 0 ? C_POSITIVE : (scorecard?.net ?? 0) >= scoreTotal * 0.05 ? C_NEGATIVE : C_WARNING}
+                          >
+                            {fmtDelta(scorecard?.net ?? 0).padStart(9)}
+                          </Text>
+                          <Text dimColor>vs typical</Text>
+                        </Box>
+                      </Box>
+                    </>
                   )}
                 </Box>
               ) : (
@@ -641,9 +750,9 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
           ) : (
             <Box flexDirection="column" marginTop={1}>
               <SectionHeader>SPENDING BY FLEXIBILITY</SectionHeader>
-              {driftMode && range === 'alltime' ? (
-                <Box marginTop={1}><Text dimColor>Delta not available for All Time range.</Text></Box>
-              ) : driftMode ? (
+              {scorecardMode && range === 'alltime' ? (
+                <Box marginTop={1}><Text dimColor>Scorecard not available for All Time range.</Text></Box>
+              ) : scorecardMode ? (
                 <Box flexDirection="column" marginTop={1}>
                   {/* column headers */}
                   <Box gap={2}>
@@ -656,7 +765,7 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
                   {flexDrift && FLEX_TIERS.map(({ key, label }) => {
                     const slice = flexDrift[key];
                     if (slice.current === 0 && slice.avg12m === 0) return null;
-                    const color = driftColor(slice.current, slice.avg12m);
+                    const color = driftColor(slice);
                     return (
                       <Box key={key} gap={2}>
                         <Text color={color}>{'  '}{label.padEnd(16)}</Text>
@@ -684,7 +793,7 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
                   })}
                 </Box>
               )}
-              {!driftMode && displayFlexData && displayFlexData.untagged > 0 && !search && (
+              {!scorecardMode && displayFlexData && displayFlexData.untagged > 0 && !search && (
                 <Box marginTop={1}><Text dimColor>{pct(displayFlexData.untagged, totalExpenses)} untagged — set tiers in Rules → Categories</Text></Box>
               )}
             </Box>

--- a/tui/Dashboard.tsx
+++ b/tui/Dashboard.tsx
@@ -461,7 +461,7 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
                     ? `[/] search  ·  ← → period  ·  ↑↓ select  ·  Enter txns${scorecardMode ? `  ·  [x] ${detailMode ? 'compact' : 'columns'}` : '  ·  [m] merchants'}  ·  [Tab] view  ·  [s] scorecard`
                     : view === 'owner'
                       ? '← → period  ·  [r] range  ·  [Tab] view'
-                      : '[/] search  ·  ← → period  ·  Enter txns  ·  [Tab] view  ·  [s] scorecard')
+                      : `[/] search  ·  ← → period  ·  Enter txns${scorecardMode ? `  ·  [x] ${detailMode ? 'compact' : 'columns'}` : ''}  ·  [Tab] view  ·  [s] scorecard`)
               : '[/] search'}
           </Text>
       }
@@ -527,7 +527,7 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
                 <Box gap={2}>
                   <Text dimColor>{'Account'.padEnd(dashAcctNameW)}</Text>
                   {scorecardMode
-                    ? <Text dimColor>{'vs prev'.padStart(10)}</Text>
+                    ? <Text dimColor>{'Δ typical'.padStart(10)}</Text>
                     : <Text dimColor>{'Income'.padStart(10)}</Text>}
                   <Text dimColor>{'Expenses'.padStart(10)}</Text>
                 </Box>
@@ -544,7 +544,7 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
                     </Text>
                     {scorecardMode
                       ? <Text color={drift ? spendColor : C_NEUTRAL} dimColor={!drift}>
-                          {drift ? fmtDelta(drift.lastPeriodDelta).padStart(10) : '—'.padStart(10)}
+                          {drift ? fmtDelta(drift.medianDelta).padStart(10) : '—'.padStart(10)}
                         </Text>
                       : <Text color={C_POSITIVE} dimColor={acct.income === 0}>{(acct.income > 0 ? fmt(acct.income) : '—').padStart(10)}</Text>}
                     <Text color={scorecardMode ? spendColor : C_NEGATIVE} dimColor={acct.spending === 0}>
@@ -752,7 +752,7 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
               <SectionHeader>SPENDING BY FLEXIBILITY</SectionHeader>
               {scorecardMode && range === 'alltime' ? (
                 <Box marginTop={1}><Text dimColor>Scorecard not available for All Time range.</Text></Box>
-              ) : scorecardMode ? (
+              ) : scorecardMode && detailMode ? (
                 <Box flexDirection="column" marginTop={1}>
                   {/* column headers */}
                   <Box gap={2}>
@@ -773,6 +773,29 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
                         <Text color={color}>{fmtDelta(slice.lastPeriodDelta).padStart(9)}</Text>
                         <Text color={color}>{fmtDelta(slice.lastYearDelta).padStart(9)}</Text>
                         <Text color={color}>{fmtDelta(slice.avg12mDelta).padStart(9)}</Text>
+                      </Box>
+                    );
+                  })}
+                </Box>
+              ) : scorecardMode ? (
+                <Box flexDirection="column" marginTop={1}>
+                  {/* Same verdict column as the category scorecard: the displayed
+                      delta is the number the color is keyed to. */}
+                  <Box gap={2}>
+                    <Text dimColor>{''.padEnd(18)}</Text>
+                    <Text dimColor>{'amount'.padStart(10)}</Text>
+                    <Text dimColor>{'Δ typical'.padStart(9)}</Text>
+                  </Box>
+                  {flexDrift && FLEX_TIERS.map(({ key, label }) => {
+                    const slice = flexDrift[key];
+                    if (slice.current === 0 && slice.avg12m === 0) return null;
+                    const color = driftColor(slice);
+                    return (
+                      <Box key={key} gap={2}>
+                        <Text color={color}>{'  '}{label.padEnd(16)}</Text>
+                        <Text color={C_NEUTRAL}>{fmt(slice.current).padStart(10)}</Text>
+                        <Text color={color}>{fmtDelta(slice.medianDelta).padStart(9)}</Text>
+                        <Text dimColor>{ratioLabel(slice.current, slice.median12m).padStart(6)}</Text>
                       </Box>
                     );
                   })}

--- a/tui/Health.tsx
+++ b/tui/Health.tsx
@@ -4,6 +4,9 @@ import type { Screen } from './App.js';
 import { fmt, fmtSigned, fmtPct, fmtMonths, fmtCompact, Divider } from './fmt.js';
 import { handleNavKey } from './nav.js';
 import { loadHealthData, yearsToFire, coastYears, type HealthData } from '../core/health.js';
+import { getCategoryDriftData } from '../core/queries.js';
+import { getDriftWindows, getPeriodStart } from '../core/dateUtils.js';
+import { bucketDrift, type Scorecard } from '../core/scorecard.js';
 import { C_POSITIVE, C_NEGATIVE, C_WARNING, C_NEUTRAL, C_ACCENT } from './ui.js';
 import { SectionHeader, PageHeader, DialRow } from './components/index.js';
 import { useRefreshKey } from './RefreshContext.js';
@@ -57,6 +60,17 @@ export function Health({ onNavigate, isActive, showHints }: { onNavigate: (s: Sc
       setMonthlySpend(Math.max(SPEND_STEP, Math.round(d.avgMonthlyExpenses / SPEND_STEP) * SPEND_STEP));
       setMonthlySavings(Math.round(d.monthlySavings / SPEND_STEP) * SPEND_STEP);
     });
+  }, [refreshKey]);
+
+  // Trailing-30-day scorecard: which categories drifted from typical recently.
+  const [scorecard, setScorecard] = useState<Scorecard | null>(null);
+  useEffect(() => {
+    const today = new Date();
+    const windows = getDriftWindows('last30', getPeriodStart('last30', today), today);
+    if (!windows) return;
+    const { current, lastPeriod, lastYear, rolling12 } = windows;
+    void getCategoryDriftData(current, lastPeriod, lastYear, rolling12)
+      .then((rows) => setScorecard(bucketDrift(rows)));
   }, [refreshKey]);
   const [withdrawal, setWithdrawal]     = useState(DEFAULT_WITHDRAWAL);
   const [growth, setGrowth]             = useState(DEFAULT_GROWTH);
@@ -218,6 +232,38 @@ export function Health({ onNavigate, isActive, showHints }: { onNavigate: (s: Sc
           <Text dimColor>{fmt(data.liquid)} incl. brokerage</Text>
         </Box>
       </Box>
+
+      {/* ── Last 30 days scorecard strip ───────────────────────────────────── */}
+      {scorecard && (scorecard.over.length > 0 || scorecard.under.length > 0) && (
+        <Box flexDirection="column" marginTop={1}>
+          <SectionHeader>LAST 30 DAYS · VS TYPICAL</SectionHeader>
+          {scorecard.over.length > 0 && (
+            <Box gap={3} marginTop={1}>
+              <Text dimColor>{'Watch'.padEnd(L)}</Text>
+              <Text color={C_NEGATIVE}>
+                {scorecard.over.slice(0, 2).map((r) => `${r.category} ${fmtSigned(r.medianDelta, 0)}`).join('  ·  ')}
+              </Text>
+            </Box>
+          )}
+          {scorecard.under.length > 0 && (
+            <Box gap={3} marginTop={scorecard.over.length > 0 ? 0 : 1}>
+              <Text dimColor>{'Good'.padEnd(L)}</Text>
+              <Text color={C_POSITIVE}>
+                {[...scorecard.under]
+                  .sort((a, b) => a.medianDelta - b.medianDelta)
+                  .slice(0, 2)
+                  .map((r) => `${r.category} ${fmtSigned(r.medianDelta, 0)}`)
+                  .join('  ·  ')}
+              </Text>
+            </Box>
+          )}
+          <Box gap={3}>
+            <Text dimColor>{'Net'.padEnd(L)}</Text>
+            <Text bold color={scorecard.net <= 0 ? C_POSITIVE : C_WARNING}>{fmtSigned(scorecard.net, 0)}</Text>
+            <Text dimColor>[1] dashboard → [s] scorecard</Text>
+          </Box>
+        </Box>
+      )}
 
       {/* ── Debt (only shown if there is debt) ─────────────────────────────── */}
       {data.totalDebt > 0 && (


### PR DESCRIPTION
## What

Reworks the Dashboard's delta mode into a **scorecard** that answers: *where did my recent spending deviate from my own normal, ranked by how much it matters, with a verdict* — the actionability the Health page lacks. PR 1 of 3 (core + TUI + tests; GUI and MCP follow).

### Core
- **`last30` trailing range** (`dateUtils`): a trailing 30-day window is fully elapsed every day of the month, so the scorecard is never starved on day 3 the way month-to-date drift windows are. Appears in the Dashboard range cycle automatically.
- **Median baseline** (`queries`): `DriftSlice` gains `median12m`/`medianDelta`. The median absorbs one-off spikes ($7K medical month) that inflate the 12m mean and misreport following months as "good". Rolling windows predating the first transaction are now dropped — previously they contributed phantom zeros that dragged baselines down for short histories.
- **`core/scorecard.ts`** (new, pure): `bucketDrift()` → OVER / TYPICAL / UNDER + net. Significance gate: `|Δ| ≥ max($50, 15% × baseline)` — a $100 wiggle on a $4K baseline stays neutral; $80 of brand-new spending doesn't. Pure module so the GUI renderer imports it directly (no bridge changes needed in PR 2).

### TUI
- **Dashboard**: `s` toggles scorecard mode (replaces `d`/delta). OVER (worst first) / TYPICAL (dim, collapsed noise) / UNDER (biggest saving last) with bars scaled to |Δ$|, a ratio column (`4.2x`, `new`), and a NET verdict row. `x` switches to the previous 3-column diagnostic table. Flex/account deltas adopt significance-gated median coloring.
- **Health**: "Last 30 days vs typical" strip — top 2 overs, top 2 unders, net — pointing at the full scorecard.

## Tests
- `last30` window math (period dates, navigation, labels, drift windows contiguity)
- median-vs-mean spike resistance; phantom-zero window clamping
- `bucketDrift` gate, sorting, net
- Updated: TUI screen test (`d`→`s`), GUI bridge parity (scorecard helpers recorded as pure/unbridged)

`vitest run`: 615 passing; the 2 prior failures were the tests updated above. The 10 ESM loader errors in `tests/gui` are pre-existing on dev (reproduced with changes stashed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)