### PR TITLE
test: GUI and TUI screen sweeps against seeded data

### DIFF
--- a/tests/e2e/screens.spec.ts
+++ b/tests/e2e/screens.spec.ts
@@ -1,0 +1,76 @@
+import {
+  test,
+  expect,
+  _electron as electron,
+  type ElectronApplication,
+  type Page,
+} from '@playwright/test';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Screen sweep: boots one Electron instance against a temp data dir pre-seeded
+// with the demo dataset (scripts/seed-demo.ts), then visits every SideNav screen
+// and asserts it renders through the real bridge → core/queries → DB path
+// without tripping the ErrorBoundary. Complements launch.spec.ts, which proves
+// boot on an EMPTY db; this proves every screen's read path against realistic
+// rows — the class of breakage the jsdom tests (stubbed bridge) can't catch.
+
+const MAIN_ENTRY = fileURLToPath(new URL('../../out/main/index.js', import.meta.url));
+const SEED_SCRIPT = fileURLToPath(new URL('./seed-db.ts', import.meta.url));
+const PROJECT_ROOT = fileURLToPath(new URL('../..', import.meta.url));
+
+// nav = SideNav button label; heading = the screen's <h1> (Health's differs);
+// marker = seeded text that only appears if the screen's queries returned real
+// rows (null where the screen has no stable seeded datum to look for).
+const SCREENS: { nav: string; heading: string; marker: string | null }[] = [
+  { nav: 'Dashboard', heading: 'Dashboard', marker: 'Grocery' },
+  { nav: 'Transactions', heading: 'Transactions', marker: 'Whole Foods' },
+  { nav: 'Trends', heading: 'Trends', marker: null },
+  { nav: 'Net Worth', heading: 'Net Worth', marker: 'High-Yield Savings' },
+  { nav: 'Tags', heading: 'Tags', marker: 'tokyo trip' },
+  { nav: 'Health', heading: 'Financial Health', marker: null },
+  { nav: 'Rules', heading: 'Rules', marker: 'STARBUCKS' },
+  { nav: 'Accounts', heading: 'Accounts', marker: 'Everyday Checking' },
+  { nav: 'Canvas', heading: 'Canvas', marker: null },
+  { nav: 'Settings', heading: 'Settings', marker: null },
+];
+
+let app: ElectronApplication;
+let win: Page;
+let dataDir: string;
+
+// One boot for the whole sweep (unlike launch.spec.ts's per-test boots): the
+// point here is per-screen coverage, not boot coverage, and each screen remounts
+// through its own keyed ErrorBoundary so failures can't leak across tests.
+test.beforeAll(async () => {
+  dataDir = mkdtempSync(join(tmpdir(), 'fungible-e2e-sweep-'));
+  // Seed before launch. We can't just set FUNGIBLE_DEMO on the app process —
+  // gui/main/index.ts redirects that to ~/.fungible-demo, defeating the temp-dir
+  // isolation — so run the same seeder out-of-process against the temp dir.
+  execFileSync(process.execPath, ['--import', 'tsx/esm', SEED_SCRIPT], {
+    cwd: PROJECT_ROOT,
+    env: { ...process.env, FUNGIBLE_DATA_DIR: dataDir },
+  });
+  app = await electron.launch({
+    args: [MAIN_ENTRY, ...(process.env.CI ? ['--no-sandbox'] : [])],
+    env: { ...process.env, FUNGIBLE_DATA_DIR: dataDir },
+  });
+  win = await app.firstWindow();
+});
+
+test.afterAll(async () => {
+  await app?.close();
+  if (dataDir) rmSync(dataDir, { recursive: true, force: true });
+});
+
+for (const { nav, heading, marker } of SCREENS) {
+  test(`${nav} renders seeded data with no error boundary`, async () => {
+    await win.getByRole('button', { name: nav }).click();
+    await expect(win.getByRole('heading', { name: heading, level: 1 })).toBeVisible();
+    if (marker) await expect(win.getByText(marker).first()).toBeVisible();
+    await expect(win.getByText('Something went wrong')).toHaveCount(0);
+  });
+}

