### PR TITLE
Release: spending scorecard, tag date spans, Electron 43

### DIFF
--- a/core/dateUtils.ts
+++ b/core/dateUtils.ts
@@ -1,8 +1,13 @@
-export type Range = 'week' | 'month' | 'quarter' | 'year' | 'alltime';
-export const RANGES: Range[] = ['week', 'month', 'quarter', 'year', 'alltime'];
+export type Range = 'week' | 'month' | 'last30' | 'quarter' | 'year' | 'alltime';
+export const RANGES: Range[] = ['week', 'month', 'last30', 'quarter', 'year', 'alltime'];
 export const RANGE_LABELS: Record<Range, string> = {
-  week: 'Week', month: 'Month', quarter: 'Quarter', year: 'Year', alltime: 'All',
+  week: 'Week', month: 'Month', last30: '30 Days', quarter: 'Quarter', year: 'Year', alltime: 'All',
 };
+
+// last30 is a trailing 30-day window; the anchor is the window START (today−29
+// when anchored to now), keeping the anchor-is-period-start convention of the
+// other ranges. Unlike calendar ranges it never has unelapsed days.
+export const LAST30_DAYS = 30;
 
 export const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
 
@@ -19,6 +24,12 @@ export function getPeriodStart(range: Range, d: Date): Date {
       return monday;
     }
     case 'month':   return new Date(d.getFullYear(), d.getMonth(), 1);
+    case 'last30': {
+      const start = new Date(d);
+      start.setDate(d.getDate() - (LAST30_DAYS - 1));
+      start.setHours(0, 0, 0, 0);
+      return start;
+    }
     case 'quarter': return new Date(d.getFullYear(), Math.floor(d.getMonth() / 3) * 3, 1);
     case 'year':    return new Date(d.getFullYear(), 0, 1);
     case 'alltime': return new Date(2000, 0, 1);
