### PR TITLE
feat: resync button and last-synced display on Transactions + Accounts

### DIFF
--- a/core/fmt.ts
+++ b/core/fmt.ts
@@ -46,7 +46,7 @@ export function fmtTimeAgo(ms: number | null): string {
   const diffHr = Math.floor(diffMin / 60);
   if (diffHr < 24) return `${diffHr} hr ago`;
   const diffDays = Math.floor(diffHr / 24);
-  return `${diffDays} days ago`;
+  return `${diffDays} day${diffDays === 1 ? '' : 's'} ago`;
 }
 
 export function fmtSpan(earliest: string | null, latest: string | null): string {

--- a/core/fmt.ts
+++ b/core/fmt.ts
@@ -37,6 +37,18 @@ export function fmtCompactSigned(n: number): string {
 
 // Formats a tag's date span (ISO YYYY-MM-DD bounds) down to month granularity,
 // e.g. "2024-01 → 2025-06", collapsing to a single month when they match.
+export function fmtTimeAgo(ms: number | null): string {
+  if (ms === null) return 'never';
+  const diffMs = Date.now() - ms;
+  const diffMin = Math.floor(diffMs / 60_000);
+  if (diffMin < 2) return 'just now';
+  if (diffMin < 60) return `${diffMin} min ago`;
+  const diffHr = Math.floor(diffMin / 60);
+  if (diffHr < 24) return `${diffHr} hr ago`;
+  const diffDays = Math.floor(diffHr / 24);
+  return `${diffDays} days ago`;
+}
+
 export function fmtSpan(earliest: string | null, latest: string | null): string {
   if (!earliest || !latest) return '—';
   const from = earliest.slice(0, 7);

--- a/core/queries.ts
+++ b/core/queries.ts
@@ -136,6 +136,12 @@ export async function hasAccounts(): Promise<boolean> {
   return Number((result.rows[0] as unknown as { count: number }).count) > 0;
 }
 
+export async function getLastSyncedAt(): Promise<number | null> {
+  const res = await db.execute('SELECT MAX(last_synced_at) AS ts FROM plaid_items');
+  const row = res.rows[0] as unknown as { ts: number | null };
+  return row?.ts ?? null;
+}
+
 export async function getUncategorizedCount(from: string, to: string, filter?: Filter): Promise<number> {
   const f = buildFilterClause(filter, 'transactions');
   const result = await db.execute({

--- a/gui/main/registry.ts
+++ b/gui/main/registry.ts
@@ -26,6 +26,7 @@ import {
   getAllTagRules,
   getCategoryDetails,
   toggleHiddenCategory,
+  getLastSyncedAt,
 } from '../../core/queries.js';
 import {
   setTransactionCategory,
@@ -213,6 +214,7 @@ export const registry = {
   },
   sync: {
     syncAll,
+    getLastSyncedAt,
   },
   config: {
     writeEnv: async (updates: EnvUpdates): Promise<{ written: string[] }> => {

--- a/gui/renderer/src/screens/Accounts.module.css
+++ b/gui/renderer/src/screens/Accounts.module.css
@@ -44,8 +44,14 @@
   font-weight: 600;
 }
 
-.syncBtn {
+.syncRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   margin-left: auto;
+}
+
+.syncBtn {
   padding: 6px 14px;
   border: 1px solid var(--border);
   border-radius: 6px;

--- a/gui/renderer/src/screens/Accounts.tsx
+++ b/gui/renderer/src/screens/Accounts.tsx
@@ -7,6 +7,7 @@ import type { LinkedAccount, CsvAccount } from '../../../../core/queries.js';
 import { SUBTYPE_DISPLAY, ACCOUNT_TYPES, SUBTYPES, MONTHS } from '../constants.js';
 import { useScreenKeys } from '../hooks/useScreenKeys.js';
 import { KeyHints } from '../components/KeyHints.js';
+import { fmtTimeAgo } from '../../../../core/fmt.js';
 import styles from './Accounts.module.css';
 
 type Tab = 'accounts' | 'add-data' | 'dupes';
@@ -26,6 +27,7 @@ export function Accounts() {
   const accounts = useQuery(() => api.queries.getLinkedAccounts(), [reloadKey]) ?? [];
   const dupes = useQuery(() => api.accounts.getCsvPlaidDupeCandidates(), [reloadKey]) ?? [];
   const members = useQuery(() => api.profile.getHouseholdMembers(), [reloadKey]) ?? [];
+  const lastSynced = useQuery(() => api.sync.getLastSyncedAt(), [reloadKey]);
 
   const [editAcct, setEditAcct] = useState<LinkedAccount | null>(null);
   const [valueAcct, setValueAcct] = useState<LinkedAccount | null>(null);
@@ -69,9 +71,14 @@ export function Accounts() {
             </button>
           ))}
         </div>
-        <button className={styles.syncBtn} onClick={() => void forceSync()} disabled={syncing}>
-          {syncing ? 'Syncing…' : '⟳ Sync'}
-        </button>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginLeft: 'auto' }}>
+          <button className={styles.syncBtn} onClick={() => void forceSync()} disabled={syncing} style={{ marginLeft: 0 }}>
+            {syncing ? 'Syncing…' : '⟳ Sync'}
+          </button>
+          {lastSynced !== undefined && (
+            <span className="dim">{fmtTimeAgo(lastSynced ?? null)}</span>
+          )}
+        </div>
       </div>
 
       {tab === 'accounts' && (

--- a/gui/renderer/src/screens/Accounts.tsx
+++ b/gui/renderer/src/screens/Accounts.tsx
@@ -71,8 +71,8 @@ export function Accounts() {
             </button>
           ))}
         </div>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginLeft: 'auto' }}>
-          <button className={styles.syncBtn} onClick={() => void forceSync()} disabled={syncing} style={{ marginLeft: 0 }}>
+        <div className={styles.syncRow}>
+          <button className={styles.syncBtn} onClick={() => void forceSync()} disabled={syncing}>
             {syncing ? 'Syncing…' : '⟳ Sync'}
           </button>
           {lastSynced !== undefined && (

--- a/gui/renderer/src/screens/Transactions.module.css
+++ b/gui/renderer/src/screens/Transactions.module.css
@@ -24,7 +24,6 @@
 .quickFilters {
   display: flex;
   gap: 6px;
-  margin-left: auto;
 }
 
 .qf,
@@ -44,6 +43,13 @@
 .qfActive {
   color: var(--warning);
   border-color: var(--warning);
+}
+
+.syncRow {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
 .syncBtn {

--- a/gui/renderer/src/screens/Transactions.module.css
+++ b/gui/renderer/src/screens/Transactions.module.css
@@ -46,6 +46,24 @@
   border-color: var(--warning);
 }
 
+.syncBtn {
+  padding: 5px 12px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-size: 12.5px;
+  color: var(--text-dim);
+}
+
+.syncBtn:hover:not(:disabled) {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.syncBtn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
 .chips {
   display: flex;
   gap: 8px;

--- a/gui/renderer/src/screens/Transactions.tsx
+++ b/gui/renderer/src/screens/Transactions.tsx
@@ -225,12 +225,14 @@ export function Transactions() {
             All
           </button>
         </div>
-        <button className={styles.syncBtn} onClick={() => void forceSync()} disabled={syncing}>
-          {syncing ? 'Syncing…' : '⟳ Sync'}
-        </button>
-        {lastSynced !== undefined && (
-          <span className="dim">Last synced {fmtTimeAgo(lastSynced ?? null)}</span>
-        )}
+        <div className={styles.syncRow}>
+          <button className={styles.syncBtn} onClick={() => void forceSync()} disabled={syncing}>
+            {syncing ? 'Syncing…' : '⟳ Sync'}
+          </button>
+          {lastSynced !== undefined && (
+            <span className="dim">Last synced {fmtTimeAgo(lastSynced ?? null)}</span>
+          )}
+        </div>
       </div>
 
       {(chips.length > 0 || dl) && (

--- a/gui/renderer/src/screens/Transactions.tsx
+++ b/gui/renderer/src/screens/Transactions.tsx
@@ -12,6 +12,7 @@ import { isFilterActive } from '../../../../core/filters.js';
 import { useFilter } from '../hooks/useFilter.js';
 import { useLoadGuard } from '../hooks/useLoadGuard.js';
 import type { TagOption } from '../../../../core/tags.js';
+import { fmtTimeAgo } from '../../../../core/fmt.js';
 import styles from './Transactions.module.css';
 
 function fmtAmount(amount: number) {
@@ -40,9 +41,11 @@ export function Transactions() {
   const [sort, setSort] = useState<SortMode>('date-desc');
   const [reloadKey, setReloadKey] = useState(0);
   const reload = () => setReloadKey((k) => k + 1);
+  const [syncing, setSyncing] = useState(false);
 
   const bounds = useQuery(() => api.queries.getDataBounds(), []);
   const categories = useQuery(() => api.queries.getAllCategories(), [reloadKey]) ?? [];
+  const lastSynced = useQuery(() => api.sync.getLastSyncedAt(), [reloadKey]);
   const filterOptions = useQuery(() => api.queries.getFilterOptions(), [reloadKey]);
   const { filter: sharedFilter, setFilter, popFilter, canPop } = useFilter();
   const txs =
@@ -56,6 +59,21 @@ export function Transactions() {
   const [tagTx, setTagTx] = useState<TxRow | null>(null);
   const [bulkTag, setBulkTag] = useState(false);
   const [bulkCat, setBulkCat] = useState(false);
+
+  async function forceSync() {
+    if (syncing) return;
+    setSyncing(true);
+    try {
+      const results = await api.sync.syncAll(true);
+      const added = results.reduce((s, r) => s + r.added, 0);
+      showStatus(`Sync done — ${added} new transaction${added === 1 ? '' : 's'}`, 4000);
+      reload();
+    } catch {
+      showStatus('Sync failed', 3000);
+    } finally {
+      setSyncing(false);
+    }
+  }
 
   function sortHeader(col: SortCol, label: string, alignRight = false) {
     const active = sort.startsWith(col);
@@ -207,6 +225,12 @@ export function Transactions() {
             All
           </button>
         </div>
+        <button className={styles.syncBtn} onClick={() => void forceSync()} disabled={syncing}>
+          {syncing ? 'Syncing…' : '⟳ Sync'}
+        </button>
+        {lastSynced !== undefined && (
+          <span className="dim">Last synced {fmtTimeAgo(lastSynced ?? null)}</span>
+        )}
       </div>
 
       {(chips.length > 0 || dl) && (

--- a/tests/fmt.test.ts
+++ b/tests/fmt.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { fmt, fmtSigned, fmtPct, fmtMonths, fmtCompact } from '../core/fmt.js';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { fmt, fmtSigned, fmtPct, fmtMonths, fmtCompact, fmtTimeAgo } from '../core/fmt.js';
 import { bar, truncate } from '../tui/charUtils.js';
 
 describe('fmt', () => {
@@ -128,5 +128,48 @@ describe('truncate', () => {
 
   it('truncates strings over the limit with ellipsis', () => {
     expect(truncate('hello world', 8)).toBe('hello w…');
+  });
+});
+
+describe('fmtTimeAgo', () => {
+  afterEach(() => vi.useRealTimers());
+
+  it('returns "never" for null', () => {
+    expect(fmtTimeAgo(null)).toBe('never');
+  });
+
+  it('returns "just now" for under 2 minutes ago', () => {
+    vi.useFakeTimers();
+    const now = Date.now();
+    vi.setSystemTime(now + 90_000); // 90 seconds later
+    expect(fmtTimeAgo(now)).toBe('just now');
+  });
+
+  it('returns minutes for 2–59 minutes ago', () => {
+    vi.useFakeTimers();
+    const now = Date.now();
+    vi.setSystemTime(now + 5 * 60_000);
+    expect(fmtTimeAgo(now)).toBe('5 min ago');
+  });
+
+  it('returns hours for 1–23 hours ago', () => {
+    vi.useFakeTimers();
+    const now = Date.now();
+    vi.setSystemTime(now + 3 * 60 * 60_000);
+    expect(fmtTimeAgo(now)).toBe('3 hr ago');
+  });
+
+  it('returns singular "day" for exactly 1 day ago', () => {
+    vi.useFakeTimers();
+    const now = Date.now();
+    vi.setSystemTime(now + 24 * 60 * 60_000);
+    expect(fmtTimeAgo(now)).toBe('1 day ago');
+  });
+
+  it('returns plural "days" for multiple days ago', () => {
+    vi.useFakeTimers();
+    const now = Date.now();
+    vi.setSystemTime(now + 5 * 24 * 60 * 60_000);
+    expect(fmtTimeAgo(now)).toBe('5 days ago');
   });
 });

--- a/tests/queries.test.ts
+++ b/tests/queries.test.ts
@@ -12,6 +12,7 @@ import {
   getHiddenCategories,
   getRecentTransactions,
   getMerchantSummary,
+  getLastSyncedAt,
   getOwnerRows,
   hasAccounts,
   getTransactions,
@@ -480,6 +481,48 @@ describe('hasAccounts', () => {
       args: [],
     });
     expect(await hasAccounts()).toBe(true);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────
+describe('getLastSyncedAt', () => {
+  beforeEach(async () => {
+    await db.execute('DELETE FROM plaid_items');
+  });
+
+  it('returns null when no plaid_items exist', async () => {
+    expect(await getLastSyncedAt()).toBeNull();
+  });
+
+  it('returns null when items exist but last_synced_at is unset', async () => {
+    await db.execute({
+      sql: "INSERT INTO plaid_items (item_id, access_token) VALUES ('i1', 'tok')",
+      args: [],
+    });
+    expect(await getLastSyncedAt()).toBeNull();
+  });
+
+  it('returns the timestamp when one item has been synced', async () => {
+    const ts = Date.now();
+    await db.execute({
+      sql: "INSERT INTO plaid_items (item_id, access_token, last_synced_at) VALUES ('i1', 'tok', ?)",
+      args: [ts],
+    });
+    expect(await getLastSyncedAt()).toBe(ts);
+  });
+
+  it('returns the maximum last_synced_at across multiple items', async () => {
+    const older = Date.now() - 60_000;
+    const newer = Date.now();
+    await db.execute({
+      sql: "INSERT INTO plaid_items (item_id, access_token, last_synced_at) VALUES ('i1', 'tok1', ?)",
+      args: [older],
+    });
+    await db.execute({
+      sql: "INSERT INTO plaid_items (item_id, access_token, last_synced_at) VALUES ('i2', 'tok2', ?)",
+      args: [newer],
+    });
+    expect(await getLastSyncedAt()).toBe(newer);
   });
 });
 

--- a/tui/Transactions.tsx
+++ b/tui/Transactions.tsx
@@ -67,7 +67,6 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
   const [mode, setMode] = useState<Mode>('list');
   const { statusMsg, showStatus } = useStatusMessage();
   const [categories, setCategories] = useState<string[]>([]);
-  const [syncMsg, setSyncMsg] = useState<string | null>(null);
   const [syncing, setSyncing] = useState(false);
 
   // Edit panel state
@@ -406,10 +405,10 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
         syncAll(true)
           .then((results) => {
             const added = results.reduce((s, r) => s + r.added, 0);
-            setSyncMsg(`Synced — ${added} new`);
+            showStatus(`Synced — ${added} new`, 3000);
             load(search, true);
           })
-          .catch(() => setSyncMsg('Sync failed'))
+          .catch(() => showStatus('Sync failed', 3000))
           .finally(() => setSyncing(false));
         return;
       }
@@ -535,7 +534,6 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
       <Divider />
       <Text dimColor>{txs.length} transactions{txs.length === 200 ? ' (limit 200)' : ''}</Text>
       {statusMsg && <Text color={C_POSITIVE}>{statusMsg}</Text>}
-      {syncMsg && <Text color={C_POSITIVE}>{syncMsg}</Text>}
 
       {mode === 'tag' && selected && (
         <ModalPanel borderColor={C_WARNING}>

--- a/tui/Transactions.tsx
+++ b/tui/Transactions.tsx
@@ -6,6 +6,7 @@ import {
   upsertCategoryRule, upsertNameRule,
   setTransactionCategoryBulk, clearOverridesBulk, setIgnoredBulk,
 } from '../core/transactions.js';
+import { syncAll } from '../core/sync.js';
 import {
   getTagOptions, getTransactionTagIds, getOrCreateTag,
   addTagToTransaction, removeTagFromTransaction, addTagToTransactions,
@@ -66,6 +67,8 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
   const [mode, setMode] = useState<Mode>('list');
   const { statusMsg, showStatus } = useStatusMessage();
   const [categories, setCategories] = useState<string[]>([]);
+  const [syncMsg, setSyncMsg] = useState<string | null>(null);
+  const [syncing, setSyncing] = useState(false);
 
   // Edit panel state
   const [editField, setEditField] = useState<EditField>('name');
@@ -398,6 +401,18 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
         load(search);
         return;
       }
+      if (input === 'S' && !syncing) {
+        setSyncing(true);
+        syncAll(true)
+          .then((results) => {
+            const added = results.reduce((s, r) => s + r.added, 0);
+            setSyncMsg(`Synced — ${added} new`);
+            load(search, true);
+          })
+          .catch(() => setSyncMsg('Sync failed'))
+          .finally(() => setSyncing(false));
+        return;
+      }
     }
   }, { isActive: isActive !== false });
 
@@ -461,7 +476,7 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
       </Box>
       <Text dimColor>
         {showHints
-          ? `[/] search  ·  [f] filter  ·  ${from ? '← →  ·  ' : ''}[s] sort  ·  Enter edit  [g] tag  [i] ignore  [x] delete`
+          ? `[/] search  ·  [f] filter  ·  ${from ? '← →  ·  ' : ''}[s] sort  ·  Enter edit  [g] tag  [i] ignore  [x] delete  ·  [S] sync`
           : '[/] search'}
       </Text>
 
@@ -520,6 +535,7 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
       <Divider />
       <Text dimColor>{txs.length} transactions{txs.length === 200 ? ' (limit 200)' : ''}</Text>
       {statusMsg && <Text color={C_POSITIVE}>{statusMsg}</Text>}
+      {syncMsg && <Text color={C_POSITIVE}>{syncMsg}</Text>}
 
       {mode === 'tag' && selected && (
         <ModalPanel borderColor={C_WARNING}>

--- a/tui/Transactions.tsx
+++ b/tui/Transactions.tsx
@@ -14,13 +14,14 @@ import {
 } from '../core/tags.js';
 import { applyCategoriesToAll } from '../core/categorize.js';
 import { countPatternMatches } from '../core/rule-utils.js';
-import { getTransactions, getAllCategories, getDataBounds, type TxRow, type SortMode } from '../core/queries.js';
+import { getTransactions, getAllCategories, getDataBounds, getLastSyncedAt, type TxRow, type SortMode } from '../core/queries.js';
 import { isFilterActive, filterSummary } from '../core/filters.js';
 import type { Screen, TxFilter } from './App.js';
 import { useFilter } from './FilterContext.js';
 import { useLoadGuard } from './useLoadGuard.js';
 import { handleNavKey } from './nav.js';
 import { Divider } from './fmt.js';
+import { fmtTimeAgo } from '../core/fmt.js';
 import { useTerminalWidth, MONTHS, C_POSITIVE, C_NEGATIVE, C_WARNING, C_NEUTRAL, C_MANUAL, C_ACCENT, C_DIM } from './ui.js';
 import { ModalPanel, usePagination, TextInput, SelectableRow, useStatusMessage, PageHeader, SearchBar, EditTextField, EditToggleField } from './components/index.js';
 import { useRefreshKey } from './RefreshContext.js';
@@ -68,6 +69,7 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
   const { statusMsg, showStatus } = useStatusMessage();
   const [categories, setCategories] = useState<string[]>([]);
   const [syncing, setSyncing] = useState(false);
+  const [lastSynced, setLastSynced] = useState<number | null>(null);
 
   // Edit panel state
   const [editField, setEditField] = useState<EditField>('name');
@@ -96,7 +98,7 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
     });
   }
 
-  useEffect(() => { void getDataBounds().then(setBounds); void getAllCategories().then(setCategories); }, []);
+  useEffect(() => { void getDataBounds().then(setBounds); void getAllCategories().then(setCategories); void getLastSyncedAt().then(setLastSynced); }, [refreshKey]);
   useEffect(() => { load(); }, [from, to, search, sort, txType, flex, sharedFilter, refreshKey]);
 
   const setTyping = useSetTyping();
@@ -407,6 +409,7 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
             const added = results.reduce((s, r) => s + r.added, 0);
             showStatus(`Synced — ${added} new`, 3000);
             load(search, true);
+            void getLastSyncedAt().then(setLastSynced);
           })
           .catch(() => showStatus('Sync failed', 3000))
           .finally(() => setSyncing(false));
@@ -465,6 +468,7 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
         <Text bold>
           Transactions
           {filterLabel ? <Text color={C_WARNING}>  {filterLabel}</Text> : null}
+          <Text dimColor>{'  · '}{syncing ? 'syncing…' : `last synced ${fmtTimeAgo(lastSynced)}`}</Text>
           {dl ? <Text>
             <Text color={C_WARNING}>{filterLabel ? '  · ' : '  '}</Text>
             <Text dimColor>← </Text>


### PR DESCRIPTION
## Summary

Implements #21 — Plaid sync health warnings across TUI and GUI.

- **`core/fmt.ts`**: adds `fmtTimeAgo(ms)` — "just now" / "X min ago" / "X hr ago" / "X days ago" / "never"
- **`core/queries.ts`**: adds `getLastSyncedAt()` — queries `MAX(last_synced_at)` from `plaid_items`
- **`gui/main/registry.ts`**: exposes `getLastSyncedAt` in the `sync` namespace
- **`gui/renderer/src/screens/Transactions.tsx`**: adds `⟳ Sync` button + "Last synced X ago" label in the top bar
- **`gui/renderer/src/screens/Accounts.tsx`**: adds "Last synced X ago" span next to the existing sync button
- **`tui/Transactions.tsx`**: adds `[S]` keybinding to trigger a sync and displays the result below the divider

## Test plan

- [ ] `fmtTimeAgo(null)` returns `"never"`
- [ ] `fmtTimeAgo(Date.now())` returns `"just now"`
- [ ] `fmtTimeAgo(Date.now() - 5 * 60_000)` returns `"5 min ago"`
- [ ] GUI Transactions screen shows `⟳ Sync` button; clicking it syncs and shows result count
- [ ] GUI Accounts screen shows last synced time next to the sync button
- [ ] TUI Transactions: pressing `S` triggers sync and shows "Synced — N new" message
- [ ] "Last synced" label only appears once `getLastSyncedAt` resolves (not while loading)
- [ ] Works correctly when no Plaid items exist (shows "never")

🤖 Generated with [Claude Code](https://claude.com/claude-code)