--- a/tests/e2e/seed-db.ts
+++ b/tests/e2e/seed-db.ts
@@ -1,0 +1,9 @@
+// Seeds the demo dataset into whatever FUNGIBLE_DATA_DIR points at. Run as a
+// child process by screens.spec.ts before Electron launches: core/db.ts resolves
+// FUNGIBLE_DATA_DIR at import time, so the seed must happen in a process whose
+// env already carries the temp dir — it can't run inside the Playwright process.
+import { initDb } from '../../core/db.js';
+import { seedDemo } from '../../scripts/seed-demo.js';
+
+await initDb();
+await seedDemo();

--- a/tests/tui/screens.test.tsx
+++ b/tests/tui/screens.test.tsx
@@ -1844,6 +1844,45 @@ describe('App', () => {
     r.stdin.write('0');
     await waitFor(() => expect(frame(r)).toContain('Settings'));
   });
+
+  it('digit-nav sweep: every screen renders in the full app with seeded data', async () => {
+    // Bug-bash sweep: unlike the per-screen describes above (which mount each
+    // screen directly), this drives the real App through its digit navigation so
+    // every screen mounts with the props/context App actually passes it. Each
+    // step asserts the screen's header plus a seeded datum — proving its load
+    // path ran, not just that it mounted. Dashboard and Transactions anchor to
+    // the real current month (no initialFilter from App), which the fixed
+    // May-2026 seed can't reach, so give them one transaction dated today.
+    const today = new Date().toISOString().slice(0, 10);
+    await db.execute({
+      sql: `INSERT INTO transactions (id, account_id, date, name, amount, category, pending, ignored)
+            VALUES ('tx-sweep-now', 'test-credit', ?, 'Sweep Marker Coffee', 4.50, 'Dining', 0, 0)`,
+      args: [today],
+    });
+
+    const r = render(<App />);
+    await waitFor(() => expect(frame(r)).toContain('Dashboard'));
+
+    const sweep: [digit: string, markers: string[]][] = [
+      ['2', ['Transactions', 'Sweep Marker Coffee']],
+      ['3', ['Trends', 'May 2026']],
+      ['4', ['Net Worth', 'Test Checking']],
+      ['5', ['Tags', 'travel']],
+      ['6', ['Financial Health', 'SNAPSHOT']],
+      ['7', ['Category Rules', 'Whole Foods']],
+      ['8', ['Accounts', 'Test Checking']],
+      ['9', ['Canvas']],
+      ['0', ['Settings', 'HOUSEHOLD']],
+      ['1', ['Dashboard', 'Dining']],
+    ];
+    for (const [digit, markers] of sweep) {
+      r.stdin.write(digit);
+      await waitFor(() => {
+        const f = frame(r);
+        for (const m of markers) expect(f).toContain(m);
+      }, 2000);
+    }
+  });
 });
 
 // ── FilterPanel ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Pre-promotion bug-bash coverage: every screen in both frontends now renders end-to-end against realistic data in CI.

- **GUI** (`tests/e2e/screens.spec.ts`): boots one packaged Electron instance against an isolated temp data dir pre-seeded with the demo dataset (`scripts/seed-demo.ts`), then clicks through all 10 SideNav screens. Each must render its `<h1>`, show a seeded datum where one is stable, and never trip the ErrorBoundary. This covers the class of breakage the jsdom tests (stubbed bridge) can't: real IPC serialization and real `core/queries` calls against populated rows.
  - Seeding runs out-of-process (`tests/e2e/seed-db.ts`) because `core/db.ts` resolves `FUNGIBLE_DATA_DIR` at import time, and setting `FUNGIBLE_DEMO` on the app would redirect the data dir to `~/.fungible-demo`, defeating isolation.
- **TUI** (`tests/tui/screens.test.tsx`): a full-app digit-nav sweep visiting all 10 screens with per-screen data assertions — previously the App-level tests only covered 3 screens.

Runs under the existing `npm run test:e2e` / `npm test` scripts and the `gui-e2e` CI job — no workflow changes.

## Test plan
- `npm run test:e2e`: 12/12 (2 existing launch tests + 10 sweep)
- `npm test tests/tui/screens.test.tsx`: 153/153

🤖 Generated with [Claude Code](https://claude.com/claude-code)