@@ -31,6 +42,7 @@ export function getPeriodDates(range: Range, anchor: Date): { from: string; to: 
   let end: Date;
   switch (range) {
     case 'week':    end = new Date(anchor); end.setDate(anchor.getDate() + 6); break;
+    case 'last30':  end = new Date(anchor); end.setDate(anchor.getDate() + (LAST30_DAYS - 1)); break;
     case 'month':   end = new Date(anchor.getFullYear(), anchor.getMonth() + 1, 0); break;
     case 'quarter': end = new Date(anchor.getFullYear(), anchor.getMonth() + 3, 0); break;
     case 'year':    end = new Date(anchor.getFullYear(), 11, 31); break;
@@ -42,6 +54,7 @@ export function navigatePeriod(range: Range, anchor: Date, delta: -1 | 1): Date 
   const d = new Date(anchor);
   switch (range) {
     case 'week':    d.setDate(d.getDate() + delta * 7); break;
+    case 'last30':  d.setDate(d.getDate() + delta * LAST30_DAYS); break;
     case 'month':   d.setMonth(d.getMonth() + delta); break;
     case 'quarter': d.setMonth(d.getMonth() + delta * 3); break;
     case 'year':    d.setFullYear(d.getFullYear() + delta); break;
@@ -175,15 +188,23 @@ export function getDriftWindows(range: Range, anchor: Date, today: Date): DriftW
   return { current: { from, to: effectiveTo }, lastPeriod, lastYear, rolling12 };
 }
 
+function spanLabel(start: Date, end: Date): string {
+  const sameYear = start.getFullYear() === end.getFullYear();
+  const sameMonth = start.getMonth() === end.getMonth();
+  if (sameMonth && sameYear) return `${MONTHS[start.getMonth()]} ${start.getDate()}–${end.getDate()}, ${start.getFullYear()}`;
+  if (sameYear)  return `${MONTHS[start.getMonth()]} ${start.getDate()} – ${MONTHS[end.getMonth()]} ${end.getDate()}, ${start.getFullYear()}`;
+  return `${MONTHS[start.getMonth()]} ${start.getDate()} – ${MONTHS[end.getMonth()]} ${end.getDate()}, ${end.getFullYear()}`;
+}
+
 export function formatPeriodLabel(range: Range, anchor: Date): string {
   switch (range) {
     case 'week': {
       const end = new Date(anchor); end.setDate(anchor.getDate() + 6);
-      const sameYear = anchor.getFullYear() === end.getFullYear();
-      const sameMonth = anchor.getMonth() === end.getMonth();
-      if (sameMonth) return `${MONTHS[anchor.getMonth()]} ${anchor.getDate()}–${end.getDate()}, ${anchor.getFullYear()}`;
-      if (sameYear)  return `${MONTHS[anchor.getMonth()]} ${anchor.getDate()} – ${MONTHS[end.getMonth()]} ${end.getDate()}, ${anchor.getFullYear()}`;
-      return `${MONTHS[anchor.getMonth()]} ${anchor.getDate()} – ${MONTHS[end.getMonth()]} ${end.getDate()}, ${end.getFullYear()}`;
+      return spanLabel(anchor, end);
+    }
+    case 'last30': {
+      const end = new Date(anchor); end.setDate(anchor.getDate() + (LAST30_DAYS - 1));
+      return spanLabel(anchor, end);
     }
     case 'month':   return `${MONTHS[anchor.getMonth()]} ${anchor.getFullYear()}`;
     case 'quarter': return `Q${Math.floor(anchor.getMonth() / 3) + 1} ${anchor.getFullYear()}`;

--- a/core/fmt.ts
+++ b/core/fmt.ts
@@ -34,3 +34,32 @@ export function fmtCompactSigned(n: number): string {
   if (abs >= 10_000)    return `${sign}$${(abs / 1_000).toFixed(1)}K`;
   return `${sign}${fmt(abs)}`;
 }
+
+// Formats a tag's date span (ISO YYYY-MM-DD bounds) down to month granularity,
+// e.g. "2024-01 → 2025-06", collapsing to a single month when they match.
+export function fmtSpan(earliest: string | null, latest: string | null): string {
+  if (!earliest || !latest) return '—';
+  const from = earliest.slice(0, 7);
+  const to = latest.slice(0, 7);
+  return from === to ? from : `${from} → ${to}`;
+}
+
+export type TagSort = 'name' | 'recent' | 'oldest';
+
+export function sortTags<T extends { earliest: string | null; latest: string | null }>(
+  tags: T[],
+  sort: TagSort,
+): T[] {
+  if (sort === 'name') return tags;
+  const sorted = [...tags];
+  if (sort === 'recent') {
+    sorted.sort((a, b) => (b.latest ?? '').localeCompare(a.latest ?? ''));
+  } else {
+    sorted.sort((a, b) => {
+      if (!a.earliest) return 1;
+      if (!b.earliest) return -1;
+      return a.earliest.localeCompare(b.earliest);
+    });
+  }
+  return sorted;
+}

--- a/core/queries.ts
+++ b/core/queries.ts
@@ -463,20 +463,25 @@ export async function toggleHiddenCategory(category: string, hidden: Set<string>
   }
 }
 
-export type Tag = { id: number; name: string; count: number; inflow: number; outflow: number };
+export type Tag = {
+  id: number; name: string; count: number; inflow: number; outflow: number;
+  earliest: string | null; latest: string | null;
+};
 
 export async function getAllTags(): Promise<Tag[]> {
   const result = await db.execute(`
     SELECT t.id, t.name, COUNT(tt.transaction_id) as count,
       COALESCE(SUM(CASE WHEN tx.amount < 0 THEN ABS(tx.amount) ELSE 0 END), 0) as inflow,
-      COALESCE(SUM(CASE WHEN tx.amount > 0 THEN tx.amount ELSE 0 END), 0) as outflow
+      COALESCE(SUM(CASE WHEN tx.amount > 0 THEN tx.amount ELSE 0 END), 0) as outflow,
+      MIN(tx.date) as earliest, MAX(tx.date) as latest
     FROM tags t
     LEFT JOIN transaction_tags tt ON tt.tag_id = t.id
     LEFT JOIN transactions tx ON tx.id = tt.transaction_id
     GROUP BY t.id ORDER BY t.name
   `);
-  return (result.rows as unknown as { id: number; name: string; count: number; inflow: number; outflow: number }[]).map((r) => ({
+  return (result.rows as unknown as Tag[]).map((r) => ({
     id: Number(r.id), name: r.name, count: Number(r.count), inflow: Number(r.inflow), outflow: Number(r.outflow),
+    earliest: r.earliest, latest: r.latest,
   }));
 }
 

--- a/core/queries.ts
+++ b/core/queries.ts
@@ -212,7 +212,13 @@ export async function getOwnerRows(from: string, to: string, filter?: Filter): P
 
 // ── Drift ──────────────────────────────────────────────────────────────────────
 
-export type DriftSlice    = { current: number; lastPeriodDelta: number; lastYearDelta: number; avg12mDelta: number; avg12m: number };
+export type DriftSlice    = {
+  current: number; lastPeriodDelta: number; lastYearDelta: number;
+  avg12mDelta: number; avg12m: number;
+  // Median of the rolling windows — robust to one-off spikes (a single $7K
+  // medical month shouldn't inflate the "typical" baseline the way a mean does).
+  median12m: number; medianDelta: number;
+};
 export type CategoryDrift = { category: string } & DriftSlice;
 export type FlexDriftData = Record<keyof FlexSummary, DriftSlice>;
 export type AccountDrift  = { id: string; name: string; subtype: string | null } & DriftSlice;
@@ -282,17 +288,35 @@ async function queryAccountSpending(from: string, to: string): Promise<Map<strin
 
 function sliceFor(current: number, last: number, year: number, rolling: number[]): DriftSlice {
   const avg12m = rolling.length > 0 ? rolling.reduce((s, v) => s + v, 0) / rolling.length : 0;
-  return { current, lastPeriodDelta: current - last, lastYearDelta: current - year, avg12mDelta: current - avg12m, avg12m };
+  let median12m = 0;
+  if (rolling.length > 0) {
+    const sorted = [...rolling].sort((a, b) => a - b);
+    const mid = Math.floor(sorted.length / 2);
+    median12m = sorted.length % 2 === 1 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+  }
+  return {
+    current, lastPeriodDelta: current - last, lastYearDelta: current - year,
+    avg12mDelta: current - avg12m, avg12m,
+    median12m, medianDelta: current - median12m,
+  };
+}
+
+// Rolling windows from before the first transaction contribute phantom zeros
+// that drag baselines down (e.g. 3 months of history averaged over 12 windows).
+async function clampToHistory(windows: Window[]): Promise<Window[]> {
+  const { minDate } = await getDataBounds();
+  return windows.filter((w) => w.to >= minDate);
 }
 
 export async function getCategoryDriftData(
   currentWin: Window, lastPeriodWin: Window, lastYearWin: Window, rolling12: Window[], filter?: Filter,
 ): Promise<CategoryDrift[]> {
+  const rolling = await clampToHistory(rolling12);
   const [cur, last, yr, ...rolls] = await Promise.all([
     queryCategoryTotals(currentWin.from, currentWin.to, filter),
     queryCategoryTotals(lastPeriodWin.from, lastPeriodWin.to, filter),
     queryCategoryTotals(lastYearWin.from, lastYearWin.to, filter),
-    ...rolling12.map((w) => queryCategoryTotals(w.from, w.to, filter)),
+    ...rolling.map((w) => queryCategoryTotals(w.from, w.to, filter)),
   ]);
   return [...cur.entries()]
     .map(([category, currentAmt]) => ({
@@ -305,11 +329,12 @@ export async function getCategoryDriftData(
 export async function getFlexDriftData(
   currentWin: Window, lastPeriodWin: Window, lastYearWin: Window, rolling12: Window[], filter?: Filter,
 ): Promise<FlexDriftData> {
+  const rolling = await clampToHistory(rolling12);
   const [cur, last, yr, ...rolls] = await Promise.all([
     queryFlexTotals(currentWin.from, currentWin.to, filter),
     queryFlexTotals(lastPeriodWin.from, lastPeriodWin.to, filter),
     queryFlexTotals(lastYearWin.from, lastYearWin.to, filter),
-    ...rolling12.map((w) => queryFlexTotals(w.from, w.to, filter)),
+    ...rolling.map((w) => queryFlexTotals(w.from, w.to, filter)),
   ]);
   const tiers: (keyof FlexSummary)[] = ['fixed', 'flexible', 'discretionary', 'untagged'];
   return Object.fromEntries(
@@ -326,11 +351,12 @@ export async function getAccountDriftData(
   );
   const accounts = acctRes.rows as unknown as { id: string; name: string; subtype: string | null }[];
 
+  const rolling = await clampToHistory(rolling12);
   const [cur, last, yr, ...rolls] = await Promise.all([
     queryAccountSpending(currentWin.from, currentWin.to),
     queryAccountSpending(lastPeriodWin.from, lastPeriodWin.to),
     queryAccountSpending(lastYearWin.from, lastYearWin.to),
-    ...rolling12.map((w) => queryAccountSpending(w.from, w.to)),
+    ...rolling.map((w) => queryAccountSpending(w.from, w.to)),
   ]);
 
   return accounts.map((acct) => ({

--- a/core/scorecard.ts
+++ b/core/scorecard.ts
@@ -1,0 +1,45 @@
+import type { CategoryDrift } from './queries.js';
+
+// Pure bucketing of drift rows into a scorecard verdict. Kept free of DB and
+// UI imports so the GUI renderer can import it directly (no bridge needed).
+
+export type Scorecard = {
+  over: CategoryDrift[];    // significantly above baseline, worst first
+  typical: CategoryDrift[]; // within the noise band, input order preserved
+  under: CategoryDrift[];   // significantly below baseline, biggest saving last
+  net: number;              // sum of medianDelta across ALL rows (incl. typical)
+};
+
+// A delta only counts as signal when it clears both an absolute floor and a
+// share of the category's own baseline — $40 over on a $60 baseline matters,
+// $40 over on a $4,000 baseline doesn't.
+export const SIGNIFICANCE_FLOOR = 50;
+export const SIGNIFICANCE_SHARE = 0.15;
+
+export function isSignificantDelta(delta: number, baseline: number): boolean {
+  return Math.abs(delta) >= Math.max(SIGNIFICANCE_FLOOR, SIGNIFICANCE_SHARE * baseline);
+}
+
+/** "4.2x" multiplier vs baseline; "new" when there is no baseline to compare. */
+export function ratioLabel(current: number, baseline: number): string {
+  if (baseline <= 0) return current > 0 ? 'new' : '';
+  return `${(current / baseline).toFixed(1)}x`;
+}
+
+export function bucketDrift(rows: CategoryDrift[]): Scorecard {
+  const over: CategoryDrift[] = [];
+  const typical: CategoryDrift[] = [];
+  const under: CategoryDrift[] = [];
+  let net = 0;
+  for (const row of rows) {
+    net += row.medianDelta;
+    if (!isSignificantDelta(row.medianDelta, row.median12m)) typical.push(row);
+    else if (row.medianDelta > 0) over.push(row);
+    else under.push(row);
+  }
+  over.sort((a, b) => b.medianDelta - a.medianDelta);
+  // Ascending magnitude so the biggest saving sits last — extremes at the
+  // visual edges of the OVER…UNDER stack.
+  under.sort((a, b) => b.medianDelta - a.medianDelta);
+  return { over, typical, under, net };
+}

--- a/core/tools.ts
+++ b/core/tools.ts
@@ -21,7 +21,7 @@ import { deleteCategoryRule } from './rules.js';
 import { rebuildDisplayNames } from './rename.js';
 import { setTransactionCategory, clearTransactionOverride, setTransactionIgnored } from './transactions.js';
 import { addTagToTransaction, removeTagFromTransaction, getOrCreateTag } from './tags.js';
-import { fmt, fmtSigned } from './fmt.js';
+import { fmt, fmtSigned, fmtSpan } from './fmt.js';
 import { syncAll } from './sync.js';
 import { db } from './db.js';
 import { validateRegex } from './rule-utils.js';
@@ -656,13 +656,16 @@ async function executeToolImpl(
 
     case 'list_tags': {
       const result = await db.execute(`
-        SELECT t.name, COUNT(tt.transaction_id) as count
-        FROM tags t LEFT JOIN transaction_tags tt ON tt.tag_id = t.id
+        SELECT t.name, COUNT(tt.transaction_id) as count,
+          MIN(tx.date) as earliest, MAX(tx.date) as latest
+        FROM tags t
+        LEFT JOIN transaction_tags tt ON tt.tag_id = t.id
+        LEFT JOIN transactions tx ON tx.id = tt.transaction_id
         GROUP BY t.id ORDER BY t.name
       `);
-      const rows = result.rows as unknown as { name: string; count: number }[];
+      const rows = result.rows as unknown as { name: string; count: number; earliest: string | null; latest: string | null }[];
       return rows.length
-        ? rows.map((r) => `${r.name.padEnd(30)} ${r.count} txn${r.count !== 1 ? 's' : ''}`).join('\n')
+        ? rows.map((r) => `${r.name.padEnd(30)} ${String(r.count).padStart(4)} txn${r.count !== 1 ? 's' : ' '}  ${fmtSpan(r.earliest, r.latest)}`).join('\n')
         : 'No tags defined.';
     }
 

--- a/core/tools.ts
+++ b/core/tools.ts
@@ -11,9 +11,10 @@ import { writeFileSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { notifyChange } from './refresh.js';
 import { DATA_DIR } from './paths.js';
-import { getRangeSummary, getMonthlySummary, getTagSummary, getCategoryDriftData, getMerchantSummary, getNetWorthHistory, getLinkedAccounts, type NetWorthGranularity } from './queries.js';
+import { getRangeSummary, getMonthlySummary, getTagSummary, getCategoryDriftData, getMerchantSummary, getNetWorthHistory, getLinkedAccounts, type NetWorthGranularity, type CategoryDrift } from './queries.js';
 import { solveTVM } from './calculator.js';
-import { getDriftWindows } from './dateUtils.js';
+import { getDriftWindows, getPeriodStart, formatPeriodLabel } from './dateUtils.js';
+import { bucketDrift, ratioLabel } from './scorecard.js';
 import { getBalances, getFinancialHealth, getSpendingTrends } from './agent-context.js';
 import { getFinanceGuide, getFinanceTopicList, formatGuideSection, type GuideTopic } from './finance-guide.js';
 import { applyCategoriesToAll } from './categorize.js';
@@ -112,14 +113,15 @@ export const TOOL_DEFS: ToolDef[] = [
     },
   },
   {
-    name: 'get_drift',
-    description: 'Show spending deltas for each category: current amount vs prior period, same period last year, and 12-month rolling average. Useful for spotting categories where spending is quietly creeping up. Defaults to the current month-to-date.',
+    name: 'get_scorecard',
+    description: 'Spending scorecard: which categories are significantly over or under the typical month (12-month median baseline), with per-category deltas and a net verdict. Use for "how am I doing lately / where did my spending go wrong". Defaults to the trailing 30 days, which is fully populated even early in a calendar month.',
     parameters: {
       type: 'object',
       properties: {
+        window: { type: 'string', enum: ['last30', 'month'], description: "Comparison window: 'last30' = trailing 30 days ending on the given date (default), 'month' = calendar month-to-date" },
         year:  { type: 'integer', description: '4-digit year (default: current year)' },
         month: { type: 'integer', description: 'Month 1–12 (default: current month)', minimum: 1, maximum: 12 },
-        day:   { type: 'integer', description: 'Day of month to compare through — use for partial-month MTD (default: today)', minimum: 1, maximum: 31 },
+        day:   { type: 'integer', description: 'Day the window ends on (last30) or compares through (month) — default: today', minimum: 1, maximum: 31 },
       },
     },
   },
@@ -566,39 +568,51 @@ async function executeToolImpl(
       ].join('\n');
     }
 
-    case 'get_drift': {
+    case 'get_scorecard': {
       const today = new Date();
       const year  = input['year']  ? num('year')  : today.getFullYear();
       const month = input['month'] ? num('month') : today.getMonth() + 1;
       const day   = input['day']   ? num('day')   : today.getDate();
-      const anchor = new Date(year, month - 1, 1, 12);
+      const windowKind = input['window'] === 'month' ? 'month' as const : 'last30' as const;
       const asOf   = new Date(year, month - 1, day, 12);
-      const windows = getDriftWindows('month', anchor, asOf);
-      if (!windows) return 'Drift is not available for this range.';
+      const anchor = windowKind === 'month' ? new Date(year, month - 1, 1, 12) : getPeriodStart('last30', asOf);
+      const windows = getDriftWindows(windowKind, anchor, asOf);
+      if (!windows) return 'Scorecard is not available for this range.';
       const { current, lastPeriod, lastYear, rolling12 } = windows;
       const rows = await getCategoryDriftData(current, lastPeriod, lastYear, rolling12);
-      if (!rows.length) return `No expense data for ${year}-${String(month).padStart(2, '0')} through day ${day}.`;
-      const fmtAmt   = (n: number) => fmt(n, 0);
+      const label = windowKind === 'last30'
+        ? `last 30 days (${formatPeriodLabel('last30', anchor)})`
+        : `${year}-${String(month).padStart(2, '0')} through day ${day}`;
+      if (!rows.length) return `No expense data for ${label}.`;
+
+      const { over, typical, under, net } = bucketDrift(rows);
+      const name = (c: string) => c.length > 24 ? c.slice(0, 23) + '…' : c.padEnd(24);
       const signedFmt = (n: number) => n === 0 ? '—' : fmtSigned(n, 0);
-      const heat = (current: number, avg: number) => {
-        if (avg === 0) return current > 0 ? ' 🔴' : '';
-        const r = current / avg;
-        if (r <= 1.10) return ' 🟢';
-        if (r <= 1.30) return ' 🟡';
-        return ' 🔴';
+      const line = (r: CategoryDrift, mark: string) => {
+        const ratio = ratioLabel(r.current, r.median12m);
+        return `  ${name(r.category)} ${fmt(r.current, 0).padStart(9)}  ${signedFmt(r.medianDelta).padStart(8)} vs typical` +
+          (ratio ? `  (${ratio})` : '') + ` ${mark}`;
       };
-      const header = `Drift — ${year}-${String(month).padStart(2, '0')} through day ${day}\n` +
-        `${'Category'.padEnd(26)} ${'Current'.padStart(10)} ${'vs Last'.padStart(10)} ${'vs Yr'.padStart(10)} ${'vs 12m'.padStart(10)}`;
-      const divider = '─'.repeat(header.split('\n')[1].length);
-      const lines = rows.map((r) =>
-        `${r.category.length > 26 ? r.category.slice(0, 25) + '…' : r.category.padEnd(26)} ` +
-        `${fmtAmt(r.current).padStart(10)} ` +
-        `${signedFmt(r.lastPeriodDelta).padStart(10)} ` +
-        `${signedFmt(r.lastYearDelta).padStart(10)} ` +
-        `${signedFmt(r.avg12mDelta).padStart(10)}` +
-        heat(r.current, r.avg12m)
-      );
-      return [header.split('\n')[0], divider, header.split('\n')[1], divider, ...lines].join('\n');
+      const overMark = (r: CategoryDrift) =>
+        r.median12m === 0 || r.current / r.median12m >= 1.3 ? '🔴' : '🟡';
+
+      const out: string[] = [`Scorecard — ${label} · vs typical month (12-month median)`];
+      if (over.length) {
+        out.push('', 'OVER');
+        for (const r of over) out.push(line(r, overMark(r)));
+      }
+      if (under.length) {
+        out.push('', 'UNDER');
+        for (const r of under) out.push(line(r, '🟢'));
+      }
+      if (typical.length) {
+        out.push('', 'TYPICAL (within normal range)');
+        for (const r of typical) {
+          out.push(`  ${name(r.category)} ${fmt(r.current, 0).padStart(9)}  ${signedFmt(r.medianDelta).padStart(8)}`);
+        }
+      }
+      out.push('', `NET: ${signedFmt(net)} vs typical month`);
+      return out.join('\n');
     }
 
     case 'get_trends': {

--- a/gui/renderer/src/screens/Dashboard.module.css
+++ b/gui/renderer/src/screens/Dashboard.module.css
@@ -289,6 +289,27 @@
   background: var(--bg-hover);
 }
 
+.bucketRow td {
+  text-align: left !important;
+  font-size: 11.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+  font-weight: 600;
+  padding-top: 12px;
+  border-bottom: 1px solid var(--border);
+}
+
+.netRow td {
+  border-top: 1px solid var(--border);
+  font-weight: 600;
+  padding-top: 10px;
+}
+
+.netRow td:last-child {
+  text-align: left;
+  font-weight: 400;
+}
+
 .barTrack {
   height: 14px;
   border-radius: 4px;

--- a/gui/renderer/src/screens/Dashboard.tsx
+++ b/gui/renderer/src/screens/Dashboard.tsx
@@ -15,7 +15,8 @@ import {
   RANGE_LABELS,
   type Range,
 } from '../../../../core/dateUtils.js';
-import type { AccountRow, CategoryDrift, FlexSummary } from '../../../../core/queries.js';
+import type { AccountRow, CategoryDrift, DriftSlice, FlexSummary } from '../../../../core/queries.js';
+import { bucketDrift, isSignificantDelta, ratioLabel } from '../../../../core/scorecard.js';
 import { mergeFilters, type Filter } from '../../../../core/filters.js';
 import { useFilter } from '../hooks/useFilter.js';
 import type { TxFilter } from '../../../shared/nav.js';
@@ -34,15 +35,24 @@ function pct(part: number, total: number) {
   return total === 0 ? '0%' : `${Math.round((part / total) * 100)}%`;
 }
 
-/** Heat-map class based on current spend vs 12-month rolling average (mirrors TUI driftColor). */
-function driftClass(current: number, avg12m: number): string {
-  if (current === 0) return '';
-  if (avg12m === 0) return 'neg'; // new spending with no history
-  const ratio = current / avg12m;
-  if (ratio <= 1.1) return 'pos';
-  if (ratio <= 1.3) return 'warn';
-  return 'neg';
+/**
+ * Heat-map class vs the median baseline, gated on significance (mirrors TUI
+ * driftColor): rows inside the noise band stay neutral so only deltas worth
+ * acting on get color.
+ */
+function driftClass(slice: Pick<DriftSlice, 'current' | 'median12m' | 'medianDelta'>): string {
+  if (slice.current === 0 && slice.median12m === 0) return '';
+  if (!isSignificantDelta(slice.medianDelta, slice.median12m)) return '';
+  if (slice.medianDelta < 0) return 'pos';                       // meaningfully under
+  if (slice.median12m === 0) return 'neg';                       // new spending, no history
+  return slice.current / slice.median12m >= 1.3 ? 'neg' : 'warn';
 }
+
+const BUCKET_META = {
+  over:    { label: 'Over',    cls: 'neg' },
+  typical: { label: 'Typical', cls: 'dim' },
+  under:   { label: 'Under',   cls: 'pos' },
+} as const;
 
 function fmtDelta(delta: number): string {
   return delta === 0 ? '—' : fmtSigned(delta, 0);
@@ -74,7 +84,8 @@ export function Dashboard() {
     return getPeriodStart(initialRange, now);
   });
   const [view, setView] = useState<DashView>('categories');
-  const [driftMode, setDriftMode] = useState(false);
+  const [scorecardMode, setScorecardMode] = useState(txFilter.scorecard ?? false);
+  const [detailMode, setDetailMode] = useState(false); // sortable per-baseline delta columns
   const [searchInput, setSearchInput] = useState(txFilter.search ?? '');
   const [search, setSearch] = useState(txFilter.search ?? '');
   const [selectedAccount, setSelectedAccount] = useState<AccountRow | null>(null);
@@ -104,27 +115,27 @@ export function Dashboard() {
   const accountRows = useQuery(() => api.queries.getAccountRows(from, to, filter), [from, to, acctId, sharedFilter]);
   const ownerRows = useQuery(() => api.queries.getOwnerRows(from, to, filter), [from, to, acctId, sharedFilter]);
 
-  const driftWindows = driftMode ? getDriftWindows(range, anchor, new Date()) : null;
+  const driftWindows = scorecardMode ? getDriftWindows(range, anchor, new Date()) : null;
   const catDrift = useQuery(
     () =>
       driftWindows
         ? api.queries.getCategoryDriftData(driftWindows.current, driftWindows.lastPeriod, driftWindows.lastYear, driftWindows.rolling12, filter)
         : Promise.resolve(null),
-    [driftMode, from, to, acctId, sharedFilter],
+    [scorecardMode, from, to, acctId, sharedFilter],
   );
   const flexDrift = useQuery(
     () =>
       driftWindows
         ? api.queries.getFlexDriftData(driftWindows.current, driftWindows.lastPeriod, driftWindows.lastYear, driftWindows.rolling12, filter)
         : Promise.resolve(null),
-    [driftMode, from, to, acctId, sharedFilter],
+    [scorecardMode, from, to, acctId, sharedFilter],
   );
   const acctDrift = useQuery(
     () =>
       driftWindows
         ? api.queries.getAccountDriftData(driftWindows.current, driftWindows.lastPeriod, driftWindows.lastYear, driftWindows.rolling12)
         : Promise.resolve(null),
-    [driftMode, from, to],
+    [scorecardMode, from, to],
   );
 
   const searchStats = useQuery(
@@ -158,6 +169,12 @@ export function Dashboard() {
       return desc ? -cmp : cmp;
     });
   }, [catDrift, driftSort]);
+
+  const scorecard = useMemo(() => (catDrift ? bucketDrift(catDrift) : null), [catDrift]);
+  const maxScoreDelta = scorecard
+    ? Math.max(1, ...[...scorecard.over, ...scorecard.under].map((r) => Math.abs(r.medianDelta)))
+    : 1;
+  const scoreTotal = (catDrift ?? []).reduce((s, r) => s + r.current, 0);
 
   function goPeriod(delta: -1 | 1) {
     if (range === 'alltime') return;
@@ -201,7 +218,8 @@ export function Dashboard() {
       const idx = RANGES.indexOf(range);
       pickRange(RANGES[(idx + 1) % RANGES.length]);
     },
-    d: () => setDriftMode((m) => !m),
+    s: () => setScorecardMode((m) => !m),
+    x: () => { if (scorecardMode) setDetailMode((t) => !t); },
     Tab: () => {
       setMerchantDrill(null);
       setView((v) => views[(views.indexOf(v) + 1) % views.length]);
@@ -220,7 +238,7 @@ export function Dashboard() {
 
   return (
     <div className={styles.screen}>
-      <KeyHints hints="[1-9·0] screens   [r] range   [d] delta   [tab] view   [← →] period   [/] search   [esc] back" />
+      <KeyHints hints={`[1-9·0] screens   [r] range   [s] scorecard${scorecardMode ? '   [x] columns' : ''}   [tab] view   [← →] period   [/] search   [esc] back`} />
       <div className={styles.topBar}>
         <h1 className={styles.title}>Dashboard</h1>
         <div className={styles.periodNav}>
@@ -254,12 +272,21 @@ export function Dashboard() {
           ))}
         </div>
         <button
-          className={driftMode ? styles.driftBtnActive : styles.driftBtn}
-          onClick={() => setDriftMode((m) => !m)}
-          title="Compare against prior periods"
+          className={scorecardMode ? styles.driftBtnActive : styles.driftBtn}
+          onClick={() => setScorecardMode((m) => !m)}
+          title="Which categories drifted from your typical month, and does it matter"
         >
-          Δ delta
+          Δ scorecard
         </button>
+        {scorecardMode && (
+          <button
+            className={detailMode ? styles.driftBtnActive : styles.driftBtn}
+            onClick={() => setDetailMode((t) => !t)}
+            title="Sortable per-baseline delta columns (vs prev / yr ago / 12m avg)"
+          >
+            columns
+          </button>
+        )}
         <div className={styles.searchWrap}>
           <input
             ref={searchRef}
@@ -365,10 +392,10 @@ export function Dashboard() {
 
       {view === 'categories' && !merchantDrill && (
         <section className={styles.panel}>
-          <h2>Spending by category</h2>
-          {driftMode && range === 'alltime' ? (
-            <p className="dim">Delta not available for All Time range.</p>
-          ) : driftMode ? (
+          <h2>{scorecardMode && !detailMode ? 'Spending by category · vs typical (12m median)' : 'Spending by category'}</h2>
+          {scorecardMode && range === 'alltime' ? (
+            <p className="dim">Scorecard not available for All Time range.</p>
+          ) : scorecardMode && detailMode ? (
             sortedDrift && sortedDrift.length === 0 ? (
               <p className="dim">No expense data for this period.</p>
             ) : (
@@ -384,7 +411,7 @@ export function Dashboard() {
                 </thead>
                 <tbody>
                   {(sortedDrift ?? []).map((row: CategoryDrift) => {
-                    const cls = driftClass(row.current, row.avg12m);
+                    const cls = driftClass(row);
                     return (
                       <tr
                         key={row.category}
@@ -399,6 +426,64 @@ export function Dashboard() {
                       </tr>
                     );
                   })}
+                </tbody>
+              </table>
+            )
+          ) : scorecardMode ? (
+            !scorecard || scorecard.over.length + scorecard.typical.length + scorecard.under.length === 0 ? (
+              <p className="dim">No expense data for this period.</p>
+            ) : (
+              <table className={styles.table}>
+                <thead>
+                  <tr>
+                    <th className={styles.th}>Category</th>
+                    <th className={styles.th}>Amount</th>
+                    <th className={styles.th}>Δ typical</th>
+                    <th className={styles.th}></th>
+                    <th className={styles.th}>Ratio</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {(['over', 'typical', 'under'] as const).map((bucket) => {
+                    const rows = scorecard[bucket];
+                    if (rows.length === 0) return null;
+                    const meta = BUCKET_META[bucket];
+                    return (
+                      <React.Fragment key={bucket}>
+                        <tr className={styles.bucketRow}>
+                          <td colSpan={5} className={meta.cls}>{meta.label}</td>
+                        </tr>
+                        {rows.map((row) => {
+                          const isTypical = bucket === 'typical';
+                          const cls = isTypical ? 'dim' : driftClass(row);
+                          const barColor = cls === 'pos' ? 'var(--positive)' : cls === 'warn' ? 'var(--warning)' : 'var(--negative)';
+                          return (
+                            <tr
+                              key={row.category}
+                              className={styles.rowClickable}
+                              onClick={() => drillToTransactions({ categories: [row.category] })}
+                            >
+                              <td className={`${styles.tdName} ${cls}`}>{row.category}</td>
+                              <td className={`num ${isTypical ? 'dim' : ''}`}>{fmt(row.current)}</td>
+                              <td className={`num ${cls}`}>{fmtDelta(row.medianDelta)}</td>
+                              <td className={styles.tdBar}>
+                                {!isTypical && <Bar value={Math.abs(row.medianDelta)} max={maxScoreDelta} color={barColor} />}
+                              </td>
+                              <td className="num dim">{isTypical ? '' : ratioLabel(row.current, row.median12m)}</td>
+                            </tr>
+                          );
+                        })}
+                      </React.Fragment>
+                    );
+                  })}
+                  <tr className={styles.netRow}>
+                    <td className={styles.tdName}>Net</td>
+                    <td className="num">{fmt(scoreTotal)}</td>
+                    <td className={`num ${scorecard.net <= 0 ? 'pos' : scorecard.net >= scoreTotal * 0.05 ? 'neg' : 'warn'}`}>
+                      {fmtDelta(scorecard.net)}
+                    </td>
+                    <td colSpan={2} className="dim">vs typical</td>
+                  </tr>
                 </tbody>
               </table>
             )
@@ -443,9 +528,9 @@ export function Dashboard() {
       {view === 'flex' && (
         <section className={styles.panel}>
           <h2>Spending by flexibility</h2>
-          {driftMode && range === 'alltime' ? (
-            <p className="dim">Delta not available for All Time range.</p>
-          ) : driftMode && flexDrift ? (
+          {scorecardMode && range === 'alltime' ? (
+            <p className="dim">Scorecard not available for All Time range.</p>
+          ) : scorecardMode && flexDrift ? (
             <table className={styles.table}>
               <thead>
                 <tr>
@@ -460,7 +545,7 @@ export function Dashboard() {
                 {FLEX_TIERS.map(({ key, label, cssVar }) => {
                   const slice = flexDrift[key];
                   if (slice.current === 0 && slice.avg12m === 0) return null;
-                  const cls = driftClass(slice.current, slice.avg12m);
+                  const cls = driftClass(slice);
                   return (
                     <tr key={key}>
                       <td className={styles.tdName} style={{ color: cssVar }}>
@@ -527,22 +612,22 @@ export function Dashboard() {
           <h2>By account</h2>
           {(accountRows ?? []).length === 0 ? (
             <p className="dim">No accounts linked — add one in Accounts.</p>
-          ) : driftMode && range === 'alltime' ? (
-            <p className="dim">Delta not available for All Time range.</p>
+          ) : scorecardMode && range === 'alltime' ? (
+            <p className="dim">Scorecard not available for All Time range.</p>
           ) : (
             <table className={styles.table}>
               <thead>
                 <tr>
                   <th className={styles.th}>Account</th>
-                  <th className={styles.th}>{driftMode ? 'vs prev' : 'Income'}</th>
+                  <th className={styles.th}>{scorecardMode ? 'vs prev' : 'Income'}</th>
                   <th className={styles.th}>Expenses</th>
                   <th className={styles.th}>Filter</th>
                 </tr>
               </thead>
               <tbody>
                 {(accountRows ?? []).map((acct) => {
-                  const drift = driftMode ? acctDrift?.find((d) => d.id === acct.id) : undefined;
-                  const cls = drift ? driftClass(drift.current, drift.avg12m) : '';
+                  const drift = scorecardMode ? acctDrift?.find((d) => d.id === acct.id) : undefined;
+                  const cls = drift ? driftClass(drift) : '';
                   const isFiltered = selectedAccount?.id === acct.id;
                   return (
                     <tr
@@ -553,14 +638,14 @@ export function Dashboard() {
                       <td className={styles.tdName} style={isFiltered ? { color: 'var(--warning)' } : undefined}>
                         {acct.name}
                       </td>
-                      {driftMode ? (
+                      {scorecardMode ? (
                         <td className={`num ${cls}`}>{drift ? fmtDelta(drift.lastPeriodDelta) : '—'}</td>
                       ) : (
                         <td className={`num ${acct.income > 0 ? 'pos' : 'dim'}`}>
                           {acct.income > 0 ? fmt(acct.income) : '—'}
                         </td>
                       )}
-                      <td className={`num ${driftMode ? cls : acct.spending > 0 ? 'neg' : 'dim'}`}>
+                      <td className={`num ${scorecardMode ? cls : acct.spending > 0 ? 'neg' : 'dim'}`}>
                         {acct.spending > 0 ? fmt(acct.spending) : '—'}
                       </td>
                       <td className={styles.tdAction}>

--- a/gui/renderer/src/screens/Dashboard.tsx
+++ b/gui/renderer/src/screens/Dashboard.tsx
@@ -530,7 +530,7 @@ export function Dashboard() {
           <h2>Spending by flexibility</h2>
           {scorecardMode && range === 'alltime' ? (
             <p className="dim">Scorecard not available for All Time range.</p>
-          ) : scorecardMode && flexDrift ? (
+          ) : scorecardMode && detailMode && flexDrift ? (
             <table className={styles.table}>
               <thead>
                 <tr>
@@ -555,6 +555,34 @@ export function Dashboard() {
                       <td className={`num ${cls}`}>{fmtDelta(slice.lastPeriodDelta)}</td>
                       <td className={`num ${cls}`}>{fmtDelta(slice.lastYearDelta)}</td>
                       <td className={`num ${cls}`}>{fmtDelta(slice.avg12mDelta)}</td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          ) : scorecardMode && flexDrift ? (
+            <table className={styles.table}>
+              <thead>
+                <tr>
+                  <th className={styles.th}>Tier</th>
+                  <th className={styles.th}>Amount</th>
+                  <th className={styles.th}>Δ typical</th>
+                  <th className={styles.th}>Ratio</th>
+                </tr>
+              </thead>
+              <tbody>
+                {FLEX_TIERS.map(({ key, label, cssVar }) => {
+                  const slice = flexDrift[key];
+                  if (slice.current === 0 && slice.avg12m === 0) return null;
+                  const cls = driftClass(slice);
+                  return (
+                    <tr key={key}>
+                      <td className={styles.tdName} style={{ color: cssVar }}>
+                        {label}
+                      </td>
+                      <td className="num">{fmt(slice.current)}</td>
+                      <td className={`num ${cls}`}>{fmtDelta(slice.medianDelta)}</td>
+                      <td className="num dim">{ratioLabel(slice.current, slice.median12m)}</td>
                     </tr>
                   );
                 })}
@@ -619,7 +647,7 @@ export function Dashboard() {
               <thead>
                 <tr>
                   <th className={styles.th}>Account</th>
-                  <th className={styles.th}>{scorecardMode ? 'vs prev' : 'Income'}</th>
+                  <th className={styles.th}>{scorecardMode ? 'Δ typical' : 'Income'}</th>
                   <th className={styles.th}>Expenses</th>
                   <th className={styles.th}>Filter</th>
                 </tr>
@@ -639,7 +667,7 @@ export function Dashboard() {
                         {acct.name}
                       </td>
                       {scorecardMode ? (
-                        <td className={`num ${cls}`}>{drift ? fmtDelta(drift.lastPeriodDelta) : '—'}</td>
+                        <td className={`num ${cls}`}>{drift ? fmtDelta(drift.medianDelta) : '—'}</td>
                       ) : (
                         <td className={`num ${acct.income > 0 ? 'pos' : 'dim'}`}>
                           {acct.income > 0 ? fmt(acct.income) : '—'}

--- a/gui/renderer/src/screens/Health.module.css
+++ b/gui/renderer/src/screens/Health.module.css
@@ -164,3 +164,12 @@
 .dialHint {
   font-size: 12px;
 }
+
+.scorecardLink {
+  font-size: 12.5px;
+  text-decoration: underline;
+}
+
+.scorecardLink:hover {
+  color: var(--accent);
+}

--- a/gui/renderer/src/screens/Health.tsx
+++ b/gui/renderer/src/screens/Health.tsx
@@ -1,7 +1,10 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { api } from '../api.js';
 import { useQuery } from '../hooks/useQuery.js';
+import { useNav } from '../hooks/useNav.js';
 import { fmt, fmtSigned, fmtPct, fmtMonths, fmtCompact } from '../../../../core/fmt.js';
+import { getDriftWindows, getPeriodStart } from '../../../../core/dateUtils.js';
+import { bucketDrift } from '../../../../core/scorecard.js';
 import { KeyHints } from '../components/KeyHints.js';
 import styles from './Health.module.css';
 
@@ -27,7 +30,22 @@ function roundToStep(n: number): number {
 }
 
 export function Health() {
+  const { navigate } = useNav();
   const data = useQuery(() => api.health.loadHealthData(), []);
+
+  // Trailing-30-day scorecard: which categories drifted from typical recently.
+  const drift = useQuery(() => {
+    const today = new Date();
+    const w = getDriftWindows('last30', getPeriodStart('last30', today), today);
+    return w
+      ? api.queries.getCategoryDriftData(w.current, w.lastPeriod, w.lastYear, w.rolling12)
+      : Promise.resolve(null);
+  }, []);
+  const scorecard = useMemo(() => (drift ? bucketDrift(drift) : null), [drift]);
+  const topUnder = useMemo(
+    () => (scorecard ? [...scorecard.under].sort((a, b) => a.medianDelta - b.medianDelta).slice(0, 2) : []),
+    [scorecard],
+  );
 
   const [monthlySpend, setMonthlySpend] = useState<number | null>(null);
   const [monthlySavings, setMonthlySavings] = useState<number | null>(null);
@@ -109,6 +127,40 @@ export function Health() {
             <span className={`dim ${styles.metricHint}`}>{fmt(data.liquid)} incl. brokerage</span>
           </div>
         </section>
+
+        {scorecard && (scorecard.over.length > 0 || scorecard.under.length > 0) && (
+          <section className={styles.panel}>
+            <h2>Last 30 days · vs typical</h2>
+            {scorecard.over.length > 0 && (
+              <div className={styles.metric}>
+                <span className={styles.metricLabel}>Watch</span>
+                <span className={`neg ${styles.metricValue}`}>
+                  {scorecard.over.slice(0, 2).map((r) => `${r.category} ${fmtSigned(r.medianDelta, 0)}`).join('  ·  ')}
+                </span>
+              </div>
+            )}
+            {topUnder.length > 0 && (
+              <div className={styles.metric}>
+                <span className={styles.metricLabel}>Good</span>
+                <span className={`pos ${styles.metricValue}`}>
+                  {topUnder.map((r) => `${r.category} ${fmtSigned(r.medianDelta, 0)}`).join('  ·  ')}
+                </span>
+              </div>
+            )}
+            <div className={styles.metric}>
+              <span className={styles.metricLabel}>Net</span>
+              <span className={`num ${scorecard.net <= 0 ? 'pos' : 'warn'} ${styles.metricValue}`}>
+                {fmtSigned(scorecard.net, 0)}
+              </span>
+              <button
+                className={`dim ${styles.scorecardLink}`}
+                onClick={() => navigate('dashboard', { range: 'last30', scorecard: true })}
+              >
+                full scorecard →
+              </button>
+            </div>
+          </section>
+        )}
 
         {data.totalDebt > 0 && (
           <section className={styles.panel}>

--- a/gui/renderer/src/screens/Tags.module.css
+++ b/gui/renderer/src/screens/Tags.module.css
@@ -20,6 +20,15 @@
   width: 220px;
 }
 
+.select {
+  padding: 5px 8px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-size: 13px;
+  color: var(--text-dim);
+  background: transparent;
+}
+
 .addBtn {
   margin-left: auto;
   padding: 6px 14px;

--- a/gui/renderer/src/screens/Tags.tsx
+++ b/gui/renderer/src/screens/Tags.tsx
@@ -6,7 +6,7 @@ import { useNav } from '../hooks/useNav.js';
 import { useScreenKeys } from '../hooks/useScreenKeys.js';
 import { KeyHints } from '../components/KeyHints.js';
 import { Modal } from '../components/Modal.js';
-import { fmt, fmtSigned } from '../../../../core/fmt.js';
+import { fmt, fmtSigned, fmtSpan, sortTags, type TagSort } from '../../../../core/fmt.js';
 import type { Tag } from '../../../../core/queries.js';
 import { useFilter } from '../hooks/useFilter.js';
 import styles from './Tags.module.css';
@@ -27,6 +27,7 @@ export function Tags() {
   }
   const { showStatus, statusEl } = useStatus();
   const [search, setSearch] = useState('');
+  const [sort, setSort] = useState<TagSort>('name');
   const [reloadKey, setReloadKey] = useState(0);
   const reload = () => setReloadKey((k) => k + 1);
 
@@ -35,7 +36,11 @@ export function Tags() {
   const [addOpen, setAddOpen] = useState(false);
   const [renameTag, setRenameTag] = useState<Tag | null>(null);
 
-  const visibleTags = search ? tags.filter((t) => t.name.toLowerCase().includes(search.toLowerCase())) : tags;
+  const q = search.toLowerCase();
+  const visibleTags = sortTags(
+    search ? tags.filter((t) => t.name.toLowerCase().includes(q)) : tags,
+    sort,
+  );
   const selected = tags.find((t) => t.name.toLowerCase() === selectedName?.toLowerCase()) ?? null;
 
   const summary = useQuery(
@@ -76,6 +81,11 @@ export function Tags() {
             }
           }}
         />
+        <select className={styles.select} value={sort} onChange={(e) => setSort(e.target.value as TagSort)}>
+          <option value="name">Sort: name</option>
+          <option value="recent">Sort: most recent</option>
+          <option value="oldest">Sort: oldest</option>
+        </select>
         <button className={styles.addBtn} onClick={() => setAddOpen(true)}>
           + New tag
         </button>
@@ -91,6 +101,7 @@ export function Tags() {
                 <tr>
                   <th className={styles.th}>Tag</th>
                   <th className={styles.th}>Txns</th>
+                  <th className={styles.th}>Span</th>
                   <th className={styles.th}>Inflow</th>
                   <th className={styles.th}>Outflow</th>
                   <th className={styles.th} />
@@ -105,6 +116,7 @@ export function Tags() {
                   >
                     <td className={styles.tdName}>{t.name}</td>
                     <td className="num dim">{t.count}</td>
+                    <td className="dim">{fmtSpan(t.earliest, t.latest)}</td>
                     <td className="num pos">{fmt(t.inflow)}</td>
                     <td className="num neg">{fmt(t.outflow)}</td>
                     <td className={styles.tdActions}>

--- a/gui/shared/nav.ts
+++ b/gui/shared/nav.ts
@@ -18,8 +18,9 @@ export type TxFilter = {
   from?: string;
   to?: string;
   search?: string;
-  range?: string; // 'week' | 'month' | 'quarter' | 'year' | 'alltime'
+  range?: string; // 'week' | 'month' | 'last30' | 'quarter' | 'year' | 'alltime'
   anchor?: string; // YYYY-MM-DD — which specific period to land on
+  scorecard?: boolean; // land on the Dashboard with scorecard mode on
   canvasSpec?: string; // JSON-encoded CanvasSpec, used when navigating to 'canvas'
   txType?: 'income' | 'expenses';
   flex?: 'fixed' | 'flexible' | 'discretionary';

--- a/mcp/create-server.ts
+++ b/mcp/create-server.ts
@@ -270,17 +270,18 @@ export function createMcpServer(opts: { afterWrite?: () => void } = {}): McpServ
     (input) => run('get_financial_health', input),
   );
 
-  // ── get_drift ───────────────────────────────────────────────────────────────
+  // ── get_scorecard ───────────────────────────────────────────────────────────
 
   server.tool(
-    'get_drift',
-    'Show spending deltas per category: current amount vs prior period, same period last year, and 12-month rolling average. Defaults to current month-to-date.',
+    'get_scorecard',
+    'Spending scorecard: which categories are significantly over/under the typical month (12-month median baseline), with a net verdict. Defaults to the trailing 30 days.',
     {
+      window: z.enum(['last30', 'month']).optional().describe("Comparison window: 'last30' = trailing 30 days ending on the given date (default), 'month' = calendar month-to-date"),
       year:  z.number().int().optional().describe('4-digit year (default: current year)'),
       month: z.number().int().min(1).max(12).optional().describe('Month 1–12 (default: current month)'),
-      day:   z.number().int().min(1).max(31).optional().describe('Day through which to compare (default: today)'),
+      day:   z.number().int().min(1).max(31).optional().describe('Day the window ends on / compares through (default: today)'),
     },
-    (input) => run('get_drift', input),
+    (input) => run('get_scorecard', input),
   );
 
   // ── get_trends ──────────────────────────────────────────────────────────────

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "ink-testing-library": "^4.0.0",
         "jsdom": "^29.1.1",
         "react-dom": "^19.2.7",
-        "recharts": "^3.8.1",
+        "recharts": "^3.9.1",
         "typescript": "^6.0.3",
         "vite": "^7.3.5",
         "vitest": "^3.2.4"
@@ -1737,16 +1737,6 @@
         "react-redux": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@reduxjs/toolkit/node_modules/immer": {
-      "version": "11.1.8",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.8.tgz",
-      "integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==",
-      "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -5805,10 +5795,11 @@
       }
     },
     "node_modules/immer": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
-      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.8.tgz",
+      "integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -7334,10 +7325,11 @@
       }
     },
     "node_modules/recharts": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
-      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.9.1.tgz",
+      "integrity": "sha512-WMcwlXcB7l+BbxiEdyClkG+1sxrMHNZpzT577LEvU4+rXPd8oTAy1wXk72hnk2KOOmxuLvw3z5DtXT7HEAydtg==",
       "dev": true,
+      "license": "MIT",
       "workspaces": [
         "www"
       ],
@@ -7347,9 +7339,9 @@
         "decimal.js-light": "^2.5.1",
         "es-toolkit": "^1.39.3",
         "eventemitter3": "^5.0.1",
-        "immer": "^10.1.1",
+        "immer": "^11.1.8",
         "react-redux": "8.x.x || 9.x.x",
-        "reselect": "5.1.1",
+        "reselect": "5.2.0",
         "tiny-invariant": "^1.3.3",
         "use-sync-external-store": "^1.2.2",
         "victory-vendor": "^37.0.2"
@@ -7414,10 +7406,11 @@
       }
     },
     "node_modules/reselect": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
-      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
-      "dev": true
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
+      "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/resolve-alpn": {
       "version": "1.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "@types/react": "^19.2.16",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.2.0",
-        "electron": "^42.4.0",
+        "electron": "^43.0.0",
         "electron-builder": "^26.15.2",
         "electron-vite": "^5.0.0",
         "ink-testing-library": "^4.0.0",
@@ -4141,10 +4141,11 @@
       }
     },
     "node_modules/electron": {
-      "version": "42.4.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-42.4.0.tgz",
-      "integrity": "sha512-OXXqh9LD9KxXPv2Fe25EfU9N9AvWTuV6V81sfhQaNvTAXCd9ONA+Q4OWvMe+CmYD6xIwjFxGGtG/ZphDYYC5OQ==",
+      "version": "43.0.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-43.0.0.tgz",
+      "integrity": "sha512-PV60GsWU6qufhuOhw3n+Yix3WPDcqDtBqE8orbEQGQGHEkgp9o/JCPgb7L4vIL0r1HnfPdqSRtboOTqbDkcFDQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@electron-internal/extract-zip": "^1.0.1",
         "@electron/get": "^5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.2.0",
         "electron": "^43.0.0",
-        "electron-builder": "^26.15.2",
+        "electron-builder": "^26.15.3",
         "electron-vite": "^5.0.0",
         "ink-testing-library": "^4.0.0",
         "jsdom": "^29.1.1",
@@ -579,6 +579,7 @@
       "resolved": "https://registry.npmjs.org/@electron/asar/-/asar-3.4.1.tgz",
       "integrity": "sha512-i4/rNPRS84t0vSRa2HorerGRXWyF4vThfHesw0dmcWHp+cspK743UanA0suA5Q5y8kzY2y6YKrvbIUn69BCAiA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "commander": "^5.0.0",
         "glob": "^7.1.6",
@@ -595,13 +596,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@electron/asar/node_modules/brace-expansion": {
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
       "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -612,6 +615,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -624,6 +628,7 @@
       "resolved": "https://registry.npmjs.org/@electron/fuses/-/fuses-1.8.0.tgz",
       "integrity": "sha512-zx0EIq78WlY/lBb1uXlziZmDZI4ubcCXIMJ4uGjXzZW0nS19TjSPeXPAjzzTmKQlJUZm0SbmZhPKP7tuQ1SsEw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.1",
         "fs-extra": "^9.0.1",
@@ -638,6 +643,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -653,6 +659,7 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -669,6 +676,7 @@
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
       "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
@@ -716,6 +724,7 @@
       "resolved": "https://registry.npmjs.org/@electron/notarize/-/notarize-2.5.0.tgz",
       "integrity": "sha512-jNT8nwH1f9X5GEITXaQ8IF/KdskvIkOFfB2CvwumsveVidzpSc+mvhhTMdAGSYF3O+Nq49lJ7y+ssODRXu06+A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "debug": "^4.1.1",
         "fs-extra": "^9.0.1",
@@ -730,6 +739,7 @@
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
       "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
@@ -745,6 +755,7 @@
       "resolved": "https://registry.npmjs.org/@electron/osx-sign/-/osx-sign-1.3.3.tgz",
       "integrity": "sha512-KZ8mhXvWv2rIEgMbWZ4y33bDHyUKMXnx4M0sTyPNK/vcB81ImdeY9Ggdqy0SWbMDgmbqyQ+phgejh6V3R2QuSg==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "compare-version": "^0.1.2",
         "debug": "^4.3.4",
@@ -766,6 +777,7 @@
       "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.10.tgz",
       "integrity": "sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 8.0.0"
       },
@@ -774,10 +786,11 @@
       }
     },
     "node_modules/@electron/rebuild": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-4.0.4.tgz",
-      "integrity": "sha512-Rzc39XPdk/+/wBG8MfwAHohXflep0ITUfulb6Rgz3R0NeSB1noE+E9/M/cb8ftCAiyDD9PPhLuuWgE1GaInbKg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-4.1.0.tgz",
+      "integrity": "sha512-GFky+1JeO8fpSqtZCh+2wFRN/MVbAhm7tXI2M7BA1Os79OR8LEoxRtAbRPyxvmKWhEMF/p10rNJkkgP1klI13g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@malept/cross-spawn-promise": "^2.0.0",
         "debug": "^4.1.1",
@@ -798,6 +811,7 @@
       "resolved": "https://registry.npmjs.org/@electron/universal/-/universal-2.0.3.tgz",
       "integrity": "sha512-Wn9sPYIVFRFl5HmwMJkARCCf7rqK/EurkfQ/rJZ14mHP3iYTjZSIOSVonEAnhWeAXwtw7zOekGRlc6yTtZ0t+g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@electron/asar": "^3.3.1",
         "@malept/cross-spawn-promise": "^2.0.0",
@@ -815,22 +829,25 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@electron/universal/node_modules/brace-expansion": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
       "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
     },
     "node_modules/@electron/universal/node_modules/fs-extra": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
-      "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.6.tgz",
+      "integrity": "sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -845,6 +862,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
       "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.2"
       },
@@ -860,6 +878,7 @@
       "resolved": "https://registry.npmjs.org/@electron/windows-sign/-/windows-sign-1.2.2.tgz",
       "integrity": "sha512-dfZeox66AvdPtb2lD8OsIIQh12Tp0GNCRUDfBHIKGpbmopZto2/A8nSpYYLoedPIHpqkeblZ/k8OV0Gy7PYuyQ==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -877,10 +896,11 @@
       }
     },
     "node_modules/@electron/windows-sign/node_modules/fs-extra": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
-      "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.6.tgz",
+      "integrity": "sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -1342,6 +1362,7 @@
       "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
       "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "minipass": "^7.0.4"
       },
@@ -1555,6 +1576,7 @@
           "url": "https://tidelift.com/subscription/pkg/npm-.malept-cross-spawn-promise?utm_medium=referral&utm_source=npm_fund"
         }
       ],
+      "license": "Apache-2.0",
       "dependencies": {
         "cross-spawn": "^7.0.1"
       },
@@ -1567,6 +1589,7 @@
       "resolved": "https://registry.npmjs.org/@malept/flatpak-bundler/-/flatpak-bundler-0.4.0.tgz",
       "integrity": "sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "debug": "^4.1.1",
         "fs-extra": "^9.0.0",
@@ -1582,6 +1605,7 @@
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
       "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
@@ -1651,13 +1675,14 @@
       }
     },
     "node_modules/@peculiar/asn1-schema": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.7.0.tgz",
-      "integrity": "sha512-W8ZfWzLmQnrcky+eh3tni4IozMdqBDiHWU0N+vve/UGjMaUs8c0L7A2oEdkBXS8rTpWDpK/aoI3DG/L/hxmxPg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.8.0.tgz",
+      "integrity": "sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@peculiar/utils": "^2.0.2",
-        "asn1js": "^3.0.6",
+        "asn1js": "^3.0.10",
         "tslib": "^2.8.1"
       }
     },
@@ -1666,6 +1691,7 @@
       "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
       "integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.0"
       },
@@ -1678,6 +1704,7 @@
       "resolved": "https://registry.npmjs.org/@peculiar/utils/-/utils-2.0.3.tgz",
       "integrity": "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.8.1"
       }
@@ -1687,6 +1714,7 @@
       "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.7.1.tgz",
       "integrity": "sha512-ODOov0sGMJMf3jPonOkgGqPknTsu+DdQ7kD++gz8aI+aFMOMHFbWAA2taqXXVTdP+OTOQR/znGvSpmkeI0WTYQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@peculiar/asn1-schema": "^2.7.0",
         "@peculiar/json-schema": "^1.1.12",
@@ -2075,6 +2103,7 @@
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
       "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -2104,6 +2133,7 @@
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
       "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "defer-to-connect": "^2.0.0"
       },
@@ -2224,6 +2254,7 @@
       "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
       "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/http-cache-semantics": "*",
         "@types/keyv": "^3.1.4",
@@ -2330,6 +2361,7 @@
       "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
       "integrity": "sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -2338,13 +2370,15 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/keyv": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
       "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -2388,6 +2422,7 @@
       "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
       "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -2539,6 +2574,7 @@
       "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
       "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       }
@@ -2548,6 +2584,7 @@
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
       "integrity": "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
@@ -2675,10 +2712,11 @@
       }
     },
     "node_modules/app-builder-lib": {
-      "version": "26.15.2",
-      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-26.15.2.tgz",
-      "integrity": "sha512-3mYfKOjr/ZY7gFESOcq8kylBMgGPpmlQYnpBVit4p6zIg0t/8bkWBILdMMtnjFyN2jllyBf225T8dLlz3D6oBQ==",
+      "version": "26.15.3",
+      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-26.15.3.tgz",
+      "integrity": "sha512-2VnyWkqsP5v5XbBhL3tD5Syx8iNPBYsoU7kY4S2fz7wg8Rj/nztWKCUzGKaFRTv0Xwf3/H058CR1Kvtd/3lRow==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@electron/asar": "3.4.1",
         "@electron/fuses": "^1.8.0",
@@ -2694,7 +2732,7 @@
         "ajv": "^8.18.0",
         "asn1js": "^3.0.10",
         "async-exit-hook": "^2.0.1",
-        "builder-util": "26.15.0",
+        "builder-util": "26.15.3",
         "builder-util-runtime": "9.7.0",
         "chromium-pickle-js": "^0.2.0",
         "ci-info": "4.3.1",
@@ -2702,7 +2740,7 @@
         "dotenv": "^16.4.5",
         "dotenv-expand": "^11.0.6",
         "ejs": "^3.1.8",
-        "electron-publish": "26.15.1",
+        "electron-publish": "26.15.3",
         "fs-extra": "^10.1.0",
         "hosted-git-info": "^4.1.0",
         "isbinaryfile": "^5.0.0",
@@ -2726,8 +2764,8 @@
         "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "dmg-builder": "26.15.2",
-        "electron-builder-squirrel-windows": "26.15.2"
+        "dmg-builder": "26.15.3",
+        "electron-builder-squirrel-windows": "26.15.3"
       }
     },
     "node_modules/app-builder-lib/node_modules/@electron/get": {
@@ -2735,6 +2773,7 @@
       "resolved": "https://registry.npmjs.org/@electron/get/-/get-3.1.0.tgz",
       "integrity": "sha512-F+nKc0xW+kVbBRhFzaMgPy3KwmuNTYX1fx6+FxxoSnNgwYX6LD7AKBTWkU0MQ6IBoe7dz069CNkR673sPAgkCQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "debug": "^4.1.1",
         "env-paths": "^2.2.0",
@@ -2756,6 +2795,7 @@
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
       "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^4.0.0",
@@ -2770,6 +2810,7 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -2785,6 +2826,7 @@
           "url": "https://github.com/sponsors/sibiraj-s"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -2794,6 +2836,7 @@
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
       "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
       },
@@ -2806,6 +2849,7 @@
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
       "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -2815,6 +2859,7 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
       "integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
       "dev": true,
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
       }
@@ -2824,6 +2869,7 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
       "dev": true,
+      "license": "MIT",
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -2833,6 +2879,7 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -2845,6 +2892,7 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -2854,6 +2902,7 @@
       "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
       "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "isexe": "^3.1.1"
       },
@@ -2868,7 +2917,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "dev": true,
+      "license": "Python-2.0"
     },
     "node_modules/aria-query": {
       "version": "5.3.0",
@@ -2885,6 +2935,7 @@
       "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
       "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "pvtsutils": "^1.3.6",
         "pvutils": "^1.1.5",
@@ -2907,13 +2958,15 @@
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/async-exit-hook": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/async-exit-hook/-/async-exit-hook-2.0.1.tgz",
       "integrity": "sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
       }
@@ -2929,6 +2982,7 @@
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -2949,7 +3003,8 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
       "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/axios": {
       "version": "1.16.1",
@@ -2968,6 +3023,7 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
       }
@@ -2990,7 +3046,8 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.35",
@@ -3017,7 +3074,8 @@
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "2.2.2",
@@ -3049,13 +3107,15 @@
       "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
       "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
       "dev": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
@@ -3100,13 +3160,15 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/builder-util": {
-      "version": "26.15.0",
-      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-26.15.0.tgz",
-      "integrity": "sha512-dUx+HxVbiNsNQ4mGe1PyoC/tBmsHwBNDLdBuqWCj+rhHFE9lHgrXiGYKAM1uNlznhAaUSyMlms84VeSSr3gOBA==",
+      "version": "26.15.3",
+      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-26.15.3.tgz",
+      "integrity": "sha512-q2hn7Mbo2nFNkVekPiHFx6Nfo3hURmES3tfBn+k5Pqxl2RkmP3QGqZUhH/q9Pch/4G05NRhPjDlVj1O8q4Txvw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/debug": "^4.1.6",
         "builder-util-runtime": "9.7.0",
@@ -3132,6 +3194,7 @@
       "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.7.0.tgz",
       "integrity": "sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",
         "sax": "^1.2.4"
@@ -3145,6 +3208,7 @@
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 14"
       }
@@ -3154,6 +3218,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -3169,6 +3234,7 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -3185,6 +3251,7 @@
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "4"
@@ -3207,6 +3274,7 @@
       "resolved": "https://registry.npmjs.org/bytestreamjs/-/bytestreamjs-2.0.1.tgz",
       "integrity": "sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -3225,6 +3293,7 @@
       "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
       "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10.6.0"
       }
@@ -3234,6 +3303,7 @@
       "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
       "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "clone-response": "^1.0.2",
         "get-stream": "^5.1.0",
@@ -3338,6 +3408,7 @@
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
       "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
       "dev": true,
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
       }
@@ -3346,7 +3417,8 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz",
       "integrity": "sha512-1R5Fho+jBq0DDydt+/vHWj5KJNJCKdARKOCwZUen84I5BreWoLqRLANH1U87eJy1tiASPtMnGqJJq0ZsLoRPOw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ci-info": {
       "version": "4.4.0",
@@ -3501,6 +3573,7 @@
       "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
       "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "mimic-response": "^1.0.0"
       },
@@ -3564,6 +3637,7 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
       "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 6"
       }
@@ -3573,6 +3647,7 @@
       "resolved": "https://registry.npmjs.org/compare-version/-/compare-version-0.1.2.tgz",
       "integrity": "sha512-pJDh5/4wrEnXX/VWRZvruAGHkzKdr46z11OlTPN+VrATlWWhSKewNCJ1futCO5C7eJB3nPMFZA1LeYtcFboZ2A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3581,7 +3656,8 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/content-disposition": {
       "version": "1.1.0",
@@ -3642,7 +3718,8 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cors": {
       "version": "2.8.6",
@@ -3666,6 +3743,7 @@
       "resolved": "https://registry.npmjs.org/cross-dirname/-/cross-dirname-0.1.0.tgz",
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "peer": true
     },
@@ -3871,6 +3949,7 @@
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "mimic-response": "^3.1.0"
       },
@@ -3886,6 +3965,7 @@
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -3907,6 +3987,7 @@
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
       "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       }
@@ -3916,6 +3997,7 @@
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "es-define-property": "^1.0.0",
@@ -3934,6 +4016,7 @@
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "define-data-property": "^1.0.1",
@@ -3988,6 +4071,7 @@
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
       "dev": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/dir-compare": {
@@ -3995,6 +4079,7 @@
       "resolved": "https://registry.npmjs.org/dir-compare/-/dir-compare-4.2.0.tgz",
       "integrity": "sha512-2xMCmOoMrdQIPHdsTawECdNPwlVFB9zGcz3kuhmBO6U3oU+UQjsue0i8ayLKpgBcm+hcXPMVSGUN9d+pvJ6+VQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "minimatch": "^3.0.5",
         "p-limit": "^3.1.0 "
@@ -4004,13 +4089,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dir-compare/node_modules/brace-expansion": {
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
       "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -4021,6 +4108,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -4029,13 +4117,14 @@
       }
     },
     "node_modules/dmg-builder": {
-      "version": "26.15.2",
-      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-26.15.2.tgz",
-      "integrity": "sha512-fMkjRqKyPtsz4Kzu/qGP0BGjqzMCIgp+/7kw/u6YH6lvn/8hvL3c0TXhoFayBoYdpPCnEinnCHztd4bW7/jetA==",
+      "version": "26.15.3",
+      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-26.15.3.tgz",
+      "integrity": "sha512-O3zJUFUYHJKgzPqioHxfxzBzlSC1eXCSr79gMSBKBP5AgjjpmrydMsMLotEg9fAJF36vdUncb+4ndRNxoPdlSQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "app-builder-lib": "26.15.2",
-        "builder-util": "26.15.0",
+        "app-builder-lib": "26.15.3",
+        "builder-util": "26.15.3",
         "fs-extra": "^10.1.0",
         "js-yaml": "^4.1.0"
       }
@@ -4064,6 +4153,7 @@
       "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-11.0.7.tgz",
       "integrity": "sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "dotenv": "^16.4.5"
       },
@@ -4079,6 +4169,7 @@
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
       "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
       },
@@ -4105,6 +4196,7 @@
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
       "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "readable-stream": "^2.0.2"
       }
@@ -4120,6 +4212,7 @@
       "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
       "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "jake": "^10.8.5"
       },
@@ -4150,17 +4243,18 @@
       }
     },
     "node_modules/electron-builder": {
-      "version": "26.15.2",
-      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-26.15.2.tgz",
-      "integrity": "sha512-veKM9+dCljaC5A74Pwc0ZWQ9arOHREXWh9hUIf8NGg49ch7x+IB4QhbMzIrV5ONZIXM2OEkaxW11cAPjPtoi4A==",
+      "version": "26.15.3",
+      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-26.15.3.tgz",
+      "integrity": "sha512-a1KM5heqS3gQCZzizXEI8RjJy3QVogULPdeSknt76uLDpBIW/HDGsMg/XgP0riP6PI9COsRvFITKKGDqA8fJxA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "app-builder-lib": "26.15.2",
-        "builder-util": "26.15.0",
+        "app-builder-lib": "26.15.3",
+        "builder-util": "26.15.3",
         "builder-util-runtime": "9.7.0",
         "chalk": "^4.1.2",
         "ci-info": "^4.2.0",
-        "dmg-builder": "26.15.2",
+        "dmg-builder": "26.15.3",
         "fs-extra": "^10.1.0",
         "lazy-val": "^1.0.5",
         "simple-update-notifier": "2.0.0",
@@ -4175,14 +4269,15 @@
       }
     },
     "node_modules/electron-builder-squirrel-windows": {
-      "version": "26.15.2",
-      "resolved": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-26.15.2.tgz",
-      "integrity": "sha512-PNl+SSRoma9mXhxycNGxutZPgvmK19v41mn8F9oecpAU2QNAldpB4HfMuA1LwFC2j8aRzzV5M9HKlKe6dfpvNw==",
+      "version": "26.15.3",
+      "resolved": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-26.15.3.tgz",
+      "integrity": "sha512-Jc19XPV9y9+2bAdZPkXuVNGNIEFBq9poHC61l8Kv6FdK7DRG3+Ic0rerC0DXOaeHNz8yW0fg/JnF8GQROOF5MA==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "app-builder-lib": "26.15.2",
-        "builder-util": "26.15.0",
+        "app-builder-lib": "26.15.3",
+        "builder-util": "26.15.3",
         "electron-winstaller": "5.4.0"
       }
     },
@@ -4218,14 +4313,15 @@
       }
     },
     "node_modules/electron-publish": {
-      "version": "26.15.1",
-      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-26.15.1.tgz",
-      "integrity": "sha512-BMgMHOyexWn0UnOC+Afffw0DMrr0yfLp4U8YsLXwoJ3Da7LS7WUnz21teYZqO0gaApE1KgsjREWmbPqvF5JcPg==",
+      "version": "26.15.3",
+      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-26.15.3.tgz",
+      "integrity": "sha512-g/2bn8YTavY4cuS5F+jOS7zmZbXXBV8KZ8yHKfJjFPoKtzBqrpCdNPxBd3tqdBwP7BVd0lGzf7Bk2s0KesWZ4Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/fs-extra": "^9.0.11",
         "aws4": "^1.13.2",
-        "builder-util": "26.15.0",
+        "builder-util": "26.15.3",
         "builder-util-runtime": "9.7.0",
         "chalk": "^4.1.2",
         "form-data": "^4.0.5",
@@ -4239,6 +4335,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -4254,6 +4351,7 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -4763,6 +4861,7 @@
       "integrity": "sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
@@ -4783,6 +4882,7 @@
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
@@ -4798,6 +4898,7 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
@@ -4808,6 +4909,7 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">= 4.0.0"
@@ -4848,6 +4950,7 @@
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -4892,7 +4995,8 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
       "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
@@ -4960,6 +5064,7 @@
       "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
       "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
       "dev": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/esbuild": {
@@ -5085,7 +5190,8 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
       "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
-      "dev": true
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/express": {
       "version": "5.2.1",
@@ -5222,6 +5328,7 @@
       "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.6.tgz",
       "integrity": "sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "minimatch": "^5.0.1"
       }
@@ -5230,13 +5337,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/filelist/node_modules/brace-expansion": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
       "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -5246,6 +5355,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
       "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -5333,6 +5443,7 @@
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -5346,7 +5457,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -5443,6 +5555,7 @@
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
       "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "pump": "^3.0.0"
       },
@@ -5459,6 +5572,7 @@
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -5478,13 +5592,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
       "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -5495,6 +5611,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -5507,6 +5624,7 @@
       "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
       "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "optional": true,
       "dependencies": {
         "boolean": "^3.0.1",
@@ -5521,10 +5639,11 @@
       }
     },
     "node_modules/global-agent/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
+      "license": "ISC",
       "optional": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -5538,6 +5657,7 @@
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
       "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "define-properties": "^1.2.1",
@@ -5567,6 +5687,7 @@
       "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
       "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@sindresorhus/is": "^4.0.0",
         "@szmarczak/http-timer": "^4.0.5",
@@ -5607,6 +5728,7 @@
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "es-define-property": "^1.0.0"
@@ -5668,6 +5790,7 @@
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
       "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -5680,6 +5803,7 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -5691,7 +5815,8 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
@@ -5709,7 +5834,8 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-2-Clause"
     },
     "node_modules/http-errors": {
       "version": "2.0.1",
@@ -5736,6 +5862,7 @@
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.0",
         "debug": "^4.3.4"
@@ -5749,6 +5876,7 @@
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 14"
       }
@@ -5758,6 +5886,7 @@
       "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
       "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "quick-lru": "^5.1.1",
         "resolve-alpn": "^1.0.0"
@@ -5824,6 +5953,7 @@
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -5975,13 +6105,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/isbinaryfile": {
       "version": "5.0.7",
       "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-5.0.7.tgz",
       "integrity": "sha512-gnWD14Jh3FzS3CPhF0AxNOJ8CxqeblPTADzI38r0wt8ZyQl5edpy75myt08EG2oKvpyiqSqsx+Wkz9vtkbTqYQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 18.0.0"
       },
@@ -6000,6 +6132,7 @@
       "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.4.tgz",
       "integrity": "sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "async": "^3.2.6",
         "filelist": "^1.0.4",
@@ -6042,9 +6175,9 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {
@@ -6056,6 +6189,7 @@
           "url": "https://github.com/sponsors/nodeca"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -6128,7 +6262,8 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-schema-to-ts": {
       "version": "3.1.1",
@@ -6159,6 +6294,7 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
       "dev": true,
+      "license": "ISC",
       "optional": true
     },
     "node_modules/json5": {
@@ -6178,6 +6314,7 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
       "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -6190,6 +6327,7 @@
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
       }
@@ -6198,7 +6336,8 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
       "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/libsql": {
       "version": "0.5.29",
@@ -6235,7 +6374,8 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/loupe": {
       "version": "3.2.1",
@@ -6248,6 +6388,7 @@
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
       "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -6285,6 +6426,7 @@
       "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
       "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "escape-string-regexp": "^4.0.0"
@@ -6298,6 +6440,7 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=10"
@@ -6347,6 +6490,7 @@
       "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
       "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "mime": "cli.js"
       },
@@ -6389,6 +6533,7 @@
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
       "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -6398,6 +6543,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
       "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.5"
       },
@@ -6413,6 +6559,7 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -6422,6 +6569,7 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
       "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "dev": true,
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -6431,6 +6579,7 @@
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
       "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "minipass": "^7.1.2"
       },
@@ -6443,6 +6592,7 @@
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
@@ -6485,10 +6635,11 @@
       }
     },
     "node_modules/node-abi": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-4.31.0.tgz",
-      "integrity": "sha512-Erq5w/t3syw3s4sDsUaX4QttIdBPsGKTT1DTRsCkTonGggczhlDKm/wDX3o+HPJpQ41EjXCbcmXf0tgr5YZJXw==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-4.33.0.tgz",
+      "integrity": "sha512-vLBWCKb+7LWsX+TbfzWOkw0W81m377tyx3hOweBTjO43CXZnRGS1/JPWs20fr0PgZyDXk6ROYrylsEycK8raDA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "semver": "^7.6.3"
       },
@@ -6497,10 +6648,11 @@
       }
     },
     "node_modules/node-abi/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -6513,15 +6665,17 @@
       "resolved": "https://registry.npmjs.org/node-api-version/-/node-api-version-0.2.1.tgz",
       "integrity": "sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "semver": "^7.3.5"
       }
     },
     "node_modules/node-api-version/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -6534,6 +6688,7 @@
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.4.0.tgz",
       "integrity": "sha512-OMcPNvqTCFUnNaBlmdgq+lfNqY7gTiSmNRDjY3uAXRyudeKZEZxu3CLtjMQrx4zZxCX2b/mpNqTtwuCJgXhHkw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "env-paths": "^2.2.0",
         "exponential-backoff": "^3.1.1",
@@ -6558,6 +6713,7 @@
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
       "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -6567,15 +6723,17 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
       "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
       "dev": true,
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/node-gyp/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -6584,10 +6742,11 @@
       }
     },
     "node_modules/node-gyp/node_modules/undici": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
-      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18.17"
       }
@@ -6597,6 +6756,7 @@
       "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
       "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "isexe": "^4.0.0"
       },
@@ -6611,7 +6771,8 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/node-releases": {
       "version": "2.0.47",
@@ -6627,6 +6788,7 @@
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-9.0.0.tgz",
       "integrity": "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "abbrev": "^4.0.0"
       },
@@ -6642,6 +6804,7 @@
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
       "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -6675,6 +6838,7 @@
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">= 0.4"
@@ -6739,6 +6903,7 @@
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
       "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -6748,6 +6913,7 @@
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
       },
@@ -6793,6 +6959,7 @@
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6836,6 +7003,7 @@
       "resolved": "https://registry.npmjs.org/pe-library/-/pe-library-0.4.1.tgz",
       "integrity": "sha512-eRWB5LBz7PpDu4PUlwT0PhnQfTQJlDDdPa35urV4Osrm0t0AqQFGn+UIkU3klZvwJ8KPO3VbBFsXquA6p6kqZw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12",
         "npm": ">=6"
@@ -6877,6 +7045,7 @@
       "resolved": "https://registry.npmjs.org/pkijs/-/pkijs-3.4.0.tgz",
       "integrity": "sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@noble/hashes": "1.4.0",
         "asn1js": "^3.0.6",
@@ -6950,6 +7119,7 @@
       "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
       "integrity": "sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@xmldom/xmldom": "^0.8.8",
         "base64-js": "^1.5.1",
@@ -6992,6 +7162,7 @@
       "resolved": "https://registry.npmjs.org/postject/-/postject-1.0.0-alpha.6.tgz",
       "integrity": "sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -7009,6 +7180,7 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
       "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "peer": true,
       "engines": {
@@ -7065,6 +7237,7 @@
       "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
       "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
@@ -7073,7 +7246,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/progress": {
       "version": "2.0.3",
@@ -7094,6 +7268,7 @@
       "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
       "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "err-code": "^2.0.2",
         "retry": "^0.12.0"
@@ -7107,6 +7282,7 @@
       "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
       "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
         "retry": "^0.12.0",
@@ -7140,6 +7316,7 @@
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
       "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -7159,6 +7336,7 @@
       "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
       "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.8.1"
       }
@@ -7168,6 +7346,7 @@
       "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
       "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=16.0.0"
       }
