### PR TITLE
GUI spending scorecard: Dashboard buckets + Health last-30-days panel

### DIFF
--- a/gui/renderer/src/screens/Dashboard.module.css
+++ b/gui/renderer/src/screens/Dashboard.module.css
@@ -289,6 +289,27 @@
   background: var(--bg-hover);
 }
 
+.bucketRow td {
+  text-align: left !important;
+  font-size: 11.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+  font-weight: 600;
+  padding-top: 12px;
+  border-bottom: 1px solid var(--border);
+}
+
+.netRow td {
+  border-top: 1px solid var(--border);
+  font-weight: 600;
+  padding-top: 10px;
+}
+
+.netRow td:last-child {
+  text-align: left;
+  font-weight: 400;
+}
+
 .barTrack {
   height: 14px;
   border-radius: 4px;

--- a/gui/renderer/src/screens/Dashboard.tsx
+++ b/gui/renderer/src/screens/Dashboard.tsx
@@ -15,7 +15,8 @@ import {
   RANGE_LABELS,
   type Range,
 } from '../../../../core/dateUtils.js';
-import type { AccountRow, CategoryDrift, FlexSummary } from '../../../../core/queries.js';
+import type { AccountRow, CategoryDrift, DriftSlice, FlexSummary } from '../../../../core/queries.js';
+import { bucketDrift, isSignificantDelta, ratioLabel } from '../../../../core/scorecard.js';
 import { mergeFilters, type Filter } from '../../../../core/filters.js';
 import { useFilter } from '../hooks/useFilter.js';
 import type { TxFilter } from '../../../shared/nav.js';
@@ -34,15 +35,24 @@ function pct(part: number, total: number) {
   return total === 0 ? '0%' : `${Math.round((part / total) * 100)}%`;
 }
 
-/** Heat-map class based on current spend vs 12-month rolling average (mirrors TUI driftColor). */
-function driftClass(current: number, avg12m: number): string {
-  if (current === 0) return '';
-  if (avg12m === 0) return 'neg'; // new spending with no history
-  const ratio = current / avg12m;
-  if (ratio <= 1.1) return 'pos';
-  if (ratio <= 1.3) return 'warn';
-  return 'neg';
+/**
+ * Heat-map class vs the median baseline, gated on significance (mirrors TUI
+ * driftColor): rows inside the noise band stay neutral so only deltas worth
+ * acting on get color.
+ */
+function driftClass(slice: Pick<DriftSlice, 'current' | 'median12m' | 'medianDelta'>): string {
+  if (slice.current === 0 && slice.median12m === 0) return '';
+  if (!isSignificantDelta(slice.medianDelta, slice.median12m)) return '';
+  if (slice.medianDelta < 0) return 'pos';                       // meaningfully under
+  if (slice.median12m === 0) return 'neg';                       // new spending, no history
+  return slice.current / slice.median12m >= 1.3 ? 'neg' : 'warn';
 }
+
+const BUCKET_META = {
+  over:    { label: 'Over',    cls: 'neg' },
+  typical: { label: 'Typical', cls: 'dim' },
+  under:   { label: 'Under',   cls: 'pos' },
+} as const;
 
 function fmtDelta(delta: number): string {
   return delta === 0 ? '—' : fmtSigned(delta, 0);
@@ -74,7 +84,8 @@ export function Dashboard() {
     return getPeriodStart(initialRange, now);
   });
   const [view, setView] = useState<DashView>('categories');
-  const [driftMode, setDriftMode] = useState(false);
+  const [scorecardMode, setScorecardMode] = useState(txFilter.scorecard ?? false);
+  const [detailMode, setDetailMode] = useState(false); // sortable per-baseline delta columns
   const [searchInput, setSearchInput] = useState(txFilter.search ?? '');
   const [search, setSearch] = useState(txFilter.search ?? '');
   const [selectedAccount, setSelectedAccount] = useState<AccountRow | null>(null);
@@ -104,27 +115,27 @@ export function Dashboard() {
   const accountRows = useQuery(() => api.queries.getAccountRows(from, to, filter), [from, to, acctId, sharedFilter]);
   const ownerRows = useQuery(() => api.queries.getOwnerRows(from, to, filter), [from, to, acctId, sharedFilter]);
 
-  const driftWindows = driftMode ? getDriftWindows(range, anchor, new Date()) : null;
+  const driftWindows = scorecardMode ? getDriftWindows(range, anchor, new Date()) : null;
   const catDrift = useQuery(
     () =>
       driftWindows
         ? api.queries.getCategoryDriftData(driftWindows.current, driftWindows.lastPeriod, driftWindows.lastYear, driftWindows.rolling12, filter)
         : Promise.resolve(null),
-    [driftMode, from, to, acctId, sharedFilter],
+    [scorecardMode, from, to, acctId, sharedFilter],
   );
   const flexDrift = useQuery(
     () =>
       driftWindows
         ? api.queries.getFlexDriftData(driftWindows.current, driftWindows.lastPeriod, driftWindows.lastYear, driftWindows.rolling12, filter)
         : Promise.resolve(null),
-    [driftMode, from, to, acctId, sharedFilter],
+    [scorecardMode, from, to, acctId, sharedFilter],
   );
   const acctDrift = useQuery(
     () =>
       driftWindows
         ? api.queries.getAccountDriftData(driftWindows.current, driftWindows.lastPeriod, driftWindows.lastYear, driftWindows.rolling12)
         : Promise.resolve(null),
-    [driftMode, from, to],
+    [scorecardMode, from, to],
   );
 
   const searchStats = useQuery(
@@ -158,6 +169,12 @@ export function Dashboard() {
       return desc ? -cmp : cmp;
     });
   }, [catDrift, driftSort]);
+
+  const scorecard = useMemo(() => (catDrift ? bucketDrift(catDrift) : null), [catDrift]);
+  const maxScoreDelta = scorecard
+    ? Math.max(1, ...[...scorecard.over, ...scorecard.under].map((r) => Math.abs(r.medianDelta)))
+    : 1;
+  const scoreTotal = (catDrift ?? []).reduce((s, r) => s + r.current, 0);
 
   function goPeriod(delta: -1 | 1) {
     if (range === 'alltime') return;
@@ -201,7 +218,8 @@ export function Dashboard() {
       const idx = RANGES.indexOf(range);
       pickRange(RANGES[(idx + 1) % RANGES.length]);
     },
-    d: () => setDriftMode((m) => !m),
+    s: () => setScorecardMode((m) => !m),
+    x: () => { if (scorecardMode) setDetailMode((t) => !t); },
     Tab: () => {
       setMerchantDrill(null);
       setView((v) => views[(views.indexOf(v) + 1) % views.length]);
@@ -220,7 +238,7 @@ export function Dashboard() {
 
   return (
     <div className={styles.screen}>
-      <KeyHints hints="[1-9·0] screens   [r] range   [d] delta   [tab] view   [← →] period   [/] search   [esc] back" />
+      <KeyHints hints={`[1-9·0] screens   [r] range   [s] scorecard${scorecardMode ? '   [x] columns' : ''}   [tab] view   [← →] period   [/] search   [esc] back`} />
       <div className={styles.topBar}>
         <h1 className={styles.title}>Dashboard</h1>
         <div className={styles.periodNav}>
@@ -254,12 +272,21 @@ export function Dashboard() {
           ))}
         </div>
         <button
-          className={driftMode ? styles.driftBtnActive : styles.driftBtn}
-          onClick={() => setDriftMode((m) => !m)}
-          title="Compare against prior periods"
+          className={scorecardMode ? styles.driftBtnActive : styles.driftBtn}
+          onClick={() => setScorecardMode((m) => !m)}
+          title="Which categories drifted from your typical month, and does it matter"
         >
-          Δ delta
+          Δ scorecard
         </button>
+        {scorecardMode && (
+          <button
+            className={detailMode ? styles.driftBtnActive : styles.driftBtn}
+            onClick={() => setDetailMode((t) => !t)}
+            title="Sortable per-baseline delta columns (vs prev / yr ago / 12m avg)"
+          >
+            columns
+          </button>
+        )}
         <div className={styles.searchWrap}>
           <input
             ref={searchRef}
@@ -365,10 +392,10 @@ export function Dashboard() {
 
       {view === 'categories' && !merchantDrill && (
         <section className={styles.panel}>
-          <h2>Spending by category</h2>
-          {driftMode && range === 'alltime' ? (
-            <p className="dim">Delta not available for All Time range.</p>
-          ) : driftMode ? (
+          <h2>{scorecardMode && !detailMode ? 'Spending by category · vs typical (12m median)' : 'Spending by category'}</h2>
+          {scorecardMode && range === 'alltime' ? (
+            <p className="dim">Scorecard not available for All Time range.</p>
+          ) : scorecardMode && detailMode ? (
             sortedDrift && sortedDrift.length === 0 ? (
               <p className="dim">No expense data for this period.</p>
             ) : (
@@ -384,7 +411,7 @@ export function Dashboard() {
                 </thead>
                 <tbody>
                   {(sortedDrift ?? []).map((row: CategoryDrift) => {
-                    const cls = driftClass(row.current, row.avg12m);
+                    const cls = driftClass(row);
                     return (
                       <tr
                         key={row.category}
@@ -399,6 +426,64 @@ export function Dashboard() {
                       </tr>
                     );
                   })}
+                </tbody>
+              </table>
+            )
+          ) : scorecardMode ? (
+            !scorecard || scorecard.over.length + scorecard.typical.length + scorecard.under.length === 0 ? (
+              <p className="dim">No expense data for this period.</p>
+            ) : (
+              <table className={styles.table}>
+                <thead>
+                  <tr>
+                    <th className={styles.th}>Category</th>
+                    <th className={styles.th}>Amount</th>
+                    <th className={styles.th}>Δ typical</th>
+                    <th className={styles.th}></th>
+                    <th className={styles.th}>Ratio</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {(['over', 'typical', 'under'] as const).map((bucket) => {
+                    const rows = scorecard[bucket];
+                    if (rows.length === 0) return null;
+                    const meta = BUCKET_META[bucket];
+                    return (
+                      <React.Fragment key={bucket}>
+                        <tr className={styles.bucketRow}>
+                          <td colSpan={5} className={meta.cls}>{meta.label}</td>
+                        </tr>
+                        {rows.map((row) => {
+                          const isTypical = bucket === 'typical';
+                          const cls = isTypical ? 'dim' : driftClass(row);
+                          const barColor = cls === 'pos' ? 'var(--positive)' : cls === 'warn' ? 'var(--warning)' : 'var(--negative)';
+                          return (
+                            <tr
+                              key={row.category}
+                              className={styles.rowClickable}
+                              onClick={() => drillToTransactions({ categories: [row.category] })}
+                            >
+                              <td className={`${styles.tdName} ${cls}`}>{row.category}</td>
+                              <td className={`num ${isTypical ? 'dim' : ''}`}>{fmt(row.current)}</td>
+                              <td className={`num ${cls}`}>{fmtDelta(row.medianDelta)}</td>
+                              <td className={styles.tdBar}>
+                                {!isTypical && <Bar value={Math.abs(row.medianDelta)} max={maxScoreDelta} color={barColor} />}
+                              </td>
+                              <td className="num dim">{isTypical ? '' : ratioLabel(row.current, row.median12m)}</td>
+                            </tr>
+                          );
+                        })}
+                      </React.Fragment>
+                    );
+                  })}
+                  <tr className={styles.netRow}>
+                    <td className={styles.tdName}>Net</td>
+                    <td className="num">{fmt(scoreTotal)}</td>
+                    <td className={`num ${scorecard.net <= 0 ? 'pos' : scorecard.net >= scoreTotal * 0.05 ? 'neg' : 'warn'}`}>
+                      {fmtDelta(scorecard.net)}
+                    </td>
+                    <td colSpan={2} className="dim">vs typical</td>
+                  </tr>
                 </tbody>
               </table>
             )
@@ -443,9 +528,9 @@ export function Dashboard() {
       {view === 'flex' && (
         <section className={styles.panel}>
           <h2>Spending by flexibility</h2>
-          {driftMode && range === 'alltime' ? (
-            <p className="dim">Delta not available for All Time range.</p>
-          ) : driftMode && flexDrift ? (
+          {scorecardMode && range === 'alltime' ? (
+            <p className="dim">Scorecard not available for All Time range.</p>
+          ) : scorecardMode && flexDrift ? (
             <table className={styles.table}>
               <thead>
                 <tr>
@@ -460,7 +545,7 @@ export function Dashboard() {
                 {FLEX_TIERS.map(({ key, label, cssVar }) => {
                   const slice = flexDrift[key];
                   if (slice.current === 0 && slice.avg12m === 0) return null;
-                  const cls = driftClass(slice.current, slice.avg12m);
+                  const cls = driftClass(slice);
                   return (
                     <tr key={key}>
                       <td className={styles.tdName} style={{ color: cssVar }}>
@@ -527,22 +612,22 @@ export function Dashboard() {
           <h2>By account</h2>
           {(accountRows ?? []).length === 0 ? (
             <p className="dim">No accounts linked — add one in Accounts.</p>
-          ) : driftMode && range === 'alltime' ? (
-            <p className="dim">Delta not available for All Time range.</p>
+          ) : scorecardMode && range === 'alltime' ? (
+            <p className="dim">Scorecard not available for All Time range.</p>
           ) : (
             <table className={styles.table}>
               <thead>
                 <tr>
                   <th className={styles.th}>Account</th>
-                  <th className={styles.th}>{driftMode ? 'vs prev' : 'Income'}</th>
+                  <th className={styles.th}>{scorecardMode ? 'vs prev' : 'Income'}</th>
                   <th className={styles.th}>Expenses</th>
                   <th className={styles.th}>Filter</th>
                 </tr>
               </thead>
               <tbody>
                 {(accountRows ?? []).map((acct) => {
-                  const drift = driftMode ? acctDrift?.find((d) => d.id === acct.id) : undefined;
-                  const cls = drift ? driftClass(drift.current, drift.avg12m) : '';
+                  const drift = scorecardMode ? acctDrift?.find((d) => d.id === acct.id) : undefined;
+                  const cls = drift ? driftClass(drift) : '';
                   const isFiltered = selectedAccount?.id === acct.id;
                   return (
                     <tr
@@ -553,14 +638,14 @@ export function Dashboard() {
                       <td className={styles.tdName} style={isFiltered ? { color: 'var(--warning)' } : undefined}>
                         {acct.name}
                       </td>
-                      {driftMode ? (
+                      {scorecardMode ? (
                         <td className={`num ${cls}`}>{drift ? fmtDelta(drift.lastPeriodDelta) : '—'}</td>
                       ) : (
                         <td className={`num ${acct.income > 0 ? 'pos' : 'dim'}`}>
                           {acct.income > 0 ? fmt(acct.income) : '—'}
                         </td>
                       )}
-                      <td className={`num ${driftMode ? cls : acct.spending > 0 ? 'neg' : 'dim'}`}>
+                      <td className={`num ${scorecardMode ? cls : acct.spending > 0 ? 'neg' : 'dim'}`}>
                         {acct.spending > 0 ? fmt(acct.spending) : '—'}
                       </td>
                       <td className={styles.tdAction}>

--- a/gui/renderer/src/screens/Dashboard.tsx
+++ b/gui/renderer/src/screens/Dashboard.tsx
@@ -530,7 +530,7 @@ export function Dashboard() {
           <h2>Spending by flexibility</h2>
           {scorecardMode && range === 'alltime' ? (
             <p className="dim">Scorecard not available for All Time range.</p>
-          ) : scorecardMode && flexDrift ? (
+          ) : scorecardMode && detailMode && flexDrift ? (
             <table className={styles.table}>
               <thead>
                 <tr>
@@ -555,6 +555,34 @@ export function Dashboard() {
                       <td className={`num ${cls}`}>{fmtDelta(slice.lastPeriodDelta)}</td>
                       <td className={`num ${cls}`}>{fmtDelta(slice.lastYearDelta)}</td>
                       <td className={`num ${cls}`}>{fmtDelta(slice.avg12mDelta)}</td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          ) : scorecardMode && flexDrift ? (
+            <table className={styles.table}>
+              <thead>
+                <tr>
+                  <th className={styles.th}>Tier</th>
+                  <th className={styles.th}>Amount</th>
+                  <th className={styles.th}>Δ typical</th>
+                  <th className={styles.th}>Ratio</th>
+                </tr>
+              </thead>
+              <tbody>
+                {FLEX_TIERS.map(({ key, label, cssVar }) => {
+                  const slice = flexDrift[key];
+                  if (slice.current === 0 && slice.avg12m === 0) return null;
+                  const cls = driftClass(slice);
+                  return (
+                    <tr key={key}>
+                      <td className={styles.tdName} style={{ color: cssVar }}>
+                        {label}
+                      </td>
+                      <td className="num">{fmt(slice.current)}</td>
+                      <td className={`num ${cls}`}>{fmtDelta(slice.medianDelta)}</td>
+                      <td className="num dim">{ratioLabel(slice.current, slice.median12m)}</td>
                     </tr>
                   );
                 })}
@@ -619,7 +647,7 @@ export function Dashboard() {
               <thead>
                 <tr>
                   <th className={styles.th}>Account</th>
-                  <th className={styles.th}>{scorecardMode ? 'vs prev' : 'Income'}</th>
+                  <th className={styles.th}>{scorecardMode ? 'Δ typical' : 'Income'}</th>
                   <th className={styles.th}>Expenses</th>
                   <th className={styles.th}>Filter</th>
                 </tr>
@@ -639,7 +667,7 @@ export function Dashboard() {
                         {acct.name}
                       </td>
                       {scorecardMode ? (
-                        <td className={`num ${cls}`}>{drift ? fmtDelta(drift.lastPeriodDelta) : '—'}</td>
+                        <td className={`num ${cls}`}>{drift ? fmtDelta(drift.medianDelta) : '—'}</td>
                       ) : (
                         <td className={`num ${acct.income > 0 ? 'pos' : 'dim'}`}>
                           {acct.income > 0 ? fmt(acct.income) : '—'}

--- a/gui/renderer/src/screens/Health.module.css
+++ b/gui/renderer/src/screens/Health.module.css
@@ -164,3 +164,12 @@
 .dialHint {
   font-size: 12px;
 }
+
+.scorecardLink {
+  font-size: 12.5px;
+  text-decoration: underline;
+}
+
+.scorecardLink:hover {
+  color: var(--accent);
+}

--- a/gui/renderer/src/screens/Health.tsx
+++ b/gui/renderer/src/screens/Health.tsx
@@ -1,7 +1,10 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { api } from '../api.js';
 import { useQuery } from '../hooks/useQuery.js';
+import { useNav } from '../hooks/useNav.js';
 import { fmt, fmtSigned, fmtPct, fmtMonths, fmtCompact } from '../../../../core/fmt.js';
+import { getDriftWindows, getPeriodStart } from '../../../../core/dateUtils.js';
+import { bucketDrift } from '../../../../core/scorecard.js';
 import { KeyHints } from '../components/KeyHints.js';
 import styles from './Health.module.css';
 
@@ -27,7 +30,22 @@ function roundToStep(n: number): number {
 }
 
 export function Health() {
+  const { navigate } = useNav();
   const data = useQuery(() => api.health.loadHealthData(), []);
+
+  // Trailing-30-day scorecard: which categories drifted from typical recently.
+  const drift = useQuery(() => {
+    const today = new Date();
+    const w = getDriftWindows('last30', getPeriodStart('last30', today), today);
+    return w
+      ? api.queries.getCategoryDriftData(w.current, w.lastPeriod, w.lastYear, w.rolling12)
+      : Promise.resolve(null);
+  }, []);
+  const scorecard = useMemo(() => (drift ? bucketDrift(drift) : null), [drift]);
+  const topUnder = useMemo(
+    () => (scorecard ? [...scorecard.under].sort((a, b) => a.medianDelta - b.medianDelta).slice(0, 2) : []),
+    [scorecard],
+  );
 
   const [monthlySpend, setMonthlySpend] = useState<number | null>(null);
   const [monthlySavings, setMonthlySavings] = useState<number | null>(null);
@@ -109,6 +127,40 @@ export function Health() {
             <span className={`dim ${styles.metricHint}`}>{fmt(data.liquid)} incl. brokerage</span>
           </div>
         </section>
+
+        {scorecard && (scorecard.over.length > 0 || scorecard.under.length > 0) && (
+          <section className={styles.panel}>
+            <h2>Last 30 days · vs typical</h2>
+            {scorecard.over.length > 0 && (
+              <div className={styles.metric}>
+                <span className={styles.metricLabel}>Watch</span>
+                <span className={`neg ${styles.metricValue}`}>
+                  {scorecard.over.slice(0, 2).map((r) => `${r.category} ${fmtSigned(r.medianDelta, 0)}`).join('  ·  ')}
+                </span>
+              </div>
+            )}
+            {topUnder.length > 0 && (
+              <div className={styles.metric}>
+                <span className={styles.metricLabel}>Good</span>
+                <span className={`pos ${styles.metricValue}`}>
+                  {topUnder.map((r) => `${r.category} ${fmtSigned(r.medianDelta, 0)}`).join('  ·  ')}
+                </span>
+              </div>
+            )}
+            <div className={styles.metric}>
+              <span className={styles.metricLabel}>Net</span>
+              <span className={`num ${scorecard.net <= 0 ? 'pos' : 'warn'} ${styles.metricValue}`}>
+                {fmtSigned(scorecard.net, 0)}
+              </span>
+              <button
+                className={`dim ${styles.scorecardLink}`}
+                onClick={() => navigate('dashboard', { range: 'last30', scorecard: true })}
+              >
+                full scorecard →
+              </button>
+            </div>
+          </section>
+        )}
 
         {data.totalDebt > 0 && (
           <section className={styles.panel}>

--- a/gui/shared/nav.ts
+++ b/gui/shared/nav.ts
@@ -18,8 +18,9 @@ export type TxFilter = {
   from?: string;
   to?: string;
   search?: string;
-  range?: string; // 'week' | 'month' | 'quarter' | 'year' | 'alltime'
+  range?: string; // 'week' | 'month' | 'last30' | 'quarter' | 'year' | 'alltime'
   anchor?: string; // YYYY-MM-DD — which specific period to land on
+  scorecard?: boolean; // land on the Dashboard with scorecard mode on
   canvasSpec?: string; // JSON-encoded CanvasSpec, used when navigating to 'canvas'
   txType?: 'income' | 'expenses';
   flex?: 'fixed' | 'flexible' | 'discretionary';

--- a/tests/gui/dashboard.test.tsx
+++ b/tests/gui/dashboard.test.tsx
@@ -76,6 +76,60 @@ describe('GUI Dashboard', () => {
     );
   });
 
+  it('scorecard mode buckets categories vs the typical-month baseline', async () => {
+    renderScreen(<Dashboard />, { txFilter: MAY_FILTER });
+    await waitFor(() => expect(screen.getByText('Grocery')).toBeTruthy());
+    await userEvent.click(screen.getByRole('button', { name: 'Δ scorecard' }));
+
+    const section = await waitFor(() => {
+      const s = screen.getByText(/Spending by category · vs typical/).closest('section')!;
+      expect(s.textContent).toContain('Over');
+      return s;
+    });
+    // Grocery: May $205 vs April-only baseline $100 → over by $105.
+    // Bills & Utilities: $95 with no history → over, flagged "new".
+    // Dining (+$5) and Shopping ($43.99, no baseline) sit under the
+    // significance gate → typical. Nothing is under → no Under section.
+    expect(section.textContent).toContain('+$105');
+    expect(section.textContent).toContain('+$95');
+    expect(section.textContent).toContain('new');
+    expect(section.textContent).toContain('Typical');
+    expect(section.textContent).not.toContain('Under');
+    // Net row: 105 + 5 + 95 + 43.99 ≈ +$249 vs typical.
+    expect(section.textContent).toContain('+$249');
+    expect(section.textContent).toContain('vs typical');
+  });
+
+  it('scorecard rows drill to transactions like category rows', async () => {
+    const navigate = vi.fn();
+    renderScreen(<Dashboard />, { txFilter: MAY_FILTER, navigate });
+    await waitFor(() => expect(screen.getByText('Grocery')).toBeTruthy());
+    await userEvent.click(screen.getByRole('button', { name: 'Δ scorecard' }));
+    await waitFor(() => expect(screen.getByText('Over')).toBeTruthy());
+    await userEvent.click(screen.getByText('Grocery'));
+    expect(navigate).toHaveBeenCalledWith(
+      'transactions',
+      expect.objectContaining({ from: '2026-05-01', to: '2026-05-31', drillFrom: 'dashboard' }),
+    );
+  });
+
+  it('columns toggle switches to the sortable per-baseline delta table', async () => {
+    renderScreen(<Dashboard />, { txFilter: MAY_FILTER });
+    await waitFor(() => expect(screen.getByText('Grocery')).toBeTruthy());
+    await userEvent.click(screen.getByRole('button', { name: 'Δ scorecard' }));
+    await waitFor(() => expect(screen.getByRole('button', { name: 'columns' })).toBeTruthy());
+    await userEvent.click(screen.getByRole('button', { name: 'columns' }));
+    // The diagnostic table has the three baseline columns; the scorecard doesn't.
+    await waitFor(() => expect(screen.getByText(/vs prev/)).toBeTruthy());
+    expect(screen.getByText(/yr ago/)).toBeTruthy();
+    expect(screen.getByText(/12m avg/)).toBeTruthy();
+  });
+
+  it('mounts with scorecard mode on when navigated with scorecard: true', async () => {
+    renderScreen(<Dashboard />, { txFilter: { ...MAY_FILTER, scorecard: true } });
+    await waitFor(() => expect(screen.getByText(/Spending by category · vs typical/)).toBeTruthy());
+  });
+
   it('Spending by category rows sum to the displayed Expenses total', async () => {
     // Exercise the two cases that used to break reconciliation: a refund inside a
     // real category (must NET to 200) and an income+spend mix inside Uncategorized

--- a/tests/gui/health.test.tsx
+++ b/tests/gui/health.test.tsx
@@ -61,6 +61,34 @@ describe('GUI Health', () => {
     expect(restored).toBe(before);
   });
 
+  it('hides the last-30-days panel when the trailing window has no drift', async () => {
+    // Seed data is fixed in May 2026; the trailing 30 days (real clock) is empty.
+    renderScreen(<Health />);
+    await waitFor(() => expect(screen.getByText('Snapshot')).toBeTruthy());
+    expect(screen.queryByText(/Last 30 days/)).toBeNull();
+  });
+
+  it('shows recent movers and deep-links to the Dashboard scorecard', async () => {
+    // Date the spend relative to the real clock so it always falls inside the
+    // trailing 30-day window; with no Transportation history it buckets as over.
+    const recent = new Date();
+    recent.setDate(recent.getDate() - 5);
+    await db.execute({
+      sql: `INSERT INTO transactions (id, account_id, date, name, amount, category, pending, ignored)
+            VALUES ('tx-transport', 'test-credit', ?, 'Uber', 500.00, 'Transportation', 0, 0)`,
+      args: [recent.toISOString().slice(0, 10)],
+    });
+
+    const navigate = vi.fn();
+    renderScreen(<Health />, { navigate });
+    await waitFor(() => expect(screen.getByText(/Last 30 days/)).toBeTruthy());
+    expect(screen.getByText('Watch')).toBeTruthy();
+    expect(screen.getByText(/Transportation \+\$500/)).toBeTruthy();
+
+    await userEvent.click(screen.getByRole('button', { name: /full scorecard/ }));
+    expect(navigate).toHaveBeenCalledWith('dashboard', { range: 'last30', scorecard: true });
+  });
+
   it('withdrawal slider changes the FIRE number', async () => {
     renderScreen(<Health />);
     await waitFor(() => expect(screen.getByText('FIRE number')).toBeTruthy());


### PR DESCRIPTION
## What

PR 2 of 3 — GUI wiring for the spending scorecard. **Stacked on #104**; GitHub will retarget this to `dev` when #104 merges.

### Dashboard
- `s` toggles **scorecard mode** (replaces `d`/delta), matching the TUI. Default view: bucketed **Over / Typical / Under** table — |Δ$|-scaled bars, ratio column (`4.2x`, `new`), and a **Net** verdict row. Rows click through to Transactions as before.
- The previous sortable delta table (vs prev / yr ago / 12m avg) lives behind a **columns** toggle (`x` or button) for diagnosis.
- Flex and account deltas use the significance-gated median coloring (`driftClass` mirrors TUI `driftColor`).
- The **30 Days** range pill appears automatically via the shared `RANGES` constant.

### Health
- New **"Last 30 days · vs typical"** panel: Watch (top 2 overs), Good (top 2 unders), Net — with a *full scorecard →* link that lands on the Dashboard with `range=last30` + scorecard on (new `TxFilter.scorecard` nav param).

### Notes
- No bridge/registry changes: `bucketDrift`/`ratioLabel`/`isSignificantDelta` are pure `core/scorecard.ts` imports (recorded in the bridge-parity test in #104).
- Verified: renderer + root typecheck, `gh` bridge-parity test, `electron-vite build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)