### PR TITLE
feat: scorecard ×med/×avg ratio columns, n/a for no-baseline

### DIFF
--- a/core/scorecard.ts
+++ b/core/scorecard.ts
@@ -20,9 +20,9 @@ export function isSignificantDelta(delta: number, baseline: number): boolean {
   return Math.abs(delta) >= Math.max(SIGNIFICANCE_FLOOR, SIGNIFICANCE_SHARE * baseline);
 }
 
-/** "4.2x" multiplier vs baseline; "new" when there is no baseline to compare. */
+/** "4.2x" multiplier vs baseline; "n/a" when there is no baseline to compare. */
 export function ratioLabel(current: number, baseline: number): string {
-  if (baseline <= 0) return current > 0 ? 'new' : '';
+  if (baseline <= 0) return current > 0 ? 'n/a' : '';
   return `${(current / baseline).toFixed(1)}x`;
 }
 

--- a/gui/renderer/src/screens/Dashboard.tsx
+++ b/gui/renderer/src/screens/Dashboard.tsx
@@ -440,7 +440,8 @@ export function Dashboard() {
                     <th className={styles.th}>Amount</th>
                     <th className={styles.th}>Δ typical</th>
                     <th className={styles.th}></th>
-                    <th className={styles.th}>Ratio</th>
+                    <th className={styles.th}>× med</th>
+                    <th className={styles.th}>× avg</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -451,7 +452,7 @@ export function Dashboard() {
                     return (
                       <React.Fragment key={bucket}>
                         <tr className={styles.bucketRow}>
-                          <td colSpan={5} className={meta.cls}>{meta.label}</td>
+                          <td colSpan={6} className={meta.cls}>{meta.label}</td>
                         </tr>
                         {rows.map((row) => {
                           const isTypical = bucket === 'typical';
@@ -470,6 +471,7 @@ export function Dashboard() {
                                 {!isTypical && <Bar value={Math.abs(row.medianDelta)} max={maxScoreDelta} color={barColor} />}
                               </td>
                               <td className="num dim">{isTypical ? '' : ratioLabel(row.current, row.median12m)}</td>
+                              <td className="num dim">{isTypical ? '' : ratioLabel(row.current, row.avg12m)}</td>
                             </tr>
                           );
                         })}
@@ -482,7 +484,7 @@ export function Dashboard() {
                     <td className={`num ${scorecard.net <= 0 ? 'pos' : scorecard.net >= scoreTotal * 0.05 ? 'neg' : 'warn'}`}>
                       {fmtDelta(scorecard.net)}
                     </td>
-                    <td colSpan={2} className="dim">vs typical</td>
+                    <td colSpan={3} className="dim">vs typical</td>
                   </tr>
                 </tbody>
               </table>

--- a/gui/renderer/src/screens/Dashboard.tsx
+++ b/gui/renderer/src/screens/Dashboard.tsx
@@ -569,7 +569,8 @@ export function Dashboard() {
                   <th className={styles.th}>Tier</th>
                   <th className={styles.th}>Amount</th>
                   <th className={styles.th}>Δ typical</th>
-                  <th className={styles.th}>Ratio</th>
+                  <th className={styles.th}>× med</th>
+                  <th className={styles.th}>× avg</th>
                 </tr>
               </thead>
               <tbody>
@@ -585,6 +586,7 @@ export function Dashboard() {
                       <td className="num">{fmt(slice.current)}</td>
                       <td className={`num ${cls}`}>{fmtDelta(slice.medianDelta)}</td>
                       <td className="num dim">{ratioLabel(slice.current, slice.median12m)}</td>
+                      <td className="num dim">{ratioLabel(slice.current, slice.avg12m)}</td>
                     </tr>
                   );
                 })}

--- a/tests/gui/dashboard.test.tsx
+++ b/tests/gui/dashboard.test.tsx
@@ -87,12 +87,12 @@ describe('GUI Dashboard', () => {
       return s;
     });
     // Grocery: May $205 vs April-only baseline $100 → over by $105.
-    // Bills & Utilities: $95 with no history → over, flagged "new".
+    // Bills & Utilities: $95 with no history → over, ratio shows "n/a".
     // Dining (+$5) and Shopping ($43.99, no baseline) sit under the
     // significance gate → typical. Nothing is under → no Under section.
     expect(section.textContent).toContain('+$105');
     expect(section.textContent).toContain('+$95');
-    expect(section.textContent).toContain('new');
+    expect(section.textContent).toContain('n/a');
     expect(section.textContent).toContain('Typical');
     expect(section.textContent).not.toContain('Under');
     // Net row: 105 + 5 + 95 + 43.99 ≈ +$249 vs typical.

--- a/tests/scorecard-tool.test.ts
+++ b/tests/scorecard-tool.test.ts
@@ -65,7 +65,7 @@ describe('get_scorecard tool output', () => {
 
     expect(out).toContain('Scorecard — last 30 days (Jun 4 – Jul 3, 2026)');
     expect(out).toContain('OVER');
-    expect(out).toContain('(new) 🔴'); // no baseline history → new spending
+    expect(out).toContain('(n/a) 🔴'); // no baseline history → no ratio
   });
 
   it('reports no data for an empty window', async () => {

--- a/tests/scorecard.test.ts
+++ b/tests/scorecard.test.ts
@@ -32,8 +32,8 @@ describe('ratioLabel', () => {
     expect(ratioLabel(291, 762)).toBe('0.4x');
   });
 
-  it('labels new spending with no baseline', () => {
-    expect(ratioLabel(100, 0)).toBe('new');
+  it('labels spending with no baseline as n/a', () => {
+    expect(ratioLabel(100, 0)).toBe('n/a');
     expect(ratioLabel(0, 0)).toBe('');
   });
 });

--- a/tui/Dashboard.tsx
+++ b/tui/Dashboard.tsx
@@ -789,6 +789,8 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
                     <Text dimColor>{''.padEnd(18)}</Text>
                     <Text dimColor>{'amount'.padStart(10)}</Text>
                     <Text dimColor>{'Δ typical'.padStart(9)}</Text>
+                    <Text dimColor>{'×med'.padStart(6)}</Text>
+                    <Text dimColor>{'×avg'.padStart(5)}</Text>
                   </Box>
                   {flexDrift && FLEX_TIERS.map(({ key, label }) => {
                     const slice = flexDrift[key];

--- a/tui/Dashboard.tsx
+++ b/tui/Dashboard.tsx
@@ -255,8 +255,8 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
   // Drift detail: 3 delta cols × 9 chars + 4 gaps of 2 = 27+8=35 for cols; plus amount(10)+gaps
   // total fixed = 2(cursor) + 10(amt) + 4(gaps to amt) + 27(3×9) + 4(gaps between deltas) = 47
   const driftCatNameW = Math.max(12, inner - 47);
-  // Scorecard: [sel=2] [name] [amount=10] [delta=9] [bar] [ratio=5] with 5 gaps of 2 = 36 fixed
-  const scoreFlex  = Math.max(18, inner - 36);
+  // Scorecard: [sel=2] [name] [amount=10] [delta=9] [bar] [×med=5] [×avg=5] with 6 gaps of 2 = 43 fixed
+  const scoreFlex  = Math.max(18, inner - 43);
   const scoreNameW = Math.max(12, Math.min(20, Math.floor(scoreFlex * 0.55)));
   const scoreBarW  = Math.max(6,  Math.min(14, scoreFlex - scoreNameW));
   // Normal flex: [label=18] gap [amount=10] gap [pct=4] gap [bar] — 3 gaps of 2
@@ -669,6 +669,9 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
                           <Text dimColor>{''.padEnd(scoreNameW)}</Text>
                           <Text dimColor>{'amount'.padStart(10)}</Text>
                           <Text dimColor>{'Δ typical'.padStart(9)}</Text>
+                          <Text dimColor>{''.padEnd(scoreBarW)}</Text>
+                          <Text dimColor>{'×med'.padStart(5)}</Text>
+                          <Text dimColor>{'×avg'.padStart(5)}</Text>
                         </Box>
                       </Box>
                       {scoreBuckets.map((bucket) => (
@@ -699,6 +702,7 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
                                   <>
                                     <Text color={color}>{bar(Math.abs(row.medianDelta), maxScoreDelta, scoreBarW).padEnd(scoreBarW)}</Text>
                                     <Text dimColor>{ratioLabel(row.current, row.median12m).padStart(5)}</Text>
+                                    <Text dimColor>{ratioLabel(row.current, row.avg12m).padStart(5)}</Text>
                                   </>
                                 )}
                               </SelectableRow>
@@ -796,6 +800,7 @@ export function Dashboard({ onNavigate, isActive, initialFilter, showHints }: { 
                         <Text color={C_NEUTRAL}>{fmt(slice.current).padStart(10)}</Text>
                         <Text color={color}>{fmtDelta(slice.medianDelta).padStart(9)}</Text>
                         <Text dimColor>{ratioLabel(slice.current, slice.median12m).padStart(6)}</Text>
+                        <Text dimColor>{ratioLabel(slice.current, slice.avg12m).padStart(5)}</Text>
                       </Box>
                     );
                   })}


### PR DESCRIPTION
## Summary
- Splits the scorecard's single **Ratio** column (current ÷ 12-month median) into two columns, **× med** and **× avg** (current ÷ 12-month average, already computed in `core/queries.ts`), in both the GUI and TUI dashboards.
- Relabels the no-baseline ratio from `new` to `n/a` in `ratioLabel()` — surfaces in both dashboards and the `get_scorecard` MCP tool output.

## Test plan
- `tests/scorecard.test.ts`, `tests/scorecard-tool.test.ts`, `tests/gui/dashboard.test.tsx` updated and passing (21/21)
- `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)