### PR TITLE
MCP scorecard: rename get_drift → get_scorecard with bucketed verdict output

### DIFF
--- a/core/tools.ts
+++ b/core/tools.ts
@@ -11,9 +11,10 @@ import { writeFileSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { notifyChange } from './refresh.js';
 import { DATA_DIR } from './paths.js';
-import { getRangeSummary, getMonthlySummary, getTagSummary, getCategoryDriftData, getMerchantSummary, getNetWorthHistory, getLinkedAccounts, type NetWorthGranularity } from './queries.js';
+import { getRangeSummary, getMonthlySummary, getTagSummary, getCategoryDriftData, getMerchantSummary, getNetWorthHistory, getLinkedAccounts, type NetWorthGranularity, type CategoryDrift } from './queries.js';
 import { solveTVM } from './calculator.js';
-import { getDriftWindows } from './dateUtils.js';
+import { getDriftWindows, getPeriodStart, formatPeriodLabel } from './dateUtils.js';
+import { bucketDrift, ratioLabel } from './scorecard.js';
 import { getBalances, getFinancialHealth, getSpendingTrends } from './agent-context.js';
 import { getFinanceGuide, getFinanceTopicList, formatGuideSection, type GuideTopic } from './finance-guide.js';
 import { applyCategoriesToAll } from './categorize.js';
@@ -112,14 +113,15 @@ export const TOOL_DEFS: ToolDef[] = [
     },
   },
   {
-    name: 'get_drift',
-    description: 'Show spending deltas for each category: current amount vs prior period, same period last year, and 12-month rolling average. Useful for spotting categories where spending is quietly creeping up. Defaults to the current month-to-date.',
+    name: 'get_scorecard',
+    description: 'Spending scorecard: which categories are significantly over or under the typical month (12-month median baseline), with per-category deltas and a net verdict. Use for "how am I doing lately / where did my spending go wrong". Defaults to the trailing 30 days, which is fully populated even early in a calendar month.',
     parameters: {
       type: 'object',
       properties: {
+        window: { type: 'string', enum: ['last30', 'month'], description: "Comparison window: 'last30' = trailing 30 days ending on the given date (default), 'month' = calendar month-to-date" },
         year:  { type: 'integer', description: '4-digit year (default: current year)' },
         month: { type: 'integer', description: 'Month 1–12 (default: current month)', minimum: 1, maximum: 12 },
-        day:   { type: 'integer', description: 'Day of month to compare through — use for partial-month MTD (default: today)', minimum: 1, maximum: 31 },
+        day:   { type: 'integer', description: 'Day the window ends on (last30) or compares through (month) — default: today', minimum: 1, maximum: 31 },
       },
     },
   },
@@ -566,39 +568,51 @@ async function executeToolImpl(
       ].join('\n');
     }
 
