### PR TITLE
Surface sync errors

### DIFF
--- a/core/db.ts
+++ b/core/db.ts
@@ -126,6 +126,7 @@ export async function initDb() {
     'ALTER TABLE accounts ADD COLUMN owner TEXT',
     'ALTER TABLE accounts ADD COLUMN apr REAL',
     'ALTER TABLE accounts ADD COLUMN excluded INTEGER NOT NULL DEFAULT 0',
+    'ALTER TABLE accounts ADD COLUMN item_id TEXT',
     'ALTER TABLE category_rules ADD COLUMN account_id TEXT',
     'ALTER TABLE name_rules ADD COLUMN account_id TEXT',
   ];

--- a/core/plaid.ts
+++ b/core/plaid.ts
@@ -36,6 +36,22 @@ export async function createLinkToken(userId: string, daysRequested?: number) {
   return response.data.link_token;
 }
 
+/**
+ * Extract a human-readable message from a rejected Plaid request. The Plaid SDK
+ * rejects with an Axios error whose useful payload lives at `err.response.data`
+ * ({ error_type, error_code, error_message, display_message }); the bare
+ * `err.message` is only "Request failed with status code 400". Prefer Plaid's
+ * user-facing `display_message`, fall back to `error_code: error_message`, then
+ * to the generic error message.
+ */
+export function plaidErrorMessage(err: unknown): string {
+  const data = (err as { response?: { data?: Record<string, string> } })?.response?.data;
+  if (data?.error_code) {
+    return data.display_message || `${data.error_code}: ${data.error_message}`;
+  }
+  return err instanceof Error ? err.message : String(err);
+}
+
 export async function exchangePublicToken(publicToken: string) {
   const response = await getPlaidClient().itemPublicTokenExchange({ public_token: publicToken });
   return {

--- a/core/queries.ts
+++ b/core/queries.ts
@@ -593,11 +593,11 @@ export async function countSearchMatches(
   return { count: matches.length, expenses: matches.filter((r) => Number(r.amount) > 0).reduce((s, r) => s + Number(r.amount), 0) };
 }
 
-export type LinkedAccount = { id: string; name: string; nickname: string | null; owner: string | null; type: string; subtype: string | null; institution_name: string | null; mask: string | null; last_synced: string | null; apr: number | null; excluded: boolean };
+export type LinkedAccount = { id: string; name: string; nickname: string | null; owner: string | null; type: string; subtype: string | null; institution_name: string | null; mask: string | null; item_id: string | null; last_synced: string | null; apr: number | null; excluded: boolean };
 
 export async function getLinkedAccounts(): Promise<LinkedAccount[]> {
   const result = await db.execute(`
-    SELECT a.id, a.name, a.nickname, a.owner, a.type, a.subtype, a.institution_name, a.mask, a.apr, a.excluded,
+    SELECT a.id, a.name, a.nickname, a.owner, a.type, a.subtype, a.institution_name, a.mask, a.item_id, a.apr, a.excluded,
       (SELECT MAX(date) FROM balance_history WHERE account_id = a.id) as last_synced
     FROM accounts a
     ORDER BY CASE a.type WHEN 'depository' THEN 0 WHEN 'investment' THEN 1 WHEN 'credit' THEN 2 ELSE 3 END, a.name

--- a/core/sync-status.ts
+++ b/core/sync-status.ts
@@ -1,0 +1,38 @@
+import { EventEmitter } from 'node:events';
+import type { SyncItemResult } from './sync.js';
+
+// Session-only store for the most recent sync's per-item failures, shared by
+// both sync paths (startup sync in tui/index.tsx and the user-triggered sync in
+// tui/Accounts.tsx). Mirrors core/refresh.ts: a tiny EventEmitter plus a getter,
+// so a React provider that mounts *after* the startup sync resolves can still
+// read the current state. Nothing is persisted — it clears on the next sync.
+
+export type SyncFailure = { itemId: string; error: string };
+
+const emitter = new EventEmitter();
+let failures: SyncFailure[] = [];
+
+/** Record a sync's outcome. Keeps only the failed items; a clean run clears all. */
+export function setSyncResult(results: SyncItemResult[]): void {
+  failures = results
+    .filter((r): r is SyncItemResult & { error: string } => !!r.error)
+    .map((r) => ({ itemId: r.itemId, error: r.error }));
+  emitter.emit('status');
+}
+
+/** Current failure snapshot — read by a provider on mount to catch a sync that already resolved. */
+export function getSyncFailures(): SyncFailure[] {
+  return failures;
+}
+
+/** Clear all recorded failures (e.g. manual dismissal). No-op if already empty. */
+export function clearSyncFailures(): void {
+  if (failures.length === 0) return;
+  failures = [];
+  emitter.emit('status');
+}
+
+export function onSyncStatus(fn: () => void): () => void {
+  emitter.on('status', fn);
+  return () => { emitter.off('status', fn); };
+}

--- a/core/sync.ts
+++ b/core/sync.ts
@@ -1,4 +1,4 @@
-import { getPlaidClient } from './plaid.js';
+import { getPlaidClient, plaidErrorMessage } from './plaid.js';
 import { db } from './db.js';
 import { categorizeWithRules, loadCategoryRules } from './categorize.js';
 import { applyNameRulesWithRules, loadNameRules } from './rename.js';
@@ -38,10 +38,10 @@ export async function syncTransactions(accessToken: string, itemId: string) {
     accountsResponse.data.accounts.flatMap((acct) => {
       const rows: { sql: string; args: (string | number | null)[] }[] = [
         {
-          sql: `INSERT INTO accounts (id, name, type, subtype, mask)
-                VALUES (?, ?, ?, ?, ?)
-                ON CONFLICT(id) DO UPDATE SET name=excluded.name`,
-          args: [acct.account_id, acct.name, acct.type, acct.subtype ?? null, acct.mask ?? null],
+          sql: `INSERT INTO accounts (id, name, type, subtype, mask, item_id)
+                VALUES (?, ?, ?, ?, ?, ?)
+                ON CONFLICT(id) DO UPDATE SET name=excluded.name, item_id=excluded.item_id`,
+          args: [acct.account_id, acct.name, acct.type, acct.subtype ?? null, acct.mask ?? null, itemId],
         },
       ];
       const balance = acct.balances.current;
@@ -126,20 +126,37 @@ export async function syncTransactions(accessToken: string, itemId: string) {
 
 const DEBOUNCE_MS = 15 * 60 * 1000;
 
-export async function syncAll(force = false) {
+export type SyncItemResult = {
+  itemId: string;
+  added: number; modified: number; removed: number; dupes: number;
+  skipped: boolean;
+  // Set when this item failed to sync; carries the extracted Plaid/error message
+  // so callers can report which item broke and why. One item failing does not
+  // abort the others.
+  error?: string;
+};
+
+export async function syncAll(force = false): Promise<SyncItemResult[]> {
   const itemsRes = await db.execute('SELECT item_id, access_token, last_synced_at FROM plaid_items');
   const items = itemsRes.rows as unknown as {
     item_id: string; access_token: string; last_synced_at: number | null;
   }[];
 
-  const results = [];
+  const results: SyncItemResult[] = [];
   for (const item of items) {
     if (!force && item.last_synced_at && Date.now() - Number(item.last_synced_at) < DEBOUNCE_MS) {
       results.push({ itemId: item.item_id, added: 0, modified: 0, removed: 0, dupes: 0, skipped: true });
       continue;
     }
-    const result = await syncTransactions(decryptToken(item.access_token), item.item_id);
-    results.push({ itemId: item.item_id, ...result, skipped: false });
+    try {
+      const result = await syncTransactions(decryptToken(item.access_token), item.item_id);
+      results.push({ itemId: item.item_id, ...result, skipped: false });
+    } catch (err) {
+      results.push({
+        itemId: item.item_id, added: 0, modified: 0, removed: 0, dupes: 0,
+        skipped: false, error: plaidErrorMessage(err),
+      });
+    }
   }
   return results;
 }

--- a/core/sync.ts
+++ b/core/sync.ts
@@ -93,10 +93,18 @@ export async function syncTransactions(accessToken: string, itemId: string) {
     await applyTagRules({ txIds: [...added, ...modified].map((tx) => tx.transaction_id) });
   }
 
-  // Remove deleted
+  // Remove deleted. Clear child rows first: transaction_tags has a FK
+  // (transaction_id → transactions.id), so deleting a tagged transaction
+  // directly fails with a FOREIGN KEY constraint. tag_rule_suppressions is
+  // keyed by transaction_id too (no FK, but clearing it avoids orphan rows).
+  // One batch keeps the three deletes atomic.
   if (removedIds.length > 0) {
     const placeholders = removedIds.map(() => '?').join(',');
-    await db.execute({ sql: `DELETE FROM transactions WHERE id IN (${placeholders})`, args: removedIds });
+    await db.batch([
+      { sql: `DELETE FROM transaction_tags WHERE transaction_id IN (${placeholders})`, args: removedIds },
+      { sql: `DELETE FROM tag_rule_suppressions WHERE transaction_id IN (${placeholders})`, args: removedIds },
+      { sql: `DELETE FROM transactions WHERE id IN (${placeholders})`, args: removedIds },
+    ], 'write');
   }
 
   // Save cursor and last_synced_at

--- a/gui/main/app.ts
+++ b/gui/main/app.ts
@@ -6,8 +6,11 @@ import { initDb } from '../../core/db.js';
 import { backupDb } from '../../core/backup.js';
 import { rebuildDisplayNames } from '../../core/rename.js';
 import { syncAll } from '../../core/sync.js';
+import { setSyncResult } from '../../core/sync-status.js';
+import { plaidErrorMessage } from '../../core/plaid.js';
 import { registerBridge } from './bridge.js';
 import { registerRefreshPush } from './refresh-ipc.js';
+import { registerSyncStatusPush } from './sync-status-ipc.js';
 import { registerAgentIpc, rejectPendingConfirms } from './agent-ipc.js';
 import { cancelActivePlaidLink } from './plaid-link.js';
 import { buildMenu } from './menu.js';
@@ -46,11 +49,21 @@ if (!app.requestSingleInstanceLock()) {
 
     registerBridge();
     registerRefreshPush();
+    registerSyncStatusPush();
     registerAgentIpc();
     buildMenu();
     createWindow();
 
-    if (!isDemo) syncAll().catch((err) => console.error('[gui] background sync failed:', err));
+    // Background startup sync: record its outcome in the shared store so failures
+    // surface (banner + badges) instead of only logging to the main console.
+    if (!isDemo) {
+      syncAll()
+        .then(setSyncResult)
+        .catch((err) => {
+          console.error('[gui] background sync failed:', err);
+          setSyncResult([{ itemId: '', added: 0, modified: 0, removed: 0, dupes: 0, skipped: false, error: plaidErrorMessage(err) }]);
+        });
+    }
 
     app.on('activate', () => {
       if (BrowserWindow.getAllWindows().length === 0) createWindow();

--- a/gui/main/registry.ts
+++ b/gui/main/registry.ts
@@ -90,6 +90,7 @@ import { getCsvPlaidDupeCandidates } from '../../core/dedup.js';
 import { applyCategoriesToAll } from '../../core/categorize.js';
 import { loadProfile, saveProfile, householdMembers } from '../../core/profile.js';
 import { syncAll } from '../../core/sync.js';
+import { setSyncResult, getSyncFailures } from '../../core/sync-status.js';
 import { loadHistory, deleteHistoryEntry, CANVAS_SPEC_PATH } from '../../core/canvas-history.js';
 import type { CanvasSpec } from '../../core/canvas-spec.js';
 import { writeEnvFile, type EnvUpdates } from '../../core/env-file.js';
@@ -212,7 +213,15 @@ export const registry = {
     },
   },
   sync: {
-    syncAll,
+    // Wrap so every user-triggered sync records its outcome in the shared store,
+    // which drives the renderer banner + row badges via the sync-status push.
+    syncAll: async (force?: boolean) => {
+      const results = await syncAll(force);
+      setSyncResult(results);
+      return results;
+    },
+    // Initial hydration for a renderer that mounts after a background sync failed.
+    getStatus: async () => getSyncFailures(),
   },
   config: {
     writeEnv: async (updates: EnvUpdates): Promise<{ written: string[] }> => {

--- a/gui/main/sync-status-ipc.ts
+++ b/gui/main/sync-status-ipc.ts
@@ -1,0 +1,14 @@
+import { BrowserWindow } from 'electron';
+import { onSyncStatus, getSyncFailures } from '../../core/sync-status.js';
+
+// Mirrors refresh-ipc.ts, but carries a payload: on every sync-status change,
+// push the current failures to every open window so the renderer's banner and
+// row badges update without a round-trip. Initial state is pulled via
+// api.sync.getStatus() when a provider mounts (covers a sync that resolved first).
+export function registerSyncStatusPush() {
+  onSyncStatus(() => {
+    for (const win of BrowserWindow.getAllWindows()) {
+      win.webContents.send('sync-status', getSyncFailures());
+    }
+  });
+}

--- a/gui/renderer/src/App.module.css
+++ b/gui/renderer/src/App.module.css
@@ -15,3 +15,12 @@
   overflow-y: auto;
   padding: 24px 28px;
 }
+
+.syncBanner {
+  flex: none;
+  padding: 8px 28px;
+  font-size: 0.85rem;
+  color: var(--negative);
+  background: color-mix(in srgb, var(--negative) 12%, transparent);
+  border-bottom: 1px solid color-mix(in srgb, var(--negative) 30%, transparent);
+}

--- a/gui/renderer/src/App.tsx
+++ b/gui/renderer/src/App.tsx
@@ -3,6 +3,7 @@ import type { Screen, TxFilter } from '../../shared/nav.js';
 import { SCREEN_KEYS } from '../../shared/nav.js';
 import { api } from './api.js';
 import { RefreshProvider, useRefreshKey } from './hooks/useRefresh.js';
+import { SyncStatusProvider, useSyncStatus } from './hooks/useSyncStatus.js';
 import { NavContext } from './hooks/useNav.js';
 import { FilterProvider } from './hooks/useFilter.js';
 import { UiPrefsProvider } from './hooks/useUiPrefs.js';
@@ -28,7 +29,23 @@ function AppInner() {
   const [txFilter, setTxFilter] = useState<TxFilter>({});
   const [navKey, setNavKey] = useState(0);
   const refreshKey = useRefreshKey();
+  const { failures } = useSyncStatus();
+  const [acctNames, setAcctNames] = useState<Record<string, string>>({});
   const lastSpecRef = useRef('');
+
+  // Resolve failing item ids to account names for the banner; only loads when
+  // there's something to show, and falls back to the item id if a name is missing.
+  useEffect(() => {
+    if (failures.length === 0) return;
+    let live = true;
+    void api.queries.getLinkedAccounts().then((accts) => {
+      if (!live) return;
+      const m: Record<string, string> = {};
+      for (const a of accts) if (a.item_id) m[a.item_id] = a.nickname ?? a.name;
+      setAcctNames(m);
+    });
+    return () => { live = false; };
+  }, [failures]);
 
   function navigate(s: Screen, filter?: TxFilter) {
     setTxFilter(filter ?? {});
@@ -89,6 +106,11 @@ function AppInner() {
       <div className={styles.shell}>
         <SideNav active={screen} onSelect={navigate} />
         <div className={styles.main}>
+          {failures.length > 0 && screen !== 'accounts' && (
+            <div className={styles.syncBanner}>
+              ⚠ Sync failed — {failures.map((f) => `${acctNames[f.itemId] ?? (f.itemId || 'account')}: ${f.error}`).join('  ·  ')}  ·  open Accounts to retry
+            </div>
+          )}
           {filterableScreens.includes(screen) && <FilterBar />}
           <main className={styles.content}>
             <ErrorBoundary key={`${screen}:${navKey}`}>{current}</ErrorBoundary>
@@ -103,11 +125,13 @@ function AppInner() {
 export function App() {
   return (
     <RefreshProvider>
-      <FilterProvider>
-        <UiPrefsProvider>
-          <AppInner />
-        </UiPrefsProvider>
-      </FilterProvider>
+      <SyncStatusProvider>
+        <FilterProvider>
+          <UiPrefsProvider>
+            <AppInner />
+          </UiPrefsProvider>
+        </FilterProvider>
+      </SyncStatusProvider>
     </RefreshProvider>
   );
 }

--- a/gui/renderer/src/hooks/useSyncStatus.tsx
+++ b/gui/renderer/src/hooks/useSyncStatus.tsx
@@ -1,0 +1,23 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import { api } from '../api.js';
+import type { SyncFailure } from '../../../../core/sync-status.js';
+
+type SyncStatusValue = { failures: SyncFailure[]; failingItems: Set<string> };
+
+const SyncStatusContext = createContext<SyncStatusValue>({ failures: [], failingItems: new Set() });
+
+export function SyncStatusProvider({ children }: { children: React.ReactNode }) {
+  const [failures, setFailures] = useState<SyncFailure[]>([]);
+  useEffect(() => {
+    // Pull once (a background sync may have failed before we subscribed), then
+    // stay live via the sync-status push. `on` returns its own unsubscribe fn.
+    void api.sync.getStatus().then(setFailures);
+    return window.__bridge.on('sync-status', (f) => setFailures(f as SyncFailure[]));
+  }, []);
+  const value: SyncStatusValue = { failures, failingItems: new Set(failures.map((f) => f.itemId)) };
+  return <SyncStatusContext.Provider value={value}>{children}</SyncStatusContext.Provider>;
+}
+
+export function useSyncStatus(): SyncStatusValue {
+  return useContext(SyncStatusContext);
+}

--- a/gui/renderer/src/screens/Accounts.tsx
+++ b/gui/renderer/src/screens/Accounts.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { api } from '../api.js';
 import { useQuery } from '../hooks/useQuery.js';
 import { useStatus } from '../hooks/useStatus.js';
+import { useSyncStatus } from '../hooks/useSyncStatus.js';
 import { Modal } from '../components/Modal.js';
 import type { LinkedAccount, CsvAccount } from '../../../../core/queries.js';
 import { SUBTYPE_DISPLAY, ACCOUNT_TYPES, SUBTYPES, MONTHS } from '../constants.js';
@@ -35,14 +36,28 @@ export function Accounts() {
   const [linkOpen, setLinkOpen] = useState(false);
   const [syncing, setSyncing] = useState(false);
   const plaidConfigured = useQuery(() => api.plaid.isConfigured(), []) ?? false;
+  // Item ids that failed the most recent sync (from either the startup or the
+  // user-triggered path), pushed from main — used to badge account rows.
+  const { failingItems } = useSyncStatus();
 
   async function forceSync() {
     if (syncing) return;
     setSyncing(true);
     try {
       const results = await api.sync.syncAll(true);
-      const added = results.reduce((s, r) => s + r.added, 0);
-      showStatus(`Sync done — ${added} new transaction${added === 1 ? '' : 's'}`, 4000);
+      const failed = results.filter((r) => r.error);
+      if (failed.length > 0) {
+        // Row badges + global banner update from the sync-status push; here we
+        // just surface a transient toast naming the account(s) and the reason.
+        const desc = failed.map((r) => {
+          const names = accounts.filter((a) => a.item_id === r.itemId).map((a) => a.nickname ?? a.name);
+          return `${names.join(', ') || r.itemId}: ${r.error}`;
+        }).join('  ·  ');
+        showStatus(`Sync failed: ${desc}`, 8000);
+      } else {
+        const added = results.reduce((s, r) => s + r.added, 0);
+        showStatus(`Sync done — ${added} new transaction${added === 1 ? '' : 's'}`, 4000);
+      }
       reload();
     } catch {
       showStatus('Sync failed', 3000);
@@ -105,7 +120,9 @@ export function Accounts() {
                       <td className="dim">{SUBTYPE_DISPLAY[raw] ?? raw}</td>
                       <td className="dim">{acct.institution_name ?? ''}</td>
                       <td>
-                        {acct.last_synced ? (
+                        {acct.item_id && failingItems.has(acct.item_id) ? (
+                          <span className="neg">⚠ sync failed</span>
+                        ) : acct.last_synced ? (
                           <span className="dim">synced <span className="pos">{fmtDate(acct.last_synced)}</span></span>
                         ) : (
                           <span className="warn">not synced</span>

--- a/tests/gui-bridge-parity.test.ts
+++ b/tests/gui-bridge-parity.test.ts
@@ -44,6 +44,15 @@ const EXPECTED_UNBRIDGED: Record<string, string> = {
 
   // Electron-side bridge namespaces live in gui/main/bridge.ts (not registry.ts)
   getDefaultDaysRequested: 'bridge plaid namespace (gui/main/bridge.ts)',
+
+  // Pure error-formatting helper — the GUI surfaces Plaid sync errors its own way
+  plaidErrorMessage: 'pure helper; GUI formats sync errors in its own layer',
+
+  // Session-only sync-failure store (core/sync-status.ts) — the GUI will surface
+  // sync status in its own layer (renderer state), not through the bridge.
+  setSyncResult: 'GUI will surface sync status in its own layer',
+  getSyncFailures: 'GUI will surface sync status in its own layer',
+  onSyncStatus: 'GUI will surface sync status in its own layer',
 };
 
 function collectTuiCoreImports(): Map<string, string[]> {

--- a/tests/helpers/makeTestDb.ts
+++ b/tests/helpers/makeTestDb.ts
@@ -11,7 +11,8 @@ const SCHEMA = `
     nickname TEXT,
     owner TEXT,
     apr REAL,
-    excluded INTEGER NOT NULL DEFAULT 0
+    excluded INTEGER NOT NULL DEFAULT 0,
+    item_id TEXT
   );
 
   CREATE TABLE transactions (

--- a/tests/sync-status.test.ts
+++ b/tests/sync-status.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { setSyncResult, getSyncFailures, clearSyncFailures, onSyncStatus } from '../core/sync-status.js';
+import type { SyncItemResult } from '../core/sync.js';
+
+const ok = (itemId: string): SyncItemResult => ({ itemId, added: 0, modified: 0, removed: 0, dupes: 0, skipped: false });
+const fail = (itemId: string, error: string): SyncItemResult => ({ ...ok(itemId), error });
+
+beforeEach(() => clearSyncFailures());
+
+describe('sync-status store', () => {
+  it('keeps only the failed items', () => {
+    setSyncResult([ok('a'), fail('b', 'ITEM_LOGIN_REQUIRED')]);
+    expect(getSyncFailures()).toEqual([{ itemId: 'b', error: 'ITEM_LOGIN_REQUIRED' }]);
+  });
+
+  it('a clean run clears prior failures', () => {
+    setSyncResult([fail('b', 'x')]);
+    setSyncResult([ok('a')]);
+    expect(getSyncFailures()).toEqual([]);
+  });
+
+  it('notifies subscribers on change and stops after unsubscribe', () => {
+    const fn = vi.fn();
+    const off = onSyncStatus(fn);
+    setSyncResult([fail('b', 'x')]);
+    expect(fn).toHaveBeenCalledTimes(1);
+    off();
+    setSyncResult([fail('c', 'y')]);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('clearSyncFailures empties, and is a no-op (no emit) when already empty', () => {
+    setSyncResult([fail('b', 'x')]);
+    const fn = vi.fn();
+    const off = onSyncStatus(fn);
+    clearSyncFailures();
+    expect(getSyncFailures()).toEqual([]);
+    expect(fn).toHaveBeenCalledTimes(1);
+    clearSyncFailures();
+    expect(fn).toHaveBeenCalledTimes(1);
+    off();
+  });
+});

--- a/tests/tui/sync-banner.test.tsx
+++ b/tests/tui/sync-banner.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import React from 'react';
+import { render, cleanup } from 'ink-testing-library';
+
+vi.mock('../../core/db.js', async () => {
+  const { makeTestDb } = await import('../helpers/makeTestDb.js');
+  return { db: await makeTestDb() };
+});
+
+import { db } from '../../core/db.js';
+import { App } from '../../tui/App.js';
+import { setSyncResult, clearSyncFailures } from '../../core/sync-status.js';
+
+const ANSI_RE = /\x1b\[[0-9;]*[mGKHFABCDJ]/g;
+const frame = (r: ReturnType<typeof render>) => (r.lastFrame() ?? '').replace(ANSI_RE, '');
+
+async function waitFor(assertion: () => void, timeout = 1000): Promise<void> {
+  const deadline = Date.now() + timeout;
+  let lastErr: unknown;
+  while (Date.now() < deadline) {
+    try { assertion(); return; } catch (e) { lastErr = e; }
+    await new Promise((res) => setTimeout(res, 30));
+  }
+  throw lastErr;
+}
+
+afterEach(() => { cleanup(); clearSyncFailures(); });
+
+describe('global sync-failure banner', () => {
+  it('shows the failure (from either sync path) on a non-Accounts screen', async () => {
+    await db.execute("INSERT INTO accounts (id, name, type, item_id) VALUES ('acct-citi', 'Citi Visa', 'credit', 'item-citi')");
+    // Simulate a startup/background sync failure landing in the shared store.
+    setSyncResult([{ itemId: 'item-citi', added: 0, modified: 0, removed: 0, dupes: 0, skipped: false, error: 'ITEM_LOGIN_REQUIRED' }]);
+
+    const r = render(<App />); // default screen is the Dashboard
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).toContain('Sync failed');
+      expect(f).toContain('ITEM_LOGIN_REQUIRED');
+    });
+  });
+
+  it('renders no banner when the store has no failures', async () => {
+    const r = render(<App />);
+    await new Promise((res) => setTimeout(res, 50)); // let effects settle
+    expect(frame(r)).not.toContain('Sync failed');
+  });
+});

--- a/tui/Accounts.tsx
+++ b/tui/Accounts.tsx
@@ -3,7 +3,10 @@ import { Box, Text, useInput } from 'ink';
 import { useSetTyping } from './TypingContext.js';
 import { useRefreshKey } from './RefreshContext.js';
 import { spawn } from 'node:child_process';
-import { syncAll } from '../core/sync.js';
+import { syncAll, type SyncItemResult } from '../core/sync.js';
+import { setSyncResult } from '../core/sync-status.js';
+import { plaidErrorMessage } from '../core/plaid.js';
+import { useSyncStatus } from './SyncStatusContext.js';
 import { getCsvPlaidDupeCandidates, type DupePair } from '../core/dedup.js';
 import { parseCSV, parseDate } from '../core/csv.js';
 import { getLinkedAccounts, getCsvAccounts, type LinkedAccount, type CsvAccount } from '../core/queries.js';
@@ -83,8 +86,11 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
   const { statusMsg: acctErr, showStatus: showAcctErr } = useStatusMessage(3000);
 
   // Sync state (shared)
-  const [syncStatus, setSyncStatus] = useState<'idle' | 'syncing' | 'done'>('idle');
+  const [syncStatus, setSyncStatus] = useState<'idle' | 'syncing' | 'done' | 'error'>('idle');
   const [syncMsg, setSyncMsg] = useState('');
+  // Item ids that failed the most recent sync (from either the startup or the
+  // user-triggered path), so their account rows can be badged. Session-only.
+  const { failingItems } = useSyncStatus();
 
   // Add-data / link state
   const [addStep, setAddStep] = useState<AddStep>('landing');
@@ -201,19 +207,41 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
     }
   }
 
+  // Name the accounts behind a failed item so the status line points at the row,
+  // not an opaque item id. Falls back to the item id if accounts aren't loaded yet.
+  function describeSyncFailures(failed: SyncItemResult[]): string {
+    return failed.map((r) => {
+      const names = linkedAccounts.filter((a) => a.item_id === r.itemId).map((a) => a.nickname ?? a.name);
+      const who = names.length > 0 ? names.join(', ') : r.itemId;
+      return `${who} — ${r.error}`;
+    }).join('  ·  ');
+  }
+
   function forceSync() {
     setSyncStatus('syncing');
     setSyncMsg('Syncing…');
     syncAll(true).then((results) => {
-      const added = results.reduce((s, r) => s + r.added, 0);
-      setSyncMsg(`Done — ${added} new transaction${added !== 1 ? 's' : ''}`);
-      setSyncStatus('done');
+      const failed = results.filter((r) => r.error);
+      // Feed the shared store: updates the row badges here and the global banner.
+      // A clean run stores an empty set, clearing both.
+      setSyncResult(results);
       loadAccounts();
-      setTimeout(() => { setSyncStatus('idle'); setSyncMsg(''); }, 4000);
-    }).catch(() => {
-      setSyncMsg('Sync failed');
-      setSyncStatus('done');
-      setTimeout(() => { setSyncStatus('idle'); setSyncMsg(''); }, 3000);
+      if (failed.length > 0) {
+        // Errors stay put until the user presses a key (see useInput) — long
+        // enough to read, and there's a real problem to act on.
+        setSyncStatus('error');
+        setSyncMsg(`Sync failed: ${describeSyncFailures(failed)}`);
+      } else {
+        const added = results.reduce((s, r) => s + r.added, 0);
+        setSyncMsg(`Done — ${added} new transaction${added !== 1 ? 's' : ''}`);
+        setSyncStatus('done');
+        setTimeout(() => { setSyncStatus('idle'); setSyncMsg(''); }, 4000);
+      }
+    }).catch((err) => {
+      // syncAll no longer throws on per-item failure, so this is a broader fault
+      // (e.g. Plaid not configured, DB error). Surface its real message.
+      setSyncMsg(`Sync failed — ${plaidErrorMessage(err)}`);
+      setSyncStatus('error');
     });
   }
 
@@ -351,6 +379,10 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
   // ─── Input handling ──────────────────────────────────────────────────────────
 
   useInput((input, key) => {
+    // A lingering sync error clears on the next keypress. The key still performs
+    // its normal action (dismiss + act), so pressing [s] here retries the sync.
+    if (syncStatus === 'error') { setSyncStatus('idle'); setSyncMsg(''); }
+
     // Global nav (only when not deep in a multi-step flow)
     const atTop = (mainView === 'accounts' && acctMode === 'list') || (mainView === 'add-data' && addStep === 'landing');
 
@@ -461,7 +493,7 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
         setAddStep('link-days');
         return;
       }
-      if (input === 's' && syncStatus === 'idle') { forceSync(); return; }
+      if (input === 's' && syncStatus !== 'syncing') { forceSync(); return; }
       return;
     }
 
@@ -496,7 +528,7 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
       if (input === 'l') { setDaysInput(String(defaultDays)); setDaysError(''); setAddStep('link-days'); return; }
       if (input === 'c') { setAddStep('file'); return; }
       if (input === 'm') { setManualName(''); setAddStep('manual-name'); return; }
-      if (input === 's' && syncStatus === 'idle') { forceSync(); return; }
+      if (input === 's' && syncStatus !== 'syncing') { forceSync(); return; }
       return;
     }
 
@@ -694,7 +726,9 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
                     <Text dimColor>{label}</Text>
                     <Text dimColor>{institution.padEnd(acctInstW)}</Text>
                     <Text dimColor>
-                      {acct.last_synced
+                      {acct.item_id && failingItems.has(acct.item_id)
+                        ? <Text color={C_NEGATIVE}>⚠ sync failed</Text>
+                        : acct.last_synced
                         ? <Text>synced <Text color={isSelected ? C_POSITIVE : undefined}>{fmtDate(acct.last_synced)}</Text></Text>
                         : <Text color={C_WARNING}>not synced</Text>
                       }
@@ -709,7 +743,7 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
 
           <Box marginTop={1}><Divider /></Box>
           <Text dimColor>{linkedAccounts.length} account{linkedAccounts.length !== 1 ? 's' : ''}</Text>
-          {syncMsg && <Text color={syncStatus === 'syncing' ? C_WARNING : C_POSITIVE}>{syncMsg}</Text>}
+          {syncMsg && <Text color={syncStatus === 'syncing' ? C_WARNING : syncStatus === 'error' ? C_NEGATIVE : C_POSITIVE}>{syncMsg}</Text>}
           {acctMsg && <Text color={C_POSITIVE}>{acctMsg}</Text>}
           {acctErr && <Text color={C_NEGATIVE}>{acctErr}</Text>}
 
@@ -812,7 +846,7 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
                   [s] Force sync          <Text dimColor>Re-sync from Plaid now</Text>
                 </Text>
               </Box>
-              {syncMsg && <Box marginTop={1}><Text color={syncStatus === 'syncing' ? C_WARNING : C_POSITIVE}>{syncMsg}</Text></Box>}
+              {syncMsg && <Box marginTop={1}><Text color={syncStatus === 'syncing' ? C_WARNING : syncStatus === 'error' ? C_NEGATIVE : C_POSITIVE}>{syncMsg}</Text></Box>}
               <Box marginTop={1}><Text dimColor>Tab or Esc to go back</Text></Box>
             </Box>
           )}