@@ -7192,6 +7371,7 @@
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -7303,6 +7483,7 @@
       "resolved": "https://registry.npmjs.org/read-binary-file-arch/-/read-binary-file-arch-1.0.6.tgz",
       "integrity": "sha512-BNg9EN3DD3GsDXX7Aa8O4p92sryjkmzYYgmgTAc6CA4uGLEDzFfxOxugu21akOxpcXHiEgsYkC6nPsQvLLLmEg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4"
       },
@@ -7315,6 +7496,7 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -7394,6 +7576,7 @@
       "resolved": "https://registry.npmjs.org/resedit/-/resedit-1.7.2.tgz",
       "integrity": "sha512-vHjcY2MlAITJhC0eRD/Vv8Vlgmu9Sd3LX9zZvtGzU5ZImdTN3+d6e/4mnTyV8vEbyf1sgNIrWxhWlrys52OkEA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "pe-library": "^0.4.1"
       },
@@ -7417,13 +7600,15 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
       "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/responselike": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
       "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "lowercase-keys": "^2.0.0"
       },
@@ -7452,6 +7637,7 @@
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 4"
       }
@@ -7462,6 +7648,7 @@
       "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
+      "license": "ISC",
       "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
@@ -7475,6 +7662,7 @@
       "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
       "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "optional": true,
       "dependencies": {
         "boolean": "^3.0.1",
@@ -7558,7 +7746,8 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -7571,6 +7760,7 @@
       "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.4.tgz",
       "integrity": "sha512-9ZyI08PsvdQl2r/bBIGubpVdR3RR9sY6RDiWFPreA21C/EFlQhmgo20UZlNjZMMZNubusLhAQozkA0Od5J21Eg==",
       "dev": true,
+      "license": "WTFPL OR ISC",
       "dependencies": {
         "truncate-utf8-bytes": "^1.0.0"
       }
@@ -7580,6 +7770,7 @@
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
       "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
       "dev": true,
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
       }