-    case 'get_drift': {
+    case 'get_scorecard': {
       const today = new Date();
       const year  = input['year']  ? num('year')  : today.getFullYear();
       const month = input['month'] ? num('month') : today.getMonth() + 1;
       const day   = input['day']   ? num('day')   : today.getDate();
-      const anchor = new Date(year, month - 1, 1, 12);
+      const windowKind = input['window'] === 'month' ? 'month' as const : 'last30' as const;
       const asOf   = new Date(year, month - 1, day, 12);
-      const windows = getDriftWindows('month', anchor, asOf);
-      if (!windows) return 'Drift is not available for this range.';
+      const anchor = windowKind === 'month' ? new Date(year, month - 1, 1, 12) : getPeriodStart('last30', asOf);
+      const windows = getDriftWindows(windowKind, anchor, asOf);
+      if (!windows) return 'Scorecard is not available for this range.';
       const { current, lastPeriod, lastYear, rolling12 } = windows;
       const rows = await getCategoryDriftData(current, lastPeriod, lastYear, rolling12);
-      if (!rows.length) return `No expense data for ${year}-${String(month).padStart(2, '0')} through day ${day}.`;
-      const fmtAmt   = (n: number) => fmt(n, 0);
+      const label = windowKind === 'last30'
+        ? `last 30 days (${formatPeriodLabel('last30', anchor)})`
+        : `${year}-${String(month).padStart(2, '0')} through day ${day}`;
+      if (!rows.length) return `No expense data for ${label}.`;
+
+      const { over, typical, under, net } = bucketDrift(rows);
+      const name = (c: string) => c.length > 24 ? c.slice(0, 23) + '…' : c.padEnd(24);
       const signedFmt = (n: number) => n === 0 ? '—' : fmtSigned(n, 0);
-      const heat = (current: number, avg: number) => {
-        if (avg === 0) return current > 0 ? ' 🔴' : '';
-        const r = current / avg;
-        if (r <= 1.10) return ' 🟢';
-        if (r <= 1.30) return ' 🟡';
-        return ' 🔴';
+      const line = (r: CategoryDrift, mark: string) => {
+        const ratio = ratioLabel(r.current, r.median12m);
+        return `  ${name(r.category)} ${fmt(r.current, 0).padStart(9)}  ${signedFmt(r.medianDelta).padStart(8)} vs typical` +
+          (ratio ? `  (${ratio})` : '') + ` ${mark}`;
       };
-      const header = `Drift — ${year}-${String(month).padStart(2, '0')} through day ${day}\n` +
-        `${'Category'.padEnd(26)} ${'Current'.padStart(10)} ${'vs Last'.padStart(10)} ${'vs Yr'.padStart(10)} ${'vs 12m'.padStart(10)}`;
-      const divider = '─'.repeat(header.split('\n')[1].length);
-      const lines = rows.map((r) =>
-        `${r.category.length > 26 ? r.category.slice(0, 25) + '…' : r.category.padEnd(26)} ` +
-        `${fmtAmt(r.current).padStart(10)} ` +
-        `${signedFmt(r.lastPeriodDelta).padStart(10)} ` +
-        `${signedFmt(r.lastYearDelta).padStart(10)} ` +
-        `${signedFmt(r.avg12mDelta).padStart(10)}` +
-        heat(r.current, r.avg12m)
-      );
-      return [header.split('\n')[0], divider, header.split('\n')[1], divider, ...lines].join('\n');
+      const overMark = (r: CategoryDrift) =>
+        r.median12m === 0 || r.current / r.median12m >= 1.3 ? '🔴' : '🟡';
+
+      const out: string[] = [`Scorecard — ${label} · vs typical month (12-month median)`];
+      if (over.length) {
+        out.push('', 'OVER');
+        for (const r of over) out.push(line(r, overMark(r)));
+      }
+      if (under.length) {
+        out.push('', 'UNDER');
+        for (const r of under) out.push(line(r, '🟢'));
+      }
+      if (typical.length) {
+        out.push('', 'TYPICAL (within normal range)');
+        for (const r of typical) {
+          out.push(`  ${name(r.category)} ${fmt(r.current, 0).padStart(9)}  ${signedFmt(r.medianDelta).padStart(8)}`);
+        }
+      }
+      out.push('', `NET: ${signedFmt(net)} vs typical month`);
+      return out.join('\n');
     }
 
     case 'get_trends': {

--- a/mcp/create-server.ts
+++ b/mcp/create-server.ts
@@ -270,17 +270,18 @@ export function createMcpServer(opts: { afterWrite?: () => void } = {}): McpServ
     (input) => run('get_financial_health', input),
   );
 
-  // ── get_drift ───────────────────────────────────────────────────────────────
+  // ── get_scorecard ───────────────────────────────────────────────────────────
 
   server.tool(
-    'get_drift',
-    'Show spending deltas per category: current amount vs prior period, same period last year, and 12-month rolling average. Defaults to current month-to-date.',
+    'get_scorecard',
+    'Spending scorecard: which categories are significantly over/under the typical month (12-month median baseline), with a net verdict. Defaults to the trailing 30 days.',
     {
+      window: z.enum(['last30', 'month']).optional().describe("Comparison window: 'last30' = trailing 30 days ending on the given date (default), 'month' = calendar month-to-date"),
       year:  z.number().int().optional().describe('4-digit year (default: current year)'),
       month: z.number().int().min(1).max(12).optional().describe('Month 1–12 (default: current month)'),
-      day:   z.number().int().min(1).max(31).optional().describe('Day through which to compare (default: today)'),
+      day:   z.number().int().min(1).max(31).optional().describe('Day the window ends on / compares through (default: today)'),
     },
-    (input) => run('get_drift', input),
+    (input) => run('get_scorecard', input),
   );
 
   // ── get_trends ──────────────────────────────────────────────────────────────

--- a/tests/scorecard-tool.test.ts
+++ b/tests/scorecard-tool.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('../core/db.js', async () => {
+  const { makeTestDb } = await import('./helpers/makeTestDb.js');
+  return { db: await makeTestDb() };
+});
+
+import { db } from '../core/db.js';
+import { executeTool } from '../core/tools.js';
+
+let txId = 0;
+async function insertTx(date: string, amount: number, category: string) {
+  txId++;
+  await db.execute({
+    sql: `INSERT INTO transactions (id, account_id, date, name, amount, category, pending, ignored)
+          VALUES (?, 'acct1', ?, 'Test', ?, ?, 0, 0)`,
+    args: [`tx${txId}`, date, amount, category],
+  });
+}
+
+beforeEach(async () => {
+  txId = 0;
+  await db.execute('DELETE FROM transactions');
+  await db.execute('DELETE FROM hidden_categories');
+});
+
+describe('get_scorecard tool output', () => {
+  it('buckets categories and reports a net verdict (calendar month window)', async () => {
+    // Deterministic with month windows: txs on the 15th land in every
+    // day-capped rolling window regardless of month length.
+    const priors = ['2026-05', '2026-04', '2026-03', '2026-02', '2026-01', '2025-12',
+                    '2025-11', '2025-10', '2025-09', '2025-08', '2025-07', '2025-06'];
+    for (const ym of priors) {
+      await insertTx(`${ym}-15`, 100, 'Transportation');
+      await insertTx(`${ym}-15`, 700, 'Grocery');
+      await insertTx(`${ym}-15`, 4000, 'Bills');
+    }
+    await insertTx('2026-06-15', 600, 'Transportation');  // +500, 6x → over
+    await insertTx('2026-06-15', 200, 'Grocery');          // -500 → under
+    await insertTx('2026-06-15', 4010, 'Bills');           // +10 → typical
+
+    const out = await executeTool('get_scorecard', { window: 'month', year: 2026, month: 6, day: 30 });
+
+    expect(out).toContain('Scorecard — 2026-06 through day 30');
+    const overIdx = out.indexOf('OVER');
+    const underIdx = out.indexOf('UNDER');
+    const typicalIdx = out.indexOf('TYPICAL');
+    expect(overIdx).toBeGreaterThan(-1);
+    expect(underIdx).toBeGreaterThan(overIdx);
+    expect(typicalIdx).toBeGreaterThan(underIdx);
+
+    const section = (from: number, to: number) => out.slice(from, to === -1 ? undefined : to);
+    expect(section(overIdx, underIdx)).toContain('Transportation');
+    expect(section(overIdx, underIdx)).toContain('+$500 vs typical  (6.0x) 🔴');
+    expect(section(underIdx, typicalIdx)).toContain('Grocery');
+    expect(section(underIdx, typicalIdx)).toContain('-$500 vs typical  (0.3x) 🟢');
+    expect(section(typicalIdx, out.length)).toContain('Bills');
+    expect(out).toContain('NET: +$10 vs typical month');
+  });
+
+  it('defaults to a trailing 30-day window and flags new spending', async () => {
+    await insertTx('2026-06-15', 100, 'Food');
+
+    const out = await executeTool('get_scorecard', { year: 2026, month: 7, day: 3 });
+
+    expect(out).toContain('Scorecard — last 30 days (Jun 4 – Jul 3, 2026)');
+    expect(out).toContain('OVER');
+    expect(out).toContain('(new) 🔴'); // no baseline history → new spending
+  });
+
+  it('reports no data for an empty window', async () => {
+    const out = await executeTool('get_scorecard', { year: 2026, month: 7, day: 3 });
+    expect(out).toContain('No expense data for last 30 days');
+  });
+});


### PR DESCRIPTION
## What

PR 3 of 3 — the agent-facing tool. **Stacked on #104**; GitHub will retarget to `dev` when it merges.

- **Renamed `get_drift` → `get_scorecard`** (only two references existed: `core/tools.ts` and `mcp/create-server.ts`; no prompt files mention drift).
- **New `window` param**: `'last30'` (trailing 30 days, **default**) or `'month'` (calendar MTD — the previous behavior). Since the tool name changed anyway, the default goes straight to the better window rather than keeping month-first compat.
- **Bucketed output via `core/scorecard`** — the agent now sees the same verdict as the screens:

```
Scorecard — last 30 days (Jun 4 – Jul 3, 2026) · vs typical month (12-month median)

OVER
  Transportation      $626    +$477 vs typical  (4.2x) 🔴
UNDER
  Grocery             $291    -$471 vs typical  (0.4x) 🟢
TYPICAL (within normal range)
  Bills & Utilities  $4,112     -$20

NET: +$421 vs typical month
```

## Tests

`tests/scorecard-tool.test.ts`: bucket ordering + net verdict (deterministic calendar-month window), trailing-30d default label + `new`-spend flagging, empty-window message. Typecheck clean; no `get_drift` references remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)