### PR TITLE
Add fungible --version flag

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# GitHub substitutes %(describe:tags) with the release tag when generating
+# archive tarballs — this is how Homebrew installs (no .git dir) learn their
+# version. In a git checkout the placeholder survives and bin/fungible falls
+# back to `git describe`.
+VERSION export-subst

--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ In the desktop app, pick **"Try Demo Mode"** from the app menu (macOS) or Help m
 ```bash
 brew tap tomfunk/fungible
 brew install fungible
-fungible --setup   # first-time setup wizard
+fungible --setup     # first-time setup wizard
+fungible --version   # print installed version
 fungible
 ```
 

--- a/VERSION
+++ b/VERSION
@@ -1,0 +1,1 @@
+$Format:%(describe:tags)$

--- a/bin/fungible
+++ b/bin/fungible
@@ -10,6 +10,18 @@ while [ -L "$SCRIPT_SOURCE" ]; do
 done
 PACKAGE_DIR="$(cd "$(dirname "$SCRIPT_SOURCE")/.." && pwd)"
 
+# Version: the VERSION file is a git export-subst placeholder that GitHub
+# fills in when it generates release tarballs (what Homebrew installs from).
+# In a git checkout the placeholder survives, so fall back to `git describe`.
+if [[ "${1:-}" == "--version" || "${1:-}" == "-v" ]]; then
+  VERSION="$(cat "$PACKAGE_DIR/VERSION" 2>/dev/null || true)"
+  if [[ "$VERSION" == *'$Format'* || -z "$VERSION" ]]; then
+    VERSION="$(git -C "$PACKAGE_DIR" describe --tags 2>/dev/null || echo "unknown")"
+  fi
+  echo "fungible ${VERSION#v}"
+  exit 0
+fi
+
 # Demo mode: use a separate data directory so real data is untouched
 for arg in "$@"; do
   if [[ "$arg" == "--demo" ]]; then


### PR DESCRIPTION
Adds `fungible --version` (and `-v`) to the CLI.

## How it works

The released version lives only in git tags (`package.json` is cosmetic — see `release.yml`), and Homebrew installs from the source tarball with no `.git` directory. So:

- A new `VERSION` file contains the git `export-subst` placeholder `$Format:%(describe:tags)$`, marked in `.gitattributes`. GitHub substitutes the real tag when generating the release tarball, which is exactly what the Homebrew formula downloads.
- In a git checkout the placeholder survives, and `bin/fungible` falls back to `git describe --tags`.

The flag is handled early in `bin/fungible` before any node startup, so it's instant.

## Verified

- `./bin/fungible --version` in the checkout → `fungible 1.7.0-23-g50eb949` (via git describe)
- `git archive HEAD` extracted to a temp dir (simulates the brew tarball) → placeholder substituted, prints `fungible 1.7.0-23-g50eb949` with no `.git` present. On a real tag this will be a clean `fungible 1.7.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)