@@ -7616,6 +7807,7 @@
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
       "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
       "dev": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/send": {
@@ -7674,6 +7866,7 @@
       "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
       "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "type-fest": "^0.13.1"
@@ -7690,6 +7883,7 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
       "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
       "dev": true,
+      "license": "(MIT OR CC0-1.0)",
       "optional": true,
       "engines": {
         "node": ">=10"
@@ -7873,6 +8067,7 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7891,6 +8086,7 @@
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -7901,6 +8097,7 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "optional": true
     },
     "node_modules/stack-utils": {
@@ -7935,6 +8132,7 @@
       "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-1.0.0.tgz",
       "integrity": "sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 6"
       }
@@ -7959,6 +8157,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -8049,10 +8248,11 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.16",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
-      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+      "version": "7.5.19",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.19.tgz",
+      "integrity": "sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==",
       "dev": true,
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
@@ -8069,6 +8269,7 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
       "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
       "dev": true,
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
       }
@@ -8078,6 +8279,7 @@
       "resolved": "https://registry.npmjs.org/temp/-/temp-0.9.4.tgz",
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
@@ -8092,6 +8294,7 @@
       "resolved": "https://registry.npmjs.org/temp-file/-/temp-file-3.4.0.tgz",
       "integrity": "sha512-C5tjlC/HCtVUOi3KWVokd4vHVViOmGjtLwIh4MuzPo/nMYTV/p1urt3RnMz2IWXDdKEGJH3k5+KPxtqRsUYGtg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "async-exit-hook": "^2.0.1",
         "fs-extra": "^10.0.0"