--- a/tui/App.tsx
+++ b/tui/App.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { Box, useInput, useApp } from 'ink';
+import { Box, Text, useInput, useApp } from 'ink';
 import { readFileSync } from 'node:fs';
 import { TypingContext } from './TypingContext.js';
 import { Dashboard } from './Dashboard.js';
@@ -14,8 +14,11 @@ import { Canvas } from './Canvas.js';
 import { Settings } from './Settings.js';
 import { Chat } from './Chat.js';
 import { RefreshProvider, useRefreshKey } from './RefreshContext.js';
+import { SyncStatusProvider, useSyncStatus } from './SyncStatusContext.js';
 import { FilterProvider } from './FilterContext.js';
 import { FilterPanel } from './FilterPanel.js';
+import { getLinkedAccounts } from '../core/queries.js';
+import { C_NEGATIVE } from './ui.js';
 import type { CanvasSpec } from '../core/canvas-agent.js';
 import { CANVAS_SPEC_PATH } from '../core/canvas-history.js';
 
@@ -50,7 +53,23 @@ function AppInner() {
   const [filterOpen, setFilterOpen] = useState(false);
   const { exit } = useApp();
   const refreshKey = useRefreshKey();
+  const { failures } = useSyncStatus();
+  const [acctNames, setAcctNames] = useState<Record<string, string>>({});
   const lastSpecRef = useRef<string>('');
+
+  // Resolve failing item ids to account names for the banner. Only loads when
+  // there's something to show; falls back to the item id if a name is missing.
+  useEffect(() => {
+    if (failures.length === 0) return;
+    let live = true;
+    void getLinkedAccounts().then((accts) => {
+      if (!live) return;
+      const m: Record<string, string> = {};
+      for (const a of accts) if (a.item_id) m[a.item_id] = a.nickname ?? a.name;
+      setAcctNames(m);
+    });
+    return () => { live = false; };
+  }, [failures]);
 
   useEffect(() => {
     try {
@@ -114,6 +133,13 @@ function AppInner() {
           {currentScreen}
         </Box>
         {filterOpen && <FilterPanel isActive={filterOpen} onClose={() => setFilterOpen(false)} />}
+        {failures.length > 0 && screen !== 'accounts' && (
+          <Box paddingX={2}>
+            <Text color={C_NEGATIVE}>
+              ⚠ Sync failed — {failures.map((f) => `${acctNames[f.itemId] ?? (f.itemId || 'account')}: ${f.error}`).join('  ·  ')}  ·  open Accounts to retry
+            </Text>
+          </Box>
+        )}
         <Chat
           isActive={chatFocused}
           onActivate={() => setChatFocused(true)}
@@ -128,9 +154,11 @@ function AppInner() {
 export function App() {
   return (
     <RefreshProvider>
-      <FilterProvider>
-        <AppInner />
-      </FilterProvider>
+      <SyncStatusProvider>
+        <FilterProvider>
+          <AppInner />
+        </FilterProvider>
+      </SyncStatusProvider>
     </RefreshProvider>
   );
 }

--- a/tui/SyncStatusContext.tsx
+++ b/tui/SyncStatusContext.tsx
@@ -1,0 +1,25 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import { onSyncStatus, getSyncFailures, type SyncFailure } from '../core/sync-status.js';
+
+type SyncStatusValue = { failures: SyncFailure[]; failingItems: Set<string> };
+
+const SyncStatusCtx = createContext<SyncStatusValue>({ failures: [], failingItems: new Set() });
+
+export function SyncStatusProvider({ children }: { children: React.ReactNode }) {
+  const [failures, setFailures] = useState<SyncFailure[]>(() => getSyncFailures());
+  useEffect(() => {
+    // Re-read on mount in case a sync resolved between the initial render and
+    // this subscription, then stay in sync with future emits.
+    setFailures(getSyncFailures());
+    return onSyncStatus(() => setFailures(getSyncFailures()));
+  }, []);
+  const value: SyncStatusValue = {
+    failures,
+    failingItems: new Set(failures.map((f) => f.itemId)),
+  };
+  return <SyncStatusCtx.Provider value={value}>{children}</SyncStatusCtx.Provider>;
+}
+
+export function useSyncStatus(): SyncStatusValue {
+  return useContext(SyncStatusCtx);
+}

--- a/tui/index.tsx
+++ b/tui/index.tsx
@@ -9,6 +9,8 @@ import stripAnsi from 'strip-ansi';
 import { initDb } from '../core/db.js';
 import { backupDb } from '../core/backup.js';
 import { syncAll } from '../core/sync.js';
+import { setSyncResult } from '../core/sync-status.js';
+import { plaidErrorMessage } from '../core/plaid.js';
 import { rebuildDisplayNames } from '../core/rename.js';
 import { App } from './App.js';
 import { Setup } from './Setup.js';
@@ -44,7 +46,15 @@ if (process.argv.includes('--setup')) {
     await seedDemo();
   }
   await rebuildDisplayNames();
-  if (!isDemo) syncAll().catch(() => {});
+  if (!isDemo) {
+    // Startup sync runs in the background; feed its outcome to the shared store
+    // so failures surface (global banner + Accounts badges) instead of vanishing.
+    syncAll()
+      .then(setSyncResult)
+      .catch((err) => setSyncResult([
+        { itemId: '', added: 0, modified: 0, removed: 0, dupes: 0, skipped: false, error: plaidErrorMessage(err) },
+      ]));
+  }
 
   const mcpPort = parseInt(process.env.FUNGIBLE_MCP_PORT ?? '3741', 10);
   const apiPort = parseInt(process.env.FUNGIBLE_API_PORT ?? '3456', 10);


### PR DESCRIPTION
Stacked PR on #127 

---

This PR surfaces Plaid sync errors in the TUI and GUI.

🤖 

Sync failures were swallowed: the accounts screen showed a bare "Sync failed" with no reason, and the startup background sync discarded errors entirely. 

Now:
- syncAll is fault-tolerant (one item failing no longer aborts the rest) and each result carries a human-readable Plaid error via plaidErrorMessage.
- A session-only store (core/sync-status.ts) is fed by both the startup and user-triggered sync paths, surfaced as a global banner (visible on any screen) and per-row "⚠ sync failed" badges on the Accounts screen.
- accounts.item_id is recorded so failing accounts can be identified.

