### PR TITLE
feat: use merchant_name as display fallback for cleaner transaction names

### DIFF
--- a/core/queries.ts
+++ b/core/queries.ts
@@ -92,7 +92,7 @@ export async function getMerchantSummary(
   const f = buildFilterClause(filter, 'transactions');
 
   const result = await db.execute({
-    sql: `SELECT COALESCE(display_name, name) as merchant, SUM(amount) as total, COUNT(*) as count
+    sql: `SELECT COALESCE(display_name, merchant_name, name) as merchant, SUM(amount) as total, COUNT(*) as count
           FROM transactions
           WHERE date >= ? AND date <= ? AND category = ?
             AND pending = 0 AND ignored = 0
@@ -370,7 +370,7 @@ export async function getSearchFilteredData(
 ): Promise<{ summary: MonthlySummary; flexData: FlexSummary }> {
   const f = buildFilterClause(filter, 't');
   const result = await db.execute({
-    sql: `SELECT COALESCE(t.display_name, t.name) as display, t.merchant_name, t.amount, t.category,
+    sql: `SELECT COALESCE(t.display_name, t.merchant_name, t.name) as display, t.merchant_name, t.amount, t.category,
             COALESCE(c.flexibility, 'untagged') as flex
           FROM transactions t
           LEFT JOIN categories c ON c.name = t.category
@@ -382,7 +382,7 @@ export async function getSearchFilteredData(
   const rows = result.rows as unknown as { display: string; merchant_name: string | null; amount: number; category: string; flex: string }[];
 
   const re = buildSearchRe(search);
-  const matches = rows.filter((r) => re.test(r.display) || (r.merchant_name ? re.test(r.merchant_name) : false));
+  const matches = rows.filter((r) => re.test(r.display));
 
   // Accumulate per-category outflow/inflow, then apply the hybrid rule: real
   // categories net (refunds reduce them), Uncategorized splits by flow (outflow =
@@ -528,8 +528,8 @@ export const SORT_ORDER_BY: Record<SortMode, string> = {
   'date-asc':      't.date ASC, t.id ASC',
   'amount-desc':   't.amount DESC',
   'amount-asc':    't.amount ASC',
-  'name-asc':      'COALESCE(t.display_name, t.name) ASC',
-  'name-desc':     'COALESCE(t.display_name, t.name) DESC',
+  'name-asc':      'COALESCE(t.display_name, t.merchant_name, t.name) ASC',
+  'name-desc':     'COALESCE(t.display_name, t.merchant_name, t.name) DESC',
   'category-asc':  't.category ASC, t.date DESC',
   'category-desc': 't.category DESC, t.date DESC',
 };
@@ -574,7 +574,7 @@ export async function getTransactions(filters: {
   const rows = result.rows as unknown as TxRow[];
   if (!search) return rows.slice(0, 200);
   const re = buildSearchRe(search);
-  return rows.filter((r) => re.test(r.display_name ?? r.name) || (r.merchant_name ? re.test(r.merchant_name) : false)).slice(0, 200);
+  return rows.filter((r) => re.test(r.display_name ?? r.merchant_name ?? r.name)).slice(0, 200);
 }
 
 export async function countSearchMatches(
@@ -583,13 +583,13 @@ export async function countSearchMatches(
   if (!search) return { count: 0, expenses: 0 };
   const f = buildFilterClause(filter, 'transactions');
   const result = await db.execute({
-    sql: `SELECT COALESCE(display_name, name) as display, merchant_name, amount
+    sql: `SELECT COALESCE(display_name, merchant_name, name) as display, amount
           FROM transactions WHERE date >= ? AND date <= ?${f.clause} AND pending = 0 AND ignored = 0`,
     args: [from, to, ...f.args],
   });
-  const rows = result.rows as unknown as { display: string; merchant_name: string | null; amount: number }[];
+  const rows = result.rows as unknown as { display: string; amount: number }[];
   const re = buildSearchRe(search);
-  const matches = rows.filter((r) => re.test(r.display) || (r.merchant_name ? re.test(r.merchant_name) : false));
+  const matches = rows.filter((r) => re.test(r.display));
   return { count: matches.length, expenses: matches.filter((r) => Number(r.amount) > 0).reduce((s, r) => s + Number(r.amount), 0) };
 }
 

--- a/core/queries.ts
+++ b/core/queries.ts
@@ -370,7 +370,7 @@ export async function getSearchFilteredData(
 ): Promise<{ summary: MonthlySummary; flexData: FlexSummary }> {
   const f = buildFilterClause(filter, 't');
   const result = await db.execute({
-    sql: `SELECT COALESCE(t.display_name, t.merchant_name, t.name) as display, t.merchant_name, t.amount, t.category,
+    sql: `SELECT COALESCE(t.display_name, t.merchant_name, t.name) as display, t.amount, t.category,
             COALESCE(c.flexibility, 'untagged') as flex
           FROM transactions t
           LEFT JOIN categories c ON c.name = t.category
@@ -379,7 +379,7 @@ export async function getSearchFilteredData(
             AND t.category NOT IN (SELECT category FROM hidden_categories)${f.clause}`,
     args: [from, to, ...f.args],
   });
-  const rows = result.rows as unknown as { display: string; merchant_name: string | null; amount: number; category: string; flex: string }[];
+  const rows = result.rows as unknown as { display: string; amount: number; category: string; flex: string }[];
 
   const re = buildSearchRe(search);
   const matches = rows.filter((r) => re.test(r.display));
@@ -574,7 +574,10 @@ export async function getTransactions(filters: {
   const rows = result.rows as unknown as TxRow[];
   if (!search) return rows.slice(0, 200);
   const re = buildSearchRe(search);
-  return rows.filter((r) => re.test(r.display_name ?? r.merchant_name ?? r.name)).slice(0, 200);
+  return rows.filter((r) =>
+    re.test(r.display_name ?? r.merchant_name ?? r.name) ||
+    (!r.display_name && r.merchant_name !== null && re.test(r.name)),
+  ).slice(0, 200);
 }
 
 export async function countSearchMatches(

--- a/gui/renderer/src/screens/Transactions.tsx
+++ b/gui/renderer/src/screens/Transactions.tsx
@@ -297,7 +297,7 @@ export function Transactions() {
                 onClick={() => setEditTx(tx)}
               >
                 <td className={`num ${styles.tdDate}`}>{tx.date}</td>
-                <td className={styles.tdDesc}>{tx.display_name ?? tx.name}</td>
+                <td className={styles.tdDesc}>{tx.display_name ?? tx.merchant_name ?? tx.name}</td>
                 <td className={`num ${styles.tdAmount} ${!isIgnored && tx.amount < 0 ? 'pos' : ''}`}>
                   {fmtAmount(tx.amount)}
                 </td>

--- a/tests/queries.test.ts
+++ b/tests/queries.test.ts
@@ -12,6 +12,7 @@ import {
   getHiddenCategories,
   getRecentTransactions,
   getMerchantSummary,
+  getSearchFilteredData,
   getOwnerRows,
   hasAccounts,
   getTransactions,
@@ -341,6 +342,54 @@ describe('getMerchantSummary', () => {
     expect(rows).toHaveLength(1);
     expect(rows[0].merchant).toBe('A');
     expect(rows[0].total).toBeCloseTo(90);
+  });
+
+  it('uses merchant_name as display when display_name is null', async () => {
+    await insertTx({ amount: 80, category: 'Food & Drink', name: 'STARBUCKS #12345', merchantName: 'Starbucks' });
+    const rows = await getMerchantSummary('Food & Drink', '2025-01-01', '2025-01-31');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].merchant).toBe('Starbucks');
+  });
+
+  it('prefers display_name over merchant_name', async () => {
+    await insertTx({ amount: 50, category: 'Food & Drink', name: 'LYFT *TRIP', merchantName: 'Lyft Technologies', displayName: 'Lyft' });
+    const rows = await getMerchantSummary('Food & Drink', '2025-01-01', '2025-01-31');
+    expect(rows[0].merchant).toBe('Lyft');
+  });
+
+  it('falls back to raw name when both display_name and merchant_name are null', async () => {
+    await insertTx({ amount: 60, category: 'Food & Drink', name: 'CORNER BAKERY' });
+    const rows = await getMerchantSummary('Food & Drink', '2025-01-01', '2025-01-31');
+    expect(rows[0].merchant).toBe('CORNER BAKERY');
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────
+describe('getSearchFilteredData merchant_name fallback', () => {
+  it('matches search against merchant_name when display_name is null', async () => {
+    await insertTx({ amount: 40, category: 'Shopping', name: 'AMZN MKTP US*12345', merchantName: 'Amazon' });
+    await insertTx({ amount: 20, category: 'Shopping', name: 'TARGET 0123' });
+
+    const { summary } = await getSearchFilteredData('2025-01-01', '2025-01-31', 'Amazon');
+    expect(summary.expenses).toBeCloseTo(40);
+  });
+
+  it('does not match raw name when merchant_name overrides the display', async () => {
+    // The raw name should not be searchable once merchant_name overrides it.
+    await insertTx({ amount: 40, category: 'Shopping', name: 'AMZN MKTP US*12345', merchantName: 'Amazon' });
+
+    const { summary: byRaw } = await getSearchFilteredData('2025-01-01', '2025-01-31', 'AMZN');
+    expect(byRaw.expenses).toBe(0);
+
+    const { summary: byMerchant } = await getSearchFilteredData('2025-01-01', '2025-01-31', 'Amazon');
+    expect(byMerchant.expenses).toBeCloseTo(40);
+  });
+
+  it('still matches display_name when both are set', async () => {
+    await insertTx({ amount: 30, category: 'Travel', name: 'LYFT *RIDE', merchantName: 'Lyft Technologies', displayName: 'Lyft' });
+
+    const { summary } = await getSearchFilteredData('2025-01-01', '2025-01-31', 'Lyft');
+    expect(summary.expenses).toBeCloseTo(30);
   });
 });
 

--- a/tui/Transactions.tsx
+++ b/tui/Transactions.tsx
@@ -502,7 +502,7 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
               <Text color={isSelected ? C_ACCENT : undefined} dimColor={isIgnored && !isSelected}>
                 {tx.date}
               </Text>
-              <Text dimColor={isIgnored}>{truncate(tx.display_name ?? tx.name, descW).padEnd(descW)}</Text>
+              <Text dimColor={isIgnored}>{truncate(tx.display_name ?? tx.merchant_name ?? tx.name, descW).padEnd(descW)}</Text>
               <Text color={isIgnored ? undefined : tx.amount < 0 ? C_POSITIVE : undefined} dimColor={isIgnored}>
                 {fmt(tx.amount).padStart(10)}
               </Text>


### PR DESCRIPTION
## Summary

- Adds `merchant_name` as the middle tier in all display name chains: `display_name ?? merchant_name ?? name`
- Plaid's cleaner merchant names (e.g. "Starbucks") now surface instead of raw transaction strings (e.g. "STARBUCKS #12345 SOME STREET") when no user override exists
- Multiple transactions at "STARBUCKS #123" and "STARBUCKS #456" with the same `merchant_name` now group together in the Merchant Summary

## Changes

- `core/queries.ts`: Updated `getMerchantSummary`, `getSearchFilteredData`, `SORT_ORDER_BY`, `getTransactions`, and `countSearchMatches` to use `COALESCE(display_name, merchant_name, name)` throughout; removed now-redundant separate `merchant_name` regex tests
- `gui/renderer/src/screens/Transactions.tsx`: Updated transaction row display to use `tx.display_name ?? tx.merchant_name ?? tx.name`
- `tui/Transactions.tsx`: Updated transaction row `truncate()` call to use `tx.display_name ?? tx.merchant_name ?? tx.name`

Closes #25

## Test plan

- [ ] Verify transactions with `merchant_name` set show cleaner names in both TUI and GUI transaction lists
- [ ] Verify name sort (`name-asc`/`name-desc`) orders by effective display name including merchant_name
- [ ] Verify merchant summary groups transactions by `merchant_name` when no `display_name` is set
- [ ] Verify search matches on `merchant_name` still work (covered by the COALESCE display column)
- [ ] Verify user `display_name` overrides still take priority over `merchant_name`

🤖 Generated with [Claude Code](https://claude.com/claude-code)