@@ -8114,6 +8317,7 @@
       "resolved": "https://registry.npmjs.org/tiny-async-pool/-/tiny-async-pool-1.3.0.tgz",
       "integrity": "sha512-01EAw5EDrcVrdgyCLgoSPvqznC0sVxDSVeiOz09FUpjh71G79VCqneOr+xvt7T1r76CF6ZZfPjHorN2+d+3mqA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "semver": "^5.5.0"
       }
@@ -8123,6 +8327,7 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
       "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver"
       }
@@ -8211,6 +8416,7 @@
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
       "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=14.14"
       }
@@ -8220,6 +8426,7 @@
       "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
       "integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "tmp": "^0.2.0"
       }
@@ -8262,6 +8469,7 @@
       "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
       "integrity": "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==",
       "dev": true,
+      "license": "WTFPL",
       "dependencies": {
         "utf8-byte-length": "^1.0.1"
       }
@@ -8275,7 +8483,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/tsx": {
       "version": "4.22.4",
@@ -8400,6 +8609,7 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -8414,23 +8624,25 @@
       }
     },
     "node_modules/unzipper": {
-      "version": "0.12.3",
-      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.12.3.tgz",
-      "integrity": "sha512-PZ8hTS+AqcGxsaQntl3IRBw65QrBI6lxzqDEL7IAo/XCEqRTKGfOX56Vea5TH9SZczRVxuzk1re04z/YjuYCJA==",
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.12.5.tgz",
+      "integrity": "sha512-tXYOi9R57Uj/2Z25SOs5RRSzq886MBQj2gY8dPL+xl/kv6s6SvByoKfAtvfVeEuhntWDgjd2o9p2lb4TVPAz0A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "bluebird": "~3.7.2",
         "duplexer2": "~0.1.4",
-        "fs-extra": "^11.2.0",
+        "fs-extra": "11.3.1",
         "graceful-fs": "^4.2.2",
         "node-int64": "^0.4.0"
       }
     },
     "node_modules/unzipper/node_modules/fs-extra": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
-      "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
+      "version": "11.3.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz",
+      "integrity": "sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -8483,13 +8695,15 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
       "integrity": "sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==",
-      "dev": true
+      "dev": true,
+      "license": "(WTFPL OR MIT)"
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -9164,6 +9378,7 @@
       "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.9.2.tgz",
       "integrity": "sha512-gsXecm82UQNlTBURJGuqOWy1Ww08S3kZUcr3aOJS02Pk0xLtkfeUAVC0u0xhgdonFme80edSJUIJyuvL/7250Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@peculiar/asn1-schema": "^2.7.0",
         "@peculiar/json-schema": "^1.1.12",
@@ -9308,6 +9523,7 @@
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
       "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.0"
       }
@@ -9409,6 +9625,7 @@
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.2.0",
     "electron": "^43.0.0",
-    "electron-builder": "^26.15.2",
+    "electron-builder": "^26.15.3",
     "electron-vite": "^5.0.0",
     "ink-testing-library": "^4.0.0",
     "jsdom": "^29.1.1",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@types/react": "^19.2.16",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.2.0",
-    "electron": "^42.4.0",
+    "electron": "^43.0.0",
     "electron-builder": "^26.15.2",
     "electron-vite": "^5.0.0",
     "ink-testing-library": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "ink-testing-library": "^4.0.0",
     "jsdom": "^29.1.1",
     "react-dom": "^19.2.7",
-    "recharts": "^3.8.1",
+    "recharts": "^3.9.1",
     "typescript": "^6.0.3",
     "vite": "^7.3.5",
     "vitest": "^3.2.4"

--- a/tests/dateUtils.test.ts
+++ b/tests/dateUtils.test.ts
@@ -91,6 +91,22 @@ describe('getPeriodStart', () => {
     });
   });
 
+  describe('last30', () => {
+    it('returns 29 days before the given date (trailing window start)', () => {
+      const start = getPeriodStart('last30', d(2026, 7, 3));
+      expect(start.getFullYear()).toBe(2026);
+      expect(start.getMonth()).toBe(5); // June
+      expect(start.getDate()).toBe(4);
+    });
+
+    it('crosses year boundaries', () => {
+      const start = getPeriodStart('last30', d(2026, 1, 10));
+      expect(start.getFullYear()).toBe(2025);
+      expect(start.getMonth()).toBe(11); // December
+      expect(start.getDate()).toBe(12);
+    });
+  });
+
   describe('alltime', () => {
     it('returns year 2000', () => {
       const start = getPeriodStart('alltime', d(2025, 1, 1));
@@ -169,6 +185,20 @@ describe('getPeriodDates', () => {
       expect(dates.to).toBe('2025-12-31');
     });
   });
+
+  describe('last30', () => {
+    it('returns a 30-day range starting at the anchor', () => {
+      const dates = getPeriodDates('last30', d(2026, 6, 4));
+      expect(dates.from).toBe('2026-06-04');
+      expect(dates.to).toBe('2026-07-03');
+    });
+
+    it('spans month and year boundaries', () => {
+      const dates = getPeriodDates('last30', d(2025, 12, 15));
+      expect(dates.from).toBe('2025-12-15');
+      expect(dates.to).toBe('2026-01-13');
+    });
+  });
 });
 
 describe('navigatePeriod', () => {
@@ -243,6 +273,20 @@ describe('navigatePeriod', () => {
     });
   });
 
+  describe('last30 navigation', () => {
+    it('moves backward 30 days', () => {
+      const prev = navigatePeriod('last30', d(2026, 6, 4), -1);
+      expect(prev.getMonth()).toBe(4); // May
+      expect(prev.getDate()).toBe(5);
+    });
+
+    it('moves forward 30 days', () => {
+      const next = navigatePeriod('last30', d(2026, 6, 4), 1);
+      expect(next.getMonth()).toBe(6); // July
+      expect(next.getDate()).toBe(4);
+    });
+  });
+
   describe('alltime navigation', () => {
     it('does not move (alltime is fixed)', () => {
       const anchor = d(2025, 6, 15);
@@ -283,6 +327,18 @@ describe('formatPeriodLabel', () => {
 
   it('formats year label', () => {
     expect(formatPeriodLabel('year', d(2025, 6, 15))).toBe('2025');
+  });
+
+  it('formats last30 label spanning months', () => {
+    expect(formatPeriodLabel('last30', d(2026, 6, 4))).toBe('Jun 4 – Jul 3, 2026');
+  });
+
+  it('formats last30 label within one month', () => {
+    expect(formatPeriodLabel('last30', d(2026, 1, 1))).toBe('Jan 1–30, 2026');
+  });
+
+  it('formats last30 label spanning years', () => {
+    expect(formatPeriodLabel('last30', d(2025, 12, 15))).toBe('Dec 15 – Jan 13, 2026');
   });
 
   it('formats alltime label', () => {

--- a/tests/drift.test.ts
+++ b/tests/drift.test.ts
@@ -117,6 +117,41 @@ describe('getDriftWindows', () => {
     });
   });
 
+  describe('last30 range', () => {
+    const anchor = d(2026, 6, 4);  // trailing window Jun 4 – Jul 3
+    const today  = d(2026, 7, 3);
+
+    it('current window is the full trailing 30 days', () => {
+      const w = getDriftWindows('last30', anchor, today)!;
+      expect(w.current.from).toBe('2026-06-04');
+      expect(w.current.to).toBe('2026-07-03');
+    });
+
+    it('lastPeriod is the contiguous prior 30 days', () => {
+      const w = getDriftWindows('last30', anchor, today)!;
+      expect(w.lastPeriod.from).toBe('2026-05-05');
+      expect(w.lastPeriod.to).toBe('2026-06-03');
+    });
+
+    it('lastYear is the same 30-day window a year earlier', () => {
+      const w = getDriftWindows('last30', anchor, today)!;
+      expect(w.lastYear.from).toBe('2025-06-04');
+      expect(w.lastYear.to).toBe('2025-07-03');
+    });
+
+    it('rolling12 is 12 contiguous 30-day windows', () => {
+      const w = getDriftWindows('last30', anchor, today)!;
+      expect(w.rolling12).toHaveLength(12);
+      expect(w.rolling12[0]).toEqual({ from: '2026-05-05', to: '2026-06-03' });
+      // each window ends the day before the next one starts
+      for (let i = 1; i < 12; i++) {
+        const next = new Date(w.rolling12[i].to + 'T12:00:00');
+        next.setDate(next.getDate() + 1);
+        expect(next.toISOString().slice(0, 10)).toBe(w.rolling12[i - 1].from);
+      }
+    });
+  });
+
   describe('week range', () => {
     const anchor = d(2025, 5, 19);
     const today  = d(2025, 5, 22);
@@ -242,6 +277,36 @@ describe('getCategoryDriftData', () => {
     const row = result.find((r) => r.category === 'BrandNew')!;
     expect(row.avg12m).toBe(0);
     expect(row.avg12mDelta).toBeCloseTo(100);
+  });
+
+  it('median12m resists a one-off spike that inflates the mean', async () => {
+    const months = ['2026-04','2026-03','2026-02','2026-01','2025-12','2025-11',
+                    '2025-10','2025-09','2025-08','2025-07','2025-06'];
+    for (const ym of months) {
+      await insertTx({ date: `${ym}-15`, amount: 100, category: 'Medical' });
+    }
+    await insertTx({ date: '2025-05-15', amount: 5000, category: 'Medical' }); // spike
+    await insertTx({ date: '2026-05-15', amount: 150, category: 'Medical' });
+
+    const result = await getCategoryDriftData(current, lastPeriod, lastYear, rolling12);
+    const row = result.find((r) => r.category === 'Medical')!;
+    expect(row.median12m).toBeCloseTo(100);
+    expect(row.medianDelta).toBeCloseTo(50);
+    expect(row.avg12m).toBeGreaterThan(500); // the mean is distorted by the spike
+  });
+
+  it('drops rolling windows that predate the first transaction', async () => {
+    // Only 3 months of history — phantom zero windows must not drag the baseline
+    await insertTx({ date: '2026-04-15', amount: 100, category: 'Food' });
+    await insertTx({ date: '2026-03-15', amount: 100, category: 'Food' });
+    await insertTx({ date: '2026-02-10', amount: 100, category: 'Food' });
+    await insertTx({ date: '2026-05-15', amount: 200, category: 'Food' });
+
+    const result = await getCategoryDriftData(current, lastPeriod, lastYear, rolling12);
+    const row = result.find((r) => r.category === 'Food')!;
+    expect(row.avg12m).toBeCloseTo(100);    // not 300/12
+    expect(row.median12m).toBeCloseTo(100);
+    expect(row.medianDelta).toBeCloseTo(100);
   });
 
   it('excludes hidden categories', async () => {

--- a/tests/gui-bridge-parity.test.ts
+++ b/tests/gui-bridge-parity.test.ts
@@ -37,6 +37,11 @@ const EXPECTED_UNBRIDGED: Record<string, string> = {
   fmtValue: 'renderer imports pure core/canvas-spec.ts directly',
   fmtDialValue: 'renderer imports pure core/canvas-spec.ts directly',
 
+  // Pure scorecard helpers — renderer imports core/scorecard.ts directly (GUI PR2)
+  bucketDrift: 'renderer imports pure core/scorecard.ts directly',
+  isSignificantDelta: 'renderer imports pure core/scorecard.ts directly',
+  ratioLabel: 'renderer imports pure core/scorecard.ts directly',
+
   // Electron-side bridge namespaces live in gui/main/bridge.ts (not registry.ts)
   getDefaultDaysRequested: 'bridge plaid namespace (gui/main/bridge.ts)',
 };

--- a/tests/gui/dashboard.test.tsx
+++ b/tests/gui/dashboard.test.tsx
@@ -76,6 +76,60 @@ describe('GUI Dashboard', () => {
     );
   });
 
+  it('scorecard mode buckets categories vs the typical-month baseline', async () => {
+    renderScreen(<Dashboard />, { txFilter: MAY_FILTER });
+    await waitFor(() => expect(screen.getByText('Grocery')).toBeTruthy());
+    await userEvent.click(screen.getByRole('button', { name: 'Δ scorecard' }));
+
+    const section = await waitFor(() => {
+      const s = screen.getByText(/Spending by category · vs typical/).closest('section')!;
+      expect(s.textContent).toContain('Over');
+      return s;
+    });
+    // Grocery: May $205 vs April-only baseline $100 → over by $105.
+    // Bills & Utilities: $95 with no history → over, flagged "new".
+    // Dining (+$5) and Shopping ($43.99, no baseline) sit under the
+    // significance gate → typical. Nothing is under → no Under section.
+    expect(section.textContent).toContain('+$105');
+    expect(section.textContent).toContain('+$95');
+    expect(section.textContent).toContain('new');
+    expect(section.textContent).toContain('Typical');
+    expect(section.textContent).not.toContain('Under');
+    // Net row: 105 + 5 + 95 + 43.99 ≈ +$249 vs typical.
+    expect(section.textContent).toContain('+$249');
+    expect(section.textContent).toContain('vs typical');
+  });
+
+  it('scorecard rows drill to transactions like category rows', async () => {
+    const navigate = vi.fn();
+    renderScreen(<Dashboard />, { txFilter: MAY_FILTER, navigate });
+    await waitFor(() => expect(screen.getByText('Grocery')).toBeTruthy());
+    await userEvent.click(screen.getByRole('button', { name: 'Δ scorecard' }));
+    await waitFor(() => expect(screen.getByText('Over')).toBeTruthy());
+    await userEvent.click(screen.getByText('Grocery'));
+    expect(navigate).toHaveBeenCalledWith(
+      'transactions',
+      expect.objectContaining({ from: '2026-05-01', to: '2026-05-31', drillFrom: 'dashboard' }),
+    );
+  });
+
+  it('columns toggle switches to the sortable per-baseline delta table', async () => {
+    renderScreen(<Dashboard />, { txFilter: MAY_FILTER });
+    await waitFor(() => expect(screen.getByText('Grocery')).toBeTruthy());
+    await userEvent.click(screen.getByRole('button', { name: 'Δ scorecard' }));
+    await waitFor(() => expect(screen.getByRole('button', { name: 'columns' })).toBeTruthy());
+    await userEvent.click(screen.getByRole('button', { name: 'columns' }));
+    // The diagnostic table has the three baseline columns; the scorecard doesn't.
+    await waitFor(() => expect(screen.getByText(/vs prev/)).toBeTruthy());
+    expect(screen.getByText(/yr ago/)).toBeTruthy();
+    expect(screen.getByText(/12m avg/)).toBeTruthy();
+  });
+
+  it('mounts with scorecard mode on when navigated with scorecard: true', async () => {
+    renderScreen(<Dashboard />, { txFilter: { ...MAY_FILTER, scorecard: true } });
+    await waitFor(() => expect(screen.getByText(/Spending by category · vs typical/)).toBeTruthy());
+  });
+
   it('Spending by category rows sum to the displayed Expenses total', async () => {
     // Exercise the two cases that used to break reconciliation: a refund inside a
     // real category (must NET to 200) and an income+spend mix inside Uncategorized

--- a/tests/gui/health.test.tsx
+++ b/tests/gui/health.test.tsx
@@ -61,6 +61,34 @@ describe('GUI Health', () => {
     expect(restored).toBe(before);
   });
 
+  it('hides the last-30-days panel when the trailing window has no drift', async () => {
+    // Seed data is fixed in May 2026; the trailing 30 days (real clock) is empty.
+    renderScreen(<Health />);
+    await waitFor(() => expect(screen.getByText('Snapshot')).toBeTruthy());
+    expect(screen.queryByText(/Last 30 days/)).toBeNull();
+  });
+
+  it('shows recent movers and deep-links to the Dashboard scorecard', async () => {
+    // Date the spend relative to the real clock so it always falls inside the
+    // trailing 30-day window; with no Transportation history it buckets as over.
+    const recent = new Date();
+    recent.setDate(recent.getDate() - 5);
+    await db.execute({
+      sql: `INSERT INTO transactions (id, account_id, date, name, amount, category, pending, ignored)
+            VALUES ('tx-transport', 'test-credit', ?, 'Uber', 500.00, 'Transportation', 0, 0)`,
+      args: [recent.toISOString().slice(0, 10)],
+    });
+
+    const navigate = vi.fn();
+    renderScreen(<Health />, { navigate });
+    await waitFor(() => expect(screen.getByText(/Last 30 days/)).toBeTruthy());
+    expect(screen.getByText('Watch')).toBeTruthy();
+    expect(screen.getByText(/Transportation \+\$500/)).toBeTruthy();
+
+    await userEvent.click(screen.getByRole('button', { name: /full scorecard/ }));
+    expect(navigate).toHaveBeenCalledWith('dashboard', { range: 'last30', scorecard: true });
+  });
+
   it('withdrawal slider changes the FIRE number', async () => {
     renderScreen(<Health />);
     await waitFor(() => expect(screen.getByText('FIRE number')).toBeTruthy());

--- a/tests/scorecard-tool.test.ts
+++ b/tests/scorecard-tool.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('../core/db.js', async () => {
+  const { makeTestDb } = await import('./helpers/makeTestDb.js');
+  return { db: await makeTestDb() };
+});
+
+import { db } from '../core/db.js';
+import { executeTool } from '../core/tools.js';
+
+let txId = 0;
+async function insertTx(date: string, amount: number, category: string) {
+  txId++;
+  await db.execute({
+    sql: `INSERT INTO transactions (id, account_id, date, name, amount, category, pending, ignored)
+          VALUES (?, 'acct1', ?, 'Test', ?, ?, 0, 0)`,
+    args: [`tx${txId}`, date, amount, category],
+  });
+}
+
+beforeEach(async () => {
+  txId = 0;
+  await db.execute('DELETE FROM transactions');
+  await db.execute('DELETE FROM hidden_categories');
+});
+
+describe('get_scorecard tool output', () => {
+  it('buckets categories and reports a net verdict (calendar month window)', async () => {
+    // Deterministic with month windows: txs on the 15th land in every
+    // day-capped rolling window regardless of month length.
+    const priors = ['2026-05', '2026-04', '2026-03', '2026-02', '2026-01', '2025-12',
+                    '2025-11', '2025-10', '2025-09', '2025-08', '2025-07', '2025-06'];
+    for (const ym of priors) {
+      await insertTx(`${ym}-15`, 100, 'Transportation');
+      await insertTx(`${ym}-15`, 700, 'Grocery');
+      await insertTx(`${ym}-15`, 4000, 'Bills');
+    }
+    await insertTx('2026-06-15', 600, 'Transportation');  // +500, 6x → over
+    await insertTx('2026-06-15', 200, 'Grocery');          // -500 → under
+    await insertTx('2026-06-15', 4010, 'Bills');           // +10 → typical
+
+    const out = await executeTool('get_scorecard', { window: 'month', year: 2026, month: 6, day: 30 });
+
+    expect(out).toContain('Scorecard — 2026-06 through day 30');
+    const overIdx = out.indexOf('OVER');
+    const underIdx = out.indexOf('UNDER');
+    const typicalIdx = out.indexOf('TYPICAL');
+    expect(overIdx).toBeGreaterThan(-1);
+    expect(underIdx).toBeGreaterThan(overIdx);
+    expect(typicalIdx).toBeGreaterThan(underIdx);
+
+    const section = (from: number, to: number) => out.slice(from, to === -1 ? undefined : to);
+    expect(section(overIdx, underIdx)).toContain('Transportation');
+    expect(section(overIdx, underIdx)).toContain('+$500 vs typical  (6.0x) 🔴');
+    expect(section(underIdx, typicalIdx)).toContain('Grocery');
+    expect(section(underIdx, typicalIdx)).toContain('-$500 vs typical  (0.3x) 🟢');
+    expect(section(typicalIdx, out.length)).toContain('Bills');
+    expect(out).toContain('NET: +$10 vs typical month');
+  });
+
+  it('defaults to a trailing 30-day window and flags new spending', async () => {
+    await insertTx('2026-06-15', 100, 'Food');
+
+    const out = await executeTool('get_scorecard', { year: 2026, month: 7, day: 3 });
+
+    expect(out).toContain('Scorecard — last 30 days (Jun 4 – Jul 3, 2026)');
+    expect(out).toContain('OVER');
+    expect(out).toContain('(new) 🔴'); // no baseline history → new spending
+  });
+
+  it('reports no data for an empty window', async () => {
+    const out = await executeTool('get_scorecard', { year: 2026, month: 7, day: 3 });
+    expect(out).toContain('No expense data for last 30 days');
+  });
+});

--- a/tests/scorecard.test.ts
+++ b/tests/scorecard.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { bucketDrift, isSignificantDelta, ratioLabel, SIGNIFICANCE_FLOOR } from '../core/scorecard.js';
+import type { CategoryDrift } from '../core/queries.js';
+
+// Minimal CategoryDrift with only the fields the scorecard cares about filled
+// meaningfully; the vs-prev/vs-year deltas are irrelevant to bucketing.
+const row = (category: string, current: number, median12m: number): CategoryDrift => ({
+  category, current,
+  lastPeriodDelta: 0, lastYearDelta: 0,
+  avg12m: median12m, avg12mDelta: current - median12m,
+  median12m, medianDelta: current - median12m,
+});
+
+describe('isSignificantDelta', () => {
+  it('requires the absolute floor on small baselines', () => {
+    expect(isSignificantDelta(49, 0)).toBe(false);
+    expect(isSignificantDelta(SIGNIFICANCE_FLOOR, 0)).toBe(true);
+    expect(isSignificantDelta(-49, 100)).toBe(false);
+    expect(isSignificantDelta(-60, 100)).toBe(true);
+  });
+
+  it('requires a share of the baseline on large baselines', () => {
+    // $100 over a $4,000 baseline is noise (needs $600)
+    expect(isSignificantDelta(100, 4000)).toBe(false);
+    expect(isSignificantDelta(700, 4000)).toBe(true);
+  });
+});
+
+describe('ratioLabel', () => {
+  it('formats a multiplier vs baseline', () => {
+    expect(ratioLabel(626, 149)).toBe('4.2x');
+    expect(ratioLabel(291, 762)).toBe('0.4x');
+  });
+
+  it('labels new spending with no baseline', () => {
+    expect(ratioLabel(100, 0)).toBe('new');
+    expect(ratioLabel(0, 0)).toBe('');
+  });
+});
+
+describe('bucketDrift', () => {
+  it('splits rows into over / typical / under', () => {
+    const { over, typical, under } = bucketDrift([
+      row('Transportation', 626, 149),   // +477, way over
+      row('Bills', 4112, 4132),          // -20, noise on a big baseline
+      row('Grocery', 291, 762),          // -471, well under
+    ]);
+    expect(over.map((r) => r.category)).toEqual(['Transportation']);
+    expect(typical.map((r) => r.category)).toEqual(['Bills']);
+    expect(under.map((r) => r.category)).toEqual(['Grocery']);
+  });
+
+  it('buckets zero-baseline new spending as over once past the floor', () => {
+    const { over, typical } = bucketDrift([
+      row('NewSub', 80, 0),
+      row('TinyNew', 20, 0),
+    ]);
+    expect(over.map((r) => r.category)).toEqual(['NewSub']);
+    expect(typical.map((r) => r.category)).toEqual(['TinyNew']);
+  });
+
+  it('sorts over worst-first and under biggest-saving-last', () => {
+    const { over, under } = bucketDrift([
+      row('Shopping', 1277, 1081),  // +196
+      row('Travel', 1471, 1011),    // +460
+      row('Grocery', 291, 762),     // -471
+      row('Dining', 633, 784),      // -151
+    ]);
+    expect(over.map((r) => r.category)).toEqual(['Travel', 'Shopping']);
+    expect(under.map((r) => r.category)).toEqual(['Dining', 'Grocery']);
+  });
+
+  it('nets deltas across all rows including typical ones', () => {
+    const { net } = bucketDrift([
+      row('Travel', 1471, 1011),  // +460
+      row('Grocery', 291, 762),   // -471
+      row('Bills', 4112, 4132),   // -20 (typical, still counted)
+    ]);
+    expect(net).toBeCloseTo(460 - 471 - 20);
+  });
+
+  it('preserves input order within typical', () => {
+    const { typical } = bucketDrift([
+      row('Bills', 4112, 4132),
+      row('Insurance', 162, 160),
+      row('Home', 271, 302),
+    ]);
+    expect(typical.map((r) => r.category)).toEqual(['Bills', 'Insurance', 'Home']);
+  });
+});

--- a/tests/tui/screens.test.tsx
+++ b/tests/tui/screens.test.tsx
@@ -279,11 +279,11 @@ describe('Dashboard', () => {
     }, 2000);
   });
 
-  it('d key toggles delta mode label', async () => {
+  it('s key toggles scorecard mode label', async () => {
     const r = dash();
     await waitFor(() => expect(frame(r)).toContain('Income'));
-    r.stdin.write('d');
-    await waitFor(() => expect(frame(r)).toContain('delta'));
+    r.stdin.write('s');
+    await waitFor(() => expect(frame(r)).toContain('scorecard'));
   });
 
   it('pressing a nav number calls onNavigate', async () => {

--- a/tui/Dashboard.tsx
+++ b/tui/Dashboard.tsx
@@ -4,8 +4,9 @@ import {
   getRangeSummary, getFlexSummary, getUncategorizedCount, getDataBounds, getAccountRows, getOwnerRows,
   getCategoryDriftData, getFlexDriftData, getAccountDriftData, countSearchMatches, getSearchFilteredData, getMerchantSummary,
   type MonthlySummary, type FlexSummary, type AccountRow, type OwnerRow,
-  type CategoryDrift, type FlexDriftData, type AccountDrift, type MerchantSummaryRow,
+  type CategoryDrift, type FlexDriftData, type AccountDrift, type MerchantSummaryRow, type DriftSlice,
 } from '../core/queries.js';
+import { bucketDrift, isSignificantDelta, ratioLabel } from '../core/scorecard.js';
 import {
   getPeriodStart, getPeriodDates, navigatePeriod, formatPeriodLabel,
   getDriftWindows,
@@ -31,14 +32,16 @@ function pct(part: number, total: number) {
   return `${Math.round((part / total) * 100)}%`;
 }
 
-/** Heat-map color based on current spend vs 12-month rolling average. */
-function driftColor(current: number, avg12m: number): string {
-  if (current === 0) return C_NEUTRAL;
-  if (avg12m === 0) return C_NEGATIVE;     // new spending with no history
-  const ratio = current / avg12m;
-  if (ratio <= 1.10) return C_POSITIVE;   // within 10% of average
-  if (ratio <= 1.30) return C_WARNING;    // creeping (10–30% over)
-  return C_NEGATIVE;                      // spiked (>30% over)
+/**
+ * Heat-map color vs the median baseline, gated on significance: rows inside
+ * the noise band stay neutral so only deltas worth acting on get color.
+ */
+function driftColor(slice: Pick<DriftSlice, 'current' | 'median12m' | 'medianDelta'>): string {
+  if (slice.current === 0 && slice.median12m === 0) return C_NEUTRAL;
+  if (!isSignificantDelta(slice.medianDelta, slice.median12m)) return C_NEUTRAL;
+  if (slice.medianDelta < 0) return C_POSITIVE;                    // meaningfully under
+  if (slice.median12m === 0) return C_NEGATIVE;                    // new spending, no history
+  return slice.current / slice.median12m >= 1.3 ? C_NEGATIVE : C_WARNING;
 }
 
 /** Format a drift delta value compactly (no cents). */
@@ -78,7 +81,8 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
   const [view, setView] = useState<DashView>('categories');
   const [bounds, setBounds] = useState<{ minDate: string; maxDate: string }>({ minDate: '2000-01-01', maxDate: '2099-12-31' });
   useEffect(() => { void getDataBounds().then(setBounds); }, []);
-  const [driftMode, setDriftMode] = useState(false);
+  const [scorecardMode, setScorecardMode] = useState(false);
+  const [detailMode, setDetailMode] = useState(false); // 'x': per-baseline delta columns
   const [catDrift,  setCatDrift]  = useState<CategoryDrift[] | null>(null);
   const [flexDrift, setFlexDrift] = useState<FlexDriftData  | null>(null);
   const [acctDrift, setAcctDrift] = useState<AccountDrift[] | null>(null);
@@ -146,7 +150,7 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
   }, [range, anchor.toISOString().slice(0, 10), queryFilter, refreshKey]);
 
   useEffect(() => {
-    if (!driftMode) { setCatDrift(null); setFlexDrift(null); setAcctDrift(null); return; }
+    if (!scorecardMode) { setCatDrift(null); setFlexDrift(null); setAcctDrift(null); return; }
     const windows = getDriftWindows(range, anchor, new Date());
     if (!windows) { setCatDrift(null); setFlexDrift(null); setAcctDrift(null); return; }
     const { current, lastPeriod, lastYear, rolling12 } = windows;
@@ -155,7 +159,7 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
     void getCategoryDriftData(current, lastPeriod, lastYear, rolling12, queryFilter).then(ok(setCatDrift));
     void getFlexDriftData(current, lastPeriod, lastYear, rolling12, queryFilter).then(ok(setFlexDrift));
     void getAccountDriftData(current, lastPeriod, lastYear, rolling12).then(ok(setAcctDrift));
-  }, [driftMode, range, anchor.toISOString().slice(0, 10), queryFilter]);
+  }, [scorecardMode, range, anchor.toISOString().slice(0, 10), queryFilter]);
 
   const setTyping = useSetTyping();
   useEffect(() => { setTyping(searchMode); }, [searchMode]);
@@ -188,7 +192,7 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
     setMerchantDrill(null);
     setMerchantRows([]);
     setMerchantCursor(0);
-  }, [queryFilter, search, driftMode, view]);
+  }, [queryFilter, search, scorecardMode, view]);
 
   // Re-fetch merchant data when period or range changes while drill is active
   useEffect(() => {
@@ -213,6 +217,29 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
 
   const categories = summary?.byCategory ?? [];
 
+  const scorecard = useMemo(() => (catDrift ? bucketDrift(catDrift) : null), [catDrift]);
+  // Flat render order (over → typical → under) shared by the cursor and Enter.
+  const scoreRows = useMemo(
+    () => (scorecard ? [...scorecard.over, ...scorecard.typical, ...scorecard.under] : []),
+    [scorecard],
+  );
+  const maxScoreDelta = Math.max(1, ...scoreRows.map((r) => Math.abs(r.medianDelta)));
+  const scoreTotal = scoreRows.reduce((s, r) => s + r.current, 0);
+  // Buckets with their starting offset in scoreRows, so each row knows its
+  // global index for cursor selection.
+  const scoreBuckets = useMemo(() => {
+    if (!scorecard) return [];
+    const defs = [
+      { key: 'over' as const,    label: 'OVER',    rows: scorecard.over },
+      { key: 'typical' as const, label: 'TYPICAL', rows: scorecard.typical },
+      { key: 'under' as const,   label: 'UNDER',   rows: scorecard.under },
+    ];
+    let start = 0;
+    return defs
+      .filter((d) => d.rows.length > 0)
+      .map((d) => { const b = { ...d, start }; start += d.rows.length; return b; });
+  }, [scorecard]);
+
   const termW = useTerminalWidth();
   const inner = Math.max(60, termW) - 4;
   // Normal categories: [sel+name] gap [amount=10] gap [bar] — 2 gaps of 2 = 16 reserved
@@ -225,9 +252,13 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
   // means an owner exists regardless of whether they spent anything this period.
   const hasOwners = ownerRows.some((r) => r.owner !== 'Unassigned');
   const maxOwnerSpend = ownerRows[0]?.spending ?? 1;
-  // Drift categories: 3 delta cols × 9 chars + 4 gaps of 2 = 27+8=35 for cols; plus amount(10)+gaps
+  // Drift detail: 3 delta cols × 9 chars + 4 gaps of 2 = 27+8=35 for cols; plus amount(10)+gaps
   // total fixed = 2(cursor) + 10(amt) + 4(gaps to amt) + 27(3×9) + 4(gaps between deltas) = 47
   const driftCatNameW = Math.max(12, inner - 47);
+  // Scorecard: [sel=2] [name] [amount=10] [delta=9] [bar] [ratio=5] with 5 gaps of 2 = 36 fixed
+  const scoreFlex  = Math.max(18, inner - 36);
+  const scoreNameW = Math.max(12, Math.min(20, Math.floor(scoreFlex * 0.55)));
+  const scoreBarW  = Math.max(6,  Math.min(14, scoreFlex - scoreNameW));
   // Normal flex: [label=18] gap [amount=10] gap [pct=4] gap [bar] — 3 gaps of 2
   const dashFlexBarW  = Math.max(8, inner - 38);
   // Account: [sel=2] gap [name] gap [col1=10] gap [col2=10] — 3 gaps of 2
@@ -307,10 +338,14 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
     }
 
     if (view === 'categories') {
-      const displayCats = displaySummary?.byCategory ?? [];
+      // Cursor and Enter track whatever list is actually rendered: scorecard
+      // buckets, drift detail rows, or the plain category breakdown.
+      const displayCats: Array<{ category: string }> = scorecardMode
+        ? (detailMode ? (catDrift ?? []) : scoreRows)
+        : (displaySummary?.byCategory ?? []);
       if (key.upArrow)   { setCatCursor((c) => Math.max(0, c - 1)); return; }
       if (key.downArrow) { setCatCursor((c) => Math.min(displayCats.length - 1, c + 1)); return; }
-      if (input === 'm' && !driftMode) {
+      if (input === 'm' && !scorecardMode) {
         const cat = displayCats[catCursor];
         if (cat) {
           const { from, to } = getPeriodDates(range, anchor);
@@ -373,7 +408,8 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
       return;
     }
 
-    if (input === 'd') { setDriftMode((m) => !m); return; }
+    if (input === 's') { setScorecardMode((m) => !m); setCatCursor(0); return; }
+    if (input === 'x' && scorecardMode) { setDetailMode((t) => !t); setCatCursor(0); return; }
 
     if (input === '/') {
       setSearchInput(search); // pre-fill with current search
@@ -420,12 +456,12 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
         : <Text dimColor>
             {showHints
               ? (view === 'account'
-                  ? `[/] search  ·  ← → period  ·  ↑↓ select  ·  Enter txns  ·  Space ${selectedAccount ? 'unfilter' : 'filter'}  ·  [c] clear  ·  [Tab] view  ·  [d] delta`
+                  ? `[/] search  ·  ← → period  ·  ↑↓ select  ·  Enter txns  ·  Space ${selectedAccount ? 'unfilter' : 'filter'}  ·  [c] clear  ·  [Tab] view  ·  [s] scorecard`
                   : view === 'categories'
-                    ? `[/] search  ·  ← → period  ·  ↑↓ select  ·  Enter txns${driftMode ? '' : '  ·  [m] merchants'}  ·  [Tab] view  ·  [d] delta`
+                    ? `[/] search  ·  ← → period  ·  ↑↓ select  ·  Enter txns${scorecardMode ? `  ·  [x] ${detailMode ? 'compact' : 'columns'}` : '  ·  [m] merchants'}  ·  [Tab] view  ·  [s] scorecard`
                     : view === 'owner'
                       ? '← → period  ·  [r] range  ·  [Tab] view'
-                      : '[/] search  ·  ← → period  ·  Enter txns  ·  [Tab] view  ·  [d] delta')
+                      : '[/] search  ·  ← → period  ·  Enter txns  ·  [Tab] view  ·  [s] scorecard')
               : '[/] search'}
           </Text>
       }
@@ -445,7 +481,7 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
             : <Text bold>{formatPeriodLabel(range, anchor)}</Text>
           }
           {selectedAccount && <Text color={C_WARNING}>{selectedAccount.name}</Text>}
-          {driftMode && <Text color={C_MANUAL} bold>delta</Text>}
+          {scorecardMode && <Text color={C_MANUAL} bold>{detailMode ? 'scorecard · columns' : 'scorecard'}</Text>}
           <Text dimColor>
             {merchantDrill ? `merchants · ${merchantDrill.category}` : view === 'categories' ? 'categories' : view === 'flex' ? 'flex' : view === 'account' ? 'account' : 'owner'}
           </Text>
@@ -482,15 +518,15 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
         <Box flexDirection="column" marginTop={1}>
           {accountRows.length === 0 ? (
             <Text dimColor>No accounts linked. [8] accounts → link a bank.</Text>
-          ) : driftMode && range === 'alltime' ? (
-            <Text dimColor>Delta not available for All Time range.</Text>
+          ) : scorecardMode && range === 'alltime' ? (
+            <Text dimColor>Scorecard not available for All Time range.</Text>
           ) : (
             <>
               <Box marginBottom={0}>
                 <Text dimColor>{'  '}</Text>
                 <Box gap={2}>
                   <Text dimColor>{'Account'.padEnd(dashAcctNameW)}</Text>
-                  {driftMode
+                  {scorecardMode
                     ? <Text dimColor>{'vs prev'.padStart(10)}</Text>
                     : <Text dimColor>{'Income'.padStart(10)}</Text>}
                   <Text dimColor>{'Expenses'.padStart(10)}</Text>
@@ -499,19 +535,19 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
               {accountRows.map((acct, i) => {
                 const isSelected = i === acctCursor;
                 const isFiltered = selectedAccount?.id === acct.id;
-                const drift = driftMode ? acctDrift?.find((d) => d.id === acct.id) : undefined;
-                const spendColor = drift ? driftColor(drift.current, drift.avg12m) : C_NEGATIVE;
+                const drift = scorecardMode ? acctDrift?.find((d) => d.id === acct.id) : undefined;
+                const spendColor = drift ? driftColor(drift) : C_NEGATIVE;
                 return (
                   <SelectableRow key={acct.id} selected={isSelected}>
                     <Text color={isFiltered ? C_WARNING : isSelected ? C_ACCENT : undefined} dimColor={!isSelected && !isFiltered}>
                       {(acct.name.length > dashAcctNameW ? acct.name.slice(0, dashAcctNameW - 1) + '…' : acct.name).padEnd(dashAcctNameW)}
                     </Text>
-                    {driftMode
+                    {scorecardMode
                       ? <Text color={drift ? spendColor : C_NEUTRAL} dimColor={!drift}>
                           {drift ? fmtDelta(drift.lastPeriodDelta).padStart(10) : '—'.padStart(10)}
                         </Text>
                       : <Text color={C_POSITIVE} dimColor={acct.income === 0}>{(acct.income > 0 ? fmt(acct.income) : '—').padStart(10)}</Text>}
-                    <Text color={driftMode ? spendColor : C_NEGATIVE} dimColor={acct.spending === 0}>
+                    <Text color={scorecardMode ? spendColor : C_NEGATIVE} dimColor={acct.spending === 0}>
                       {(acct.spending > 0 ? fmt(acct.spending) : '—').padStart(10)}
                     </Text>
                     {isFiltered && <Text color={C_WARNING}>  ●</Text>}
@@ -557,7 +593,13 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
 
           {view === 'categories' ? (
             <Box flexDirection="column" marginTop={1}>
-              <SectionHeader>{merchantDrill ? `TOP MERCHANTS · ${merchantDrill.category}` : 'SPENDING BY CATEGORY'}</SectionHeader>
+              <SectionHeader>
+                {merchantDrill
+                  ? `TOP MERCHANTS · ${merchantDrill.category}`
+                  : scorecardMode && !detailMode
+                    ? 'SPENDING BY CATEGORY · VS TYPICAL (12M MEDIAN)'
+                    : 'SPENDING BY CATEGORY'}
+              </SectionHeader>
               {merchantDrill ? (
                 <Box flexDirection="column" marginTop={1}>
                   {merchantRows.length === 0 ? (
@@ -579,9 +621,9 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
                   )}
                   {showHints && <Box marginTop={1}><Text dimColor>[Enter] transactions  ·  [Esc] back</Text></Box>}
                 </Box>
-              ) : driftMode && range === 'alltime' ? (
-                <Box marginTop={1}><Text dimColor>Delta not available for All Time range.</Text></Box>
-              ) : driftMode ? (
+              ) : scorecardMode && range === 'alltime' ? (
+                <Box marginTop={1}><Text dimColor>Scorecard not available for All Time range.</Text></Box>
+              ) : scorecardMode && detailMode ? (
                 <Box flexDirection="column" marginTop={1}>
                   {/* column headers */}
                   <Box>
@@ -599,7 +641,7 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
                   ) : (
                     (catDrift ?? []).map((row, i) => {
                       const isSelected = catCursor === i;
-                      const color = driftColor(row.current, row.avg12m);
+                      const color = driftColor(row);
                       const nameW = driftCatNameW;
                       return (
                         <SelectableRow key={`${row.category}-${i}`} selected={isSelected}>
@@ -613,6 +655,73 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
                         </SelectableRow>
                       );
                     })
+                  )}
+                </Box>
+              ) : scorecardMode ? (
+                <Box flexDirection="column" marginTop={1}>
+                  {scoreRows.length === 0 ? (
+                    <Text dimColor>No expense data for this period.</Text>
+                  ) : (
+                    <>
+                      <Box>
+                        <Text dimColor>{'  '}</Text>
+                        <Box gap={2}>
+                          <Text dimColor>{''.padEnd(scoreNameW)}</Text>
+                          <Text dimColor>{'amount'.padStart(10)}</Text>
+                          <Text dimColor>{'Δ typical'.padStart(9)}</Text>
+                        </Box>
+                      </Box>
+                      {scoreBuckets.map((bucket) => (
+                        <Box key={bucket.key} flexDirection="column">
+                          <Box>
+                            <Text
+                              bold
+                              color={bucket.key === 'over' ? C_NEGATIVE : bucket.key === 'under' ? C_POSITIVE : undefined}
+                              dimColor={bucket.key === 'typical'}
+                            >
+                              {'  '}{bucket.label}
+                            </Text>
+                            <Text dimColor> {'─'.repeat(Math.max(4, inner - bucket.label.length - 5))}</Text>
+                          </Box>
+                          {bucket.rows.map((row, i) => {
+                            const globalIdx = bucket.start + i;
+                            const isSelected = catCursor === globalIdx;
+                            const isTypical = bucket.key === 'typical';
+                            const color = isTypical ? undefined : driftColor(row);
+                            return (
+                              <SelectableRow key={row.category} selected={isSelected}>
+                                <Text color={isSelected ? C_ACCENT : color} dimColor={isTypical && !isSelected}>
+                                  {truncate(row.category, scoreNameW).padEnd(scoreNameW)}
+                                </Text>
+                                <Text color={C_NEUTRAL} dimColor={isTypical}>{fmt(row.current).padStart(10)}</Text>
+                                <Text color={color} dimColor={isTypical}>{fmtDelta(row.medianDelta).padStart(9)}</Text>
+                                {!isTypical && (
+                                  <>
+                                    <Text color={color}>{bar(Math.abs(row.medianDelta), maxScoreDelta, scoreBarW).padEnd(scoreBarW)}</Text>
+                                    <Text dimColor>{ratioLabel(row.current, row.median12m).padStart(5)}</Text>
+                                  </>
+                                )}
+                              </SelectableRow>
+                            );
+                          })}
+                        </Box>
+                      ))}
+                      <Box><Text dimColor>{'  '}{'─'.repeat(Math.max(4, inner - 2))}</Text></Box>
+                      <Box>
+                        <Text>{'  '}</Text>
+                        <Box gap={2}>
+                          <Text bold>{'NET'.padEnd(scoreNameW)}</Text>
+                          <Text color={C_NEUTRAL}>{fmt(scoreTotal).padStart(10)}</Text>
+                          <Text
+                            bold
+                            color={(scorecard?.net ?? 0) <= 0 ? C_POSITIVE : (scorecard?.net ?? 0) >= scoreTotal * 0.05 ? C_NEGATIVE : C_WARNING}
+                          >
+                            {fmtDelta(scorecard?.net ?? 0).padStart(9)}
+                          </Text>
+                          <Text dimColor>vs typical</Text>
+                        </Box>
+                      </Box>
+                    </>
                   )}
                 </Box>
               ) : (
@@ -641,9 +750,9 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
           ) : (
             <Box flexDirection="column" marginTop={1}>
               <SectionHeader>SPENDING BY FLEXIBILITY</SectionHeader>
-              {driftMode && range === 'alltime' ? (
-                <Box marginTop={1}><Text dimColor>Delta not available for All Time range.</Text></Box>
-              ) : driftMode ? (
+              {scorecardMode && range === 'alltime' ? (
+                <Box marginTop={1}><Text dimColor>Scorecard not available for All Time range.</Text></Box>
+              ) : scorecardMode ? (
                 <Box flexDirection="column" marginTop={1}>
                   {/* column headers */}
                   <Box gap={2}>
@@ -656,7 +765,7 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
                   {flexDrift && FLEX_TIERS.map(({ key, label }) => {
                     const slice = flexDrift[key];
                     if (slice.current === 0 && slice.avg12m === 0) return null;
-                    const color = driftColor(slice.current, slice.avg12m);
+                    const color = driftColor(slice);
                     return (
                       <Box key={key} gap={2}>
                         <Text color={color}>{'  '}{label.padEnd(16)}</Text>
@@ -684,7 +793,7 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
                   })}
                 </Box>
               )}
-              {!driftMode && displayFlexData && displayFlexData.untagged > 0 && !search && (
+              {!scorecardMode && displayFlexData && displayFlexData.untagged > 0 && !search && (
                 <Box marginTop={1}><Text dimColor>{pct(displayFlexData.untagged, totalExpenses)} untagged — set tiers in Rules → Categories</Text></Box>
               )}
             </Box>

--- a/tui/Dashboard.tsx
+++ b/tui/Dashboard.tsx
@@ -461,7 +461,7 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
                     ? `[/] search  ·  ← → period  ·  ↑↓ select  ·  Enter txns${scorecardMode ? `  ·  [x] ${detailMode ? 'compact' : 'columns'}` : '  ·  [m] merchants'}  ·  [Tab] view  ·  [s] scorecard`
                     : view === 'owner'
                       ? '← → period  ·  [r] range  ·  [Tab] view'
-                      : '[/] search  ·  ← → period  ·  Enter txns  ·  [Tab] view  ·  [s] scorecard')
+                      : `[/] search  ·  ← → period  ·  Enter txns${scorecardMode ? `  ·  [x] ${detailMode ? 'compact' : 'columns'}` : ''}  ·  [Tab] view  ·  [s] scorecard`)
               : '[/] search'}
           </Text>
       }
@@ -527,7 +527,7 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
                 <Box gap={2}>
                   <Text dimColor>{'Account'.padEnd(dashAcctNameW)}</Text>
                   {scorecardMode
-                    ? <Text dimColor>{'vs prev'.padStart(10)}</Text>
+                    ? <Text dimColor>{'Δ typical'.padStart(10)}</Text>
                     : <Text dimColor>{'Income'.padStart(10)}</Text>}
                   <Text dimColor>{'Expenses'.padStart(10)}</Text>
                 </Box>
@@ -544,7 +544,7 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
                     </Text>
                     {scorecardMode
                       ? <Text color={drift ? spendColor : C_NEUTRAL} dimColor={!drift}>
-                          {drift ? fmtDelta(drift.lastPeriodDelta).padStart(10) : '—'.padStart(10)}
+                          {drift ? fmtDelta(drift.medianDelta).padStart(10) : '—'.padStart(10)}
                         </Text>
                       : <Text color={C_POSITIVE} dimColor={acct.income === 0}>{(acct.income > 0 ? fmt(acct.income) : '—').padStart(10)}</Text>}
                     <Text color={scorecardMode ? spendColor : C_NEGATIVE} dimColor={acct.spending === 0}>
@@ -752,7 +752,7 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
               <SectionHeader>SPENDING BY FLEXIBILITY</SectionHeader>
               {scorecardMode && range === 'alltime' ? (
                 <Box marginTop={1}><Text dimColor>Scorecard not available for All Time range.</Text></Box>
-              ) : scorecardMode ? (
+              ) : scorecardMode && detailMode ? (
                 <Box flexDirection="column" marginTop={1}>
                   {/* column headers */}
                   <Box gap={2}>
@@ -773,6 +773,29 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
                         <Text color={color}>{fmtDelta(slice.lastPeriodDelta).padStart(9)}</Text>
                         <Text color={color}>{fmtDelta(slice.lastYearDelta).padStart(9)}</Text>
                         <Text color={color}>{fmtDelta(slice.avg12mDelta).padStart(9)}</Text>
+                      </Box>
+                    );
+                  })}
+                </Box>
+              ) : scorecardMode ? (
+                <Box flexDirection="column" marginTop={1}>
+                  {/* Same verdict column as the category scorecard: the displayed
+                      delta is the number the color is keyed to. */}
+                  <Box gap={2}>
+                    <Text dimColor>{''.padEnd(18)}</Text>
+                    <Text dimColor>{'amount'.padStart(10)}</Text>
+                    <Text dimColor>{'Δ typical'.padStart(9)}</Text>
+                  </Box>
+                  {flexDrift && FLEX_TIERS.map(({ key, label }) => {
+                    const slice = flexDrift[key];
+                    if (slice.current === 0 && slice.avg12m === 0) return null;
+                    const color = driftColor(slice);
+                    return (
+                      <Box key={key} gap={2}>
+                        <Text color={color}>{'  '}{label.padEnd(16)}</Text>
+                        <Text color={C_NEUTRAL}>{fmt(slice.current).padStart(10)}</Text>
+                        <Text color={color}>{fmtDelta(slice.medianDelta).padStart(9)}</Text>
+                        <Text dimColor>{ratioLabel(slice.current, slice.median12m).padStart(6)}</Text>
                       </Box>
                     );
                   })}

--- a/tui/Health.tsx
+++ b/tui/Health.tsx
@@ -4,6 +4,9 @@ import type { Screen } from './App.js';
 import { fmt, fmtSigned, fmtPct, fmtMonths, fmtCompact, Divider } from './fmt.js';
 import { handleNavKey } from './nav.js';
 import { loadHealthData, yearsToFire, coastYears, type HealthData } from '../core/health.js';
+import { getCategoryDriftData } from '../core/queries.js';
+import { getDriftWindows, getPeriodStart } from '../core/dateUtils.js';
+import { bucketDrift, type Scorecard } from '../core/scorecard.js';
 import { C_POSITIVE, C_NEGATIVE, C_WARNING, C_NEUTRAL, C_ACCENT } from './ui.js';
 import { SectionHeader, PageHeader, DialRow } from './components/index.js';
 import { useRefreshKey } from './RefreshContext.js';
@@ -57,6 +60,17 @@ export function Health({ onNavigate, isActive, showHints }: { onNavigate: (s: Sc
       setMonthlySpend(Math.max(SPEND_STEP, Math.round(d.avgMonthlyExpenses / SPEND_STEP) * SPEND_STEP));
       setMonthlySavings(Math.round(d.monthlySavings / SPEND_STEP) * SPEND_STEP);
     });
+  }, [refreshKey]);
+
+  // Trailing-30-day scorecard: which categories drifted from typical recently.
+  const [scorecard, setScorecard] = useState<Scorecard | null>(null);
+  useEffect(() => {
+    const today = new Date();
+    const windows = getDriftWindows('last30', getPeriodStart('last30', today), today);
+    if (!windows) return;
+    const { current, lastPeriod, lastYear, rolling12 } = windows;
+    void getCategoryDriftData(current, lastPeriod, lastYear, rolling12)
+      .then((rows) => setScorecard(bucketDrift(rows)));
   }, [refreshKey]);
   const [withdrawal, setWithdrawal]     = useState(DEFAULT_WITHDRAWAL);
   const [growth, setGrowth]             = useState(DEFAULT_GROWTH);
@@ -218,6 +232,38 @@ export function Health({ onNavigate, isActive, showHints }: { onNavigate: (s: Sc
           <Text dimColor>{fmt(data.liquid)} incl. brokerage</Text>
         </Box>
       </Box>
+
+      {/* ── Last 30 days scorecard strip ───────────────────────────────────── */}
+      {scorecard && (scorecard.over.length > 0 || scorecard.under.length > 0) && (
+        <Box flexDirection="column" marginTop={1}>
+          <SectionHeader>LAST 30 DAYS · VS TYPICAL</SectionHeader>
+          {scorecard.over.length > 0 && (
+            <Box gap={3} marginTop={1}>
+              <Text dimColor>{'Watch'.padEnd(L)}</Text>
+              <Text color={C_NEGATIVE}>
+                {scorecard.over.slice(0, 2).map((r) => `${r.category} ${fmtSigned(r.medianDelta, 0)}`).join('  ·  ')}
+              </Text>
+            </Box>
+          )}
+          {scorecard.under.length > 0 && (
+            <Box gap={3} marginTop={scorecard.over.length > 0 ? 0 : 1}>
+              <Text dimColor>{'Good'.padEnd(L)}</Text>
+              <Text color={C_POSITIVE}>
+                {[...scorecard.under]
+                  .sort((a, b) => a.medianDelta - b.medianDelta)
+                  .slice(0, 2)
+                  .map((r) => `${r.category} ${fmtSigned(r.medianDelta, 0)}`)
+                  .join('  ·  ')}
+              </Text>
+            </Box>
+          )}
+          <Box gap={3}>
+            <Text dimColor>{'Net'.padEnd(L)}</Text>
+            <Text bold color={scorecard.net <= 0 ? C_POSITIVE : C_WARNING}>{fmtSigned(scorecard.net, 0)}</Text>
+            <Text dimColor>[1] dashboard → [s] scorecard</Text>
+          </Box>
+        </Box>
+      )}
 
       {/* ── Debt (only shown if there is debt) ─────────────────────────────── */}
       {data.totalDebt > 0 && (

--- a/tui/Tags.tsx
+++ b/tui/Tags.tsx
@@ -3,7 +3,7 @@ import { Box, Text, useInput } from 'ink';
 import { getTagSummary, getAllTags, type MonthlySummary, type Tag } from '../core/queries.js';
 import { createTag, renameTag, deleteTag } from '../core/tags.js';
 import type { Screen, TxFilter } from './App.js';
-import { fmt, fmtSigned, bar, truncate, Divider } from './fmt.js';
+import { fmt, fmtSigned, fmtSpan, sortTags, type TagSort, bar, truncate, Divider } from './fmt.js';
 import { handleNavKey } from './nav.js';
 import { useTerminalWidth, C_POSITIVE, C_NEGATIVE, C_WARNING, C_ACCENT } from './ui.js';
 import { StatCard, ModalPanel, SectionHeader, TextInput, SelectableRow, useStatusMessage, PageHeader, SearchBar } from './components/index.js';
@@ -12,6 +12,9 @@ import { useRefreshKey } from './RefreshContext.js';
 import { useFilter } from './FilterContext.js';
 
 type Mode = 'list' | 'search' | 'add' | 'detail' | 'rename';
+
+const SORT_ORDER: TagSort[] = ['name', 'recent', 'oldest'];
+const SORT_LABEL: Record<TagSort, string> = { name: 'name', recent: 'most recent', oldest: 'oldest' };
 
 export function Tags({ onNavigate, isActive, showHints, initialFilter }: { onNavigate: (s: Screen, f?: TxFilter) => void; isActive?: boolean; showHints: boolean; initialFilter?: TxFilter }) {
   const refreshKey = useRefreshKey();
@@ -22,6 +25,7 @@ export function Tags({ onNavigate, isActive, showHints, initialFilter }: { onNav
   const [newName, setNewName] = useState('');
   const { statusMsg, showStatus } = useStatusMessage();
   const [search, setSearch] = useState('');
+  const [sort, setSort] = useState<TagSort>('name');
   const [tagSummary, setTagSummary] = useState<MonthlySummary | null>(null);
   const [catCursor, setCatCursor] = useState(0);
 
@@ -51,14 +55,17 @@ export function Tags({ onNavigate, isActive, showHints, initialFilter }: { onNav
     setMode('detail');
   }
 
-  const visibleTags = search
-    ? tags.filter((t) => t.name.toLowerCase().includes(search.toLowerCase()))
-    : tags;
+  const q = search.toLowerCase();
+  const visibleTags = sortTags(
+    search ? tags.filter((t) => t.name.toLowerCase().includes(q)) : tags,
+    sort,
+  );
 
   const termW = useTerminalWidth();
   const inner = Math.max(60, termW) - 4;
-  // [sel=2] gap [name] gap [count=6] gap [inflow=10] gap [outflow=10] — 4 gaps of 2
-  const tagNameW = Math.max(10, inner - 36);
+  // [sel=2] gap [name] gap [count=6] gap [span=17] gap [inflow=10] gap [outflow=10] — 5 gaps of 2
+  const SPAN_W = 17;
+  const tagNameW = Math.max(10, inner - 55);
 
   useInput((input, key) => {
     if (mode === 'search') {
@@ -143,6 +150,11 @@ export function Tags({ onNavigate, isActive, showHints, initialFilter }: { onNav
       onNavigate('dashboard'); return;
     }
     if (input === '/') { setMode('search'); return; }
+    if (input === 's') {
+      setSort((s) => SORT_ORDER[(SORT_ORDER.indexOf(s) + 1) % SORT_ORDER.length]);
+      setCursor(0);
+      return;
+    }
     if (key.upArrow) { setCursor((c) => Math.max(0, c - 1)); return; }
     if (key.downArrow) { setCursor((c) => Math.min(visibleTags.length - 1, c + 1)); return; }
     if (input === 'a') { setNewName(''); setMode('add'); return; }
@@ -216,12 +228,15 @@ export function Tags({ onNavigate, isActive, showHints, initialFilter }: { onNav
       ) : (
         <>
           <Box marginTop={1}>
-            <Text bold>Tags{search ? <Text color={C_WARNING}>  /{search}</Text> : null}</Text>
+            <Text bold>Tags
+              {search ? <Text color={C_WARNING}>  /{search}</Text> : null}
+              {sort !== 'name' ? <Text dimColor>  ↕ {SORT_LABEL[sort]}</Text> : null}
+            </Text>
           </Box>
           <Text dimColor>
             {showHints
-              ? '[/] search  ·  [a] add  [n] rename  [x] delete  ·  Enter detail  ·  [t] transactions'
-              : '[/] search'}
+              ? '[/] search  ·  [s] sort  ·  [a] add  [n] rename  [x] delete  ·  Enter detail  ·  [t] transactions'
+              : '[/] search  ·  [s] sort'}
           </Text>
           {mode === 'search' && <SearchBar value={search} />}
           <Box marginTop={1}><Divider /></Box>
@@ -238,6 +253,7 @@ export function Tags({ onNavigate, isActive, showHints, initialFilter }: { onNav
                       {t.name.length > tagNameW ? t.name.slice(0, tagNameW - 1) + '…' : t.name.padEnd(tagNameW)}
                     </Text>
                     <Text dimColor>{(t.count + ' tx').padEnd(6)}</Text>
+                    <Text dimColor>{fmtSpan(t.earliest, t.latest).padEnd(SPAN_W)}</Text>
                     <Text color={C_POSITIVE} dimColor={!isSelected}>{fmt(t.inflow).padStart(10)}</Text>
                     <Text color={C_NEGATIVE} dimColor={!isSelected}>{fmt(t.outflow).padStart(10)}</Text>
                   </SelectableRow>

--- a/tui/fmt.tsx
+++ b/tui/fmt.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Text } from 'ink';
-export { fmt, fmtSigned, fmtPct, fmtMonths, fmtCompact } from '../core/fmt.js';
+export { fmt, fmtSigned, fmtPct, fmtMonths, fmtCompact, fmtSpan, sortTags, type TagSort } from '../core/fmt.js';
 export { BAR_WIDTH, bar, truncate } from './charUtils.js';
 
 export function Divider({ width }: { width?: number }) {


### PR DESCRIPTION
## Summary
- **Spending scorecard** — new trailing-30-day (`last30`) range with a 12-month median baseline; categories bucketed into over / typical / under with a net verdict, across core, TUI, GUI, and MCP
- **Tag date spans** — tags now show the date span of their transactions, with sorting (TUI, GUI, MCP `list_tags`)
- **Dependency bumps** — Electron 42 → 43, electron-builder 26.15.3, recharts 3.9.1

## Breaking change
- MCP/agent tool `get_drift` is renamed to `get_scorecard` with new bucketed output. External MCP clients or saved prompts referencing `get_drift` need updating.

## Bug bash (pre-merge verification)
- Typecheck clean; all 693 unit tests pass (36 files)
- Playwright e2e launch tests pass on Electron 43 (real boot, native @libsql bindings, bridge round-trip)
- MCP `get_scorecard` and `list_tags` smoke-tested against real data; scorecard math verified (deltas sum to net)
- GUI driven with Playwright against a copy of real data: Dashboard scorecard (Categories + Flexibility tabs), Health last-30-days panel, and Tags span column all render correctly; no error boundaries tripped

## Notes
- Demo DB (`~/.fungible-demo`) is stale (ends 2026-05-19), so demo mode shows an empty scorecard for current periods — reseed before demos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)