### PR TITLE
feat: persisted pretax contribution dial on Health page

### DIFF
--- a/core/agent-context.ts
+++ b/core/agent-context.ts
@@ -6,6 +6,7 @@
 
 import { db } from './db.js';
 import { yearsToFire } from './health.js';
+import { getSetting, PRETAX_MONTHLY_KEY } from './settings.js';
 import { isAssetAccount, isLiabilityAccount } from './account-class.js';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -41,12 +42,16 @@ export type FinancialHealth = {
   retirement: number;
   loanDebt: number;
   avgMonthlyExpenses: number;
+  avgMonthlyIncome: number;
   avgMonthlySavings: number;
+  pretaxMonthly: number;       // from settings; 401k/HSA not in transactions
+  grossMonthlyIncome: number;  // avgMonthlyIncome + pretaxMonthly
+  savingsRate: number | null;  // (avgMonthlySavings + pretax) / grossIncome
   cashRunwayMonths: number;
   liquidRunwayMonths: number;
   fireNumber: number;          // at 4% withdrawal
   fireProgress: number;        // 0–1 ratio
-  yearsToFire: number | null;  // null = >100 years
+  yearsToFire: number | null;  // null = >100 years; includes pretax in savings
 };
 
 export type MonthlyTrendRow = {
@@ -150,24 +155,34 @@ export async function getFinancialHealth(
 ): Promise<FinancialHealth> {
   const balances = await getBalances();
 
-  const expResult = await db.execute(`
-    SELECT
-      COALESCE(SUM(CASE WHEN amount > 0 THEN amount ELSE 0 END), 0) / 12.0 AS avg_expenses,
-      COALESCE(
-        -SUM(CASE WHEN amount < 0 THEN amount ELSE 0 END) -
-         SUM(CASE WHEN amount > 0 THEN amount ELSE 0 END),
-        0
-      ) / 12.0 AS avg_savings
-    FROM transactions
-    WHERE date >= date('now', '-12 months')
-      AND pending = 0 AND ignored = 0
-      AND category NOT IN (SELECT category FROM hidden_categories)
-      AND category != 'Transfer'
-  `);
-  const expRow = expResult.rows[0] as unknown as { avg_expenses: number; avg_savings: number };
+  const [expResult, pretaxRaw] = await Promise.all([
+    db.execute(`
+      SELECT
+        COALESCE(SUM(CASE WHEN amount > 0 THEN amount ELSE 0 END), 0) / 12.0 AS avg_expenses,
+        COALESCE(-SUM(CASE WHEN amount < 0 THEN amount ELSE 0 END), 0) / 12.0 AS avg_income,
+        COALESCE(
+          -SUM(CASE WHEN amount < 0 THEN amount ELSE 0 END) -
+           SUM(CASE WHEN amount > 0 THEN amount ELSE 0 END),
+          0
+        ) / 12.0 AS avg_savings
+      FROM transactions
+      WHERE date >= date('now', '-12 months')
+        AND pending = 0 AND ignored = 0
+        AND category NOT IN (SELECT category FROM hidden_categories)
+        AND category != 'Transfer'
+    `),
+    getSetting(PRETAX_MONTHLY_KEY),
+  ]);
+  const expRow = expResult.rows[0] as unknown as { avg_expenses: number; avg_income: number; avg_savings: number };
 
   const avgMonthlyExpenses = Number(expRow.avg_expenses);
+  const avgMonthlyIncome   = Number(expRow.avg_income);
   const avgMonthlySavings  = Number(expRow.avg_savings);
+  const pretaxMonthly      = pretaxRaw ? parseFloat(pretaxRaw) : 0;
+  const grossMonthlyIncome = avgMonthlyIncome + pretaxMonthly;
+  const savingsRate        = grossMonthlyIncome > 0
+    ? ((avgMonthlySavings + pretaxMonthly) / grossMonthlyIncome) * 100
+    : null;
 
   const cashRunwayMonths   = avgMonthlyExpenses > 0 ? balances.cash   / avgMonthlyExpenses : 0;
   const liquidRunwayMonths = avgMonthlyExpenses > 0 ? balances.liquid / avgMonthlyExpenses : 0;
@@ -176,7 +191,7 @@ export async function getFinancialHealth(
   const fireNumber  = annualSpend / (withdrawalRate / 100);
   const fireProgress = fireNumber > 0 ? Math.max(0, balances.netWorth) / fireNumber : 0;
   const yearsToFireVal = yearsToFire(
-    balances.netWorth, avgMonthlySavings, fireNumber, annualGrowthPct
+    balances.netWorth, avgMonthlySavings + pretaxMonthly, fireNumber, annualGrowthPct
   );
 
   return {
@@ -186,7 +201,11 @@ export async function getFinancialHealth(
     retirement: balances.retirement,
     loanDebt: balances.loanDebt,
     avgMonthlyExpenses,
+    avgMonthlyIncome,
     avgMonthlySavings,
+    pretaxMonthly,
+    grossMonthlyIncome,
+    savingsRate,
     cashRunwayMonths,
     liquidRunwayMonths,
     fireNumber,

--- a/core/settings.ts
+++ b/core/settings.ts
@@ -7,6 +7,9 @@ export const MAX_DAYS_REQUESTED = 730;
 /** Settings key for the user's default Plaid history start date (YYYY-MM-DD). */
 export const DEFAULT_START_DATE_KEY = 'plaid_default_start_date';
 
+/** Settings key for the user's monthly pre-tax contributions (401k, HSA, etc.) in dollars. */
+export const PRETAX_MONTHLY_KEY = 'pretax_monthly';
+
 /**
  * Extra days added on top of the start-date calculation. Plaid's docs don't
  * specify the timezone used to compute the history window, so a small buffer

--- a/core/tools.ts
+++ b/core/tools.ts
@@ -559,16 +559,19 @@ async function executeToolImpl(
         input['growth_rate']     ? num('growth_rate')     : 7,
       );
       const fmtM = (n: number) => Number.isFinite(n) && n < 999 ? `${n.toFixed(1)} months` : '∞';
+      const hasPretax = h.pretaxMonthly > 0;
       return [
         `Net worth: ${h.netWorth >= 0 ? '' : '-'}${fmt(h.netWorth, 0)}`,
         `Cash runway: ${fmtM(h.cashRunwayMonths)} (${fmt(h.cash, 0)} in checking/savings)`,
         `Liquid runway: ${fmtM(h.liquidRunwayMonths)} (${fmt(h.liquid, 0)} incl. brokerage)`,
         `Avg monthly expenses (12 mo): ${fmt(h.avgMonthlyExpenses, 0)}`,
-        `Avg monthly savings (12 mo): ${fmt(h.avgMonthlySavings, 0)}`,
+        `Avg monthly income (12 mo): ${fmt(h.avgMonthlyIncome, 0)} take-home${hasPretax ? ` · ${fmt(h.grossMonthlyIncome, 0)} gross (incl. ${fmt(h.pretaxMonthly, 0)}/mo pretax)` : ''}`,
+        `Avg monthly savings (12 mo): ${fmt(h.avgMonthlySavings, 0)} take-home${hasPretax ? ` · ${fmt(h.avgMonthlySavings + h.pretaxMonthly, 0)} gross (incl. pretax)` : ''}`,
+        h.savingsRate !== null ? `Savings rate: ${h.savingsRate.toFixed(1)}%${hasPretax ? ` incl. pretax (${((h.avgMonthlySavings / h.grossMonthlyIncome) * 100).toFixed(1)}% take-home only)` : ''}` : null,
         `FIRE number: ${fmt(h.fireNumber, 0)}`,
         `FIRE progress: ${(h.fireProgress * 100).toFixed(1)}%`,
-        `Years to FIRE: ${h.yearsToFire === null ? '100+' : h.yearsToFire === 0 ? 'Achieved!' : `~${Math.ceil(h.yearsToFire)}`}`,
-      ].join('\n');
+        `Years to FIRE: ${h.yearsToFire === null ? '100+' : h.yearsToFire === 0 ? 'Achieved!' : `~${Math.ceil(h.yearsToFire)}`}${hasPretax ? ' (pretax contributions included in savings rate)' : ''}`,
+      ].filter(Boolean).join('\n');
     }
 
     case 'get_scorecard': {

--- a/gui/main/registry.ts
+++ b/gui/main/registry.ts
@@ -66,6 +66,7 @@ import {
   renameCategory,
 } from '../../core/rules.js';
 import { loadHealthData, yearsToFire, coastYears } from '../../core/health.js';
+import { getSetting, setSetting } from '../../core/settings.js';
 import {
   buildTrendViews,
   getPeriodTotals,
@@ -228,5 +229,9 @@ export const registry = {
       const { written } = writeEnvFile(updates);
       return { written };
     },
+  },
+  settings: {
+    getSetting,
+    setSetting,
   },
 } as const;

--- a/gui/main/registry.ts
+++ b/gui/main/registry.ts
@@ -66,7 +66,7 @@ import {
   renameCategory,
 } from '../../core/rules.js';
 import { loadHealthData, yearsToFire, coastYears } from '../../core/health.js';
-import { getSetting, setSetting } from '../../core/settings.js';
+import { getSetting, setSetting, PRETAX_MONTHLY_KEY } from '../../core/settings.js';
 import {
   buildTrendViews,
   getPeriodTotals,
@@ -231,7 +231,7 @@ export const registry = {
     },
   },
   settings: {
-    getSetting,
-    setSetting,
+    getPretaxMonthly: () => getSetting(PRETAX_MONTHLY_KEY),
+    setPretaxMonthly: (v: string) => setSetting(PRETAX_MONTHLY_KEY, v),
   },
 } as const;

--- a/gui/renderer/src/screens/Health.tsx
+++ b/gui/renderer/src/screens/Health.tsx
@@ -80,7 +80,8 @@ export function Health() {
   const cashMonths = spend > 0 ? data.cash / spend : 0;
   const liquidMonths = spend > 0 ? data.liquid / spend : 0;
   const fireProgress = fireNumber > 0 ? Math.max(0, data.netWorth) / fireNumber : 0;
-  const savingsRate = data.monthlyIncome > 0 ? ((savings + pretax) / data.monthlyIncome) * 100 : null;
+  const grossIncome = data.monthlyIncome + pretax;
+  const savingsRate = grossIncome > 0 ? ((savings + pretax) / grossIncome) * 100 : null;
   const netCash = data.cash - data.totalDebt;
   const remainingDebt = Math.max(0, data.totalDebt - data.cash);
   const debtMonths = savings > 0 ? remainingDebt / savings : null;
@@ -117,7 +118,7 @@ export function Health() {
           </div>
           <div className={styles.metric}>
             <span className={styles.metricLabel}>Monthly income</span>
-            <span className={`num ${styles.metricValue}`}>{fmt(data.monthlyIncome)}</span>
+            <span className={`num ${styles.metricValue}`}>{fmt(grossIncome)}</span>
             <span className={`dim ${styles.metricHint}`}>avg past 12 months</span>
           </div>
         </section>

--- a/gui/renderer/src/screens/Health.tsx
+++ b/gui/renderer/src/screens/Health.tsx
@@ -82,6 +82,7 @@ export function Health() {
   const fireProgress = fireNumber > 0 ? Math.max(0, data.netWorth) / fireNumber : 0;
   const grossIncome = data.monthlyIncome + pretax;
   const savingsRate = grossIncome > 0 ? ((savings + pretax) / grossIncome) * 100 : null;
+  const rawSavingsRate = data.monthlyIncome > 0 ? (savings / data.monthlyIncome) * 100 : null;
   const netCash = data.cash - data.totalDebt;
   const remainingDebt = Math.max(0, data.totalDebt - data.cash);
   const debtMonths = savings > 0 ? remainingDebt / savings : null;
@@ -113,13 +114,17 @@ export function Health() {
                       : savingsRate >= 50
                         ? 'FIRE pace'
                         : 'on track'}
-              {savingsRate !== null && pretax > 0 ? ` (+${fmt(pretax)}/mo pretax)` : ''}
+              {savingsRate !== null && pretax > 0 && rawSavingsRate !== null
+                ? ` (${fmtPct(rawSavingsRate)} take-home)`
+                : ''}
             </span>
           </div>
           <div className={styles.metric}>
             <span className={styles.metricLabel}>Monthly income</span>
             <span className={`num ${styles.metricValue}`}>{fmt(grossIncome)}</span>
-            <span className={`dim ${styles.metricHint}`}>avg past 12 months</span>
+            <span className={`dim ${styles.metricHint}`}>
+              avg past 12 months{pretax > 0 ? ` (${fmt(data.monthlyIncome)} take-home)` : ''}
+            </span>
           </div>
         </section>
 

--- a/gui/renderer/src/screens/Health.tsx
+++ b/gui/renderer/src/screens/Health.tsx
@@ -5,6 +5,7 @@ import { useNav } from '../hooks/useNav.js';
 import { fmt, fmtSigned, fmtPct, fmtMonths, fmtCompact } from '../../../../core/fmt.js';
 import { getDriftWindows, getPeriodStart } from '../../../../core/dateUtils.js';
 import { bucketDrift } from '../../../../core/scorecard.js';
+import { PRETAX_MONTHLY_KEY } from '../../../../core/settings.js';
 import { KeyHints } from '../components/KeyHints.js';
 import styles from './Health.module.css';
 
@@ -49,13 +50,20 @@ export function Health() {
 
   const [monthlySpend, setMonthlySpend] = useState<number | null>(null);
   const [monthlySavings, setMonthlySavings] = useState<number | null>(null);
+  const [pretaxSavings, setPretaxSavings] = useState<number | null>(null);
   const [withdrawal, setWithdrawal] = useState(DEFAULT_WITHDRAWAL);
   const [growth, setGrowth] = useState(DEFAULT_GROWTH);
+
+  const pretaxRaw = useQuery(() => api.settings.getSetting(PRETAX_MONTHLY_KEY), []);
+  useEffect(() => {
+    if (pretaxRaw !== undefined) setPretaxSavings(pretaxRaw ? roundToStep(parseFloat(pretaxRaw)) : 0);
+  }, [pretaxRaw]);
 
   const defaultSpend = data ? Math.max(SPEND_STEP, roundToStep(data.avgMonthlyExpenses)) : SPEND_STEP;
   const defaultSavings = data ? roundToStep(data.monthlySavings) : 0;
   const spend = monthlySpend ?? defaultSpend;
   const savings = monthlySavings ?? defaultSavings;
+  const pretax = pretaxSavings ?? 0;
 
   const annualSpend = spend * 12;
   const fireNumber = annualSpend / (withdrawal / 100);
@@ -64,16 +72,16 @@ export function Health() {
   const [coast, setCoast] = useState<number | null>(null);
   useEffect(() => {
     if (!data) return;
-    void api.health.yearsToFire(data.netWorth, savings, fireNumber, growth).then(setYears);
+    void api.health.yearsToFire(data.netWorth, savings + pretax, fireNumber, growth).then(setYears);
     void api.health.coastYears(data.netWorth, fireNumber, growth).then(setCoast);
-  }, [data, savings, fireNumber, growth]);
+  }, [data, savings, pretax, fireNumber, growth]);
 
   if (!data) return <p className="dim">Loading…</p>;
 
   const cashMonths = spend > 0 ? data.cash / spend : 0;
   const liquidMonths = spend > 0 ? data.liquid / spend : 0;
   const fireProgress = fireNumber > 0 ? Math.max(0, data.netWorth) / fireNumber : 0;
-  const savingsRate = data.monthlyIncome > 0 ? (savings / data.monthlyIncome) * 100 : null;
+  const savingsRate = data.monthlyIncome > 0 ? ((savings + pretax) / data.monthlyIncome) * 100 : null;
   const netCash = data.cash - data.totalDebt;
   const remainingDebt = Math.max(0, data.totalDebt - data.cash);
   const debtMonths = savings > 0 ? remainingDebt / savings : null;
@@ -105,6 +113,7 @@ export function Health() {
                       : savingsRate >= 50
                         ? 'FIRE pace'
                         : 'on track'}
+              {pretax > 0 ? ` (+${fmt(pretax)}/mo pretax)` : ''}
             </span>
           </div>
           <div className={styles.metric}>
@@ -252,6 +261,21 @@ export function Health() {
             signed
             onChange={setMonthlySavings}
             onReset={() => setMonthlySavings(null)}
+          />
+          <DollarDial
+            label="Monthly pretax savings"
+            value={pretax}
+            defaultValue={0}
+            min={0}
+            hint="401k/HSA — not in transactions"
+            onChange={(v) => {
+              setPretaxSavings(Math.max(0, v));
+              void api.settings.setSetting(PRETAX_MONTHLY_KEY, String(Math.max(0, v)));
+            }}
+            onReset={() => {
+              setPretaxSavings(0);
+              void api.settings.setSetting(PRETAX_MONTHLY_KEY, '0');
+            }}
           />
           <SliderDial
             label="Withdrawal rate"

--- a/gui/renderer/src/screens/Health.tsx
+++ b/gui/renderer/src/screens/Health.tsx
@@ -5,7 +5,6 @@ import { useNav } from '../hooks/useNav.js';
 import { fmt, fmtSigned, fmtPct, fmtMonths, fmtCompact } from '../../../../core/fmt.js';
 import { getDriftWindows, getPeriodStart } from '../../../../core/dateUtils.js';
 import { bucketDrift } from '../../../../core/scorecard.js';
-import { PRETAX_MONTHLY_KEY } from '../../../../core/settings.js';
 import { KeyHints } from '../components/KeyHints.js';
 import styles from './Health.module.css';
 
@@ -54,7 +53,7 @@ export function Health() {
   const [withdrawal, setWithdrawal] = useState(DEFAULT_WITHDRAWAL);
   const [growth, setGrowth] = useState(DEFAULT_GROWTH);
 
-  const pretaxRaw = useQuery(() => api.settings.getSetting(PRETAX_MONTHLY_KEY), []);
+  const pretaxRaw = useQuery(() => api.settings.getPretaxMonthly(), []);
   useEffect(() => {
     if (pretaxRaw !== undefined) setPretaxSavings(pretaxRaw ? roundToStep(parseFloat(pretaxRaw)) : 0);
   }, [pretaxRaw]);
@@ -113,7 +112,7 @@ export function Health() {
                       : savingsRate >= 50
                         ? 'FIRE pace'
                         : 'on track'}
-              {pretax > 0 ? ` (+${fmt(pretax)}/mo pretax)` : ''}
+              {savingsRate !== null && pretax > 0 ? ` (+${fmt(pretax)}/mo pretax)` : ''}
             </span>
           </div>
           <div className={styles.metric}>
@@ -270,11 +269,11 @@ export function Health() {
             hint="401k/HSA — not in transactions"
             onChange={(v) => {
               setPretaxSavings(Math.max(0, v));
-              void api.settings.setSetting(PRETAX_MONTHLY_KEY, String(Math.max(0, v)));
+              void api.settings.setPretaxMonthly(String(Math.max(0, v)));
             }}
             onReset={() => {
               setPretaxSavings(0);
-              void api.settings.setSetting(PRETAX_MONTHLY_KEY, '0');
+              void api.settings.setPretaxMonthly('0');
             }}
           />
           <SliderDial

--- a/tests/settings-db.test.ts
+++ b/tests/settings-db.test.ts
@@ -7,7 +7,7 @@ vi.mock('../core/db.js', async () => {
 
 import {
   getSetting, setSetting, getDefaultDaysRequested,
-  DEFAULT_START_DATE_KEY, MAX_DAYS_REQUESTED,
+  DEFAULT_START_DATE_KEY, MAX_DAYS_REQUESTED, PRETAX_MONTHLY_KEY,
 } from '../core/settings.js';
 
 describe('getSetting / setSetting', () => {
@@ -35,5 +35,29 @@ describe('getDefaultDaysRequested', () => {
   it('returns MAX_DAYS_REQUESTED for a date farther back than 730 days', async () => {
     await setSetting(DEFAULT_START_DATE_KEY, '2020-01-01');
     expect(await getDefaultDaysRequested()).toBe(MAX_DAYS_REQUESTED);
+  });
+});
+
+describe('PRETAX_MONTHLY_KEY', () => {
+  it('returns null when no pretax contribution is set', async () => {
+    expect(await getSetting(PRETAX_MONTHLY_KEY)).toBeNull();
+  });
+
+  it('stores and retrieves a pretax monthly value', async () => {
+    await setSetting(PRETAX_MONTHLY_KEY, '500');
+    expect(await getSetting(PRETAX_MONTHLY_KEY)).toBe('500');
+  });
+
+  it('upserts — updating the dial replaces the previous value', async () => {
+    await setSetting(PRETAX_MONTHLY_KEY, '400');
+    await setSetting(PRETAX_MONTHLY_KEY, '600');
+    expect(await getSetting(PRETAX_MONTHLY_KEY)).toBe('600');
+  });
+
+  it('persists independently of other settings keys', async () => {
+    await setSetting(PRETAX_MONTHLY_KEY, '350');
+    await setSetting(DEFAULT_START_DATE_KEY, '2023-01-01');
+    expect(await getSetting(PRETAX_MONTHLY_KEY)).toBe('350');
+    expect(await getSetting(DEFAULT_START_DATE_KEY)).toBe('2023-01-01');
   });
 });

--- a/tui/Health.tsx
+++ b/tui/Health.tsx
@@ -4,6 +4,7 @@ import type { Screen } from './App.js';
 import { fmt, fmtSigned, fmtPct, fmtMonths, fmtCompact, Divider } from './fmt.js';
 import { handleNavKey } from './nav.js';
 import { loadHealthData, yearsToFire, coastYears, type HealthData } from '../core/health.js';
+import { getSetting, setSetting, PRETAX_MONTHLY_KEY } from '../core/settings.js';
 import { getCategoryDriftData } from '../core/queries.js';
 import { getDriftWindows, getPeriodStart } from '../core/dateUtils.js';
 import { bucketDrift, type Scorecard } from '../core/scorecard.js';
@@ -32,7 +33,7 @@ const WITHDRAW_STEP         = 0.5;
 const GROWTH_STEP           = 1.0;
 const PROGRESS_BAR_WIDTH    = 22;
 
-const DIALS = ['spend', 'savings', 'withdrawal', 'growth'] as const;
+const DIALS = ['spend', 'savings', 'pretax', 'withdrawal', 'growth'] as const;
 type Dial = typeof DIALS[number];
 
 function progressBar(ratio: number, width = PROGRESS_BAR_WIDTH) {
@@ -51,14 +52,16 @@ export function Health({ onNavigate, isActive, showHints }: { onNavigate: (s: Sc
   const [dialIdx, setDialIdx]           = useState(0);
   const [monthlySpend, setMonthlySpend] = useState(SPEND_STEP);
   const [monthlySavings, setMonthlySavings] = useState(0);
+  const [pretaxSavings, setPretaxSavings] = useState(0);
   const [editMode, setEditMode]         = useState(false);
   const [editBuffer, setEditBuffer]     = useState('');
 
   useEffect(() => {
-    void loadHealthData().then((d) => {
+    void Promise.all([loadHealthData(), getSetting(PRETAX_MONTHLY_KEY)]).then(([d, pretax]) => {
       setData(d);
       setMonthlySpend(Math.max(SPEND_STEP, Math.round(d.avgMonthlyExpenses / SPEND_STEP) * SPEND_STEP));
       setMonthlySavings(Math.round(d.monthlySavings / SPEND_STEP) * SPEND_STEP);
+      setPretaxSavings(pretax ? Math.round(parseFloat(pretax) / SPEND_STEP) * SPEND_STEP : 0);
     });
   }, [refreshKey]);
 
@@ -80,6 +83,7 @@ export function Health({ onNavigate, isActive, showHints }: { onNavigate: (s: Sc
   function currentDialValueStr(): string {
     if (currentDial === 'spend')      return String(monthlySpend);
     if (currentDial === 'savings')    return String(monthlySavings);
+    if (currentDial === 'pretax')     return String(pretaxSavings);
     if (currentDial === 'withdrawal') return String(withdrawal);
     if (currentDial === 'growth')     return String(growth);
     return '';
@@ -90,6 +94,11 @@ export function Health({ onNavigate, isActive, showHints }: { onNavigate: (s: Sc
     if (!isNaN(n)) {
       if (currentDial === 'spend')      setMonthlySpend(Math.max(SPEND_STEP, Math.round(n / SPEND_STEP) * SPEND_STEP));
       if (currentDial === 'savings')    setMonthlySavings(Math.round(n / SPEND_STEP) * SPEND_STEP);
+      if (currentDial === 'pretax') {
+        const newValue = Math.max(0, Math.round(n / SPEND_STEP) * SPEND_STEP);
+        setPretaxSavings(newValue);
+        void setSetting(PRETAX_MONTHLY_KEY, String(newValue));
+      }
       if (currentDial === 'withdrawal') setWithdrawal(parseFloat(Math.min(10, Math.max(0.5, n)).toFixed(1)));
       if (currentDial === 'growth')     setGrowth(parseFloat(Math.min(20, Math.max(0, n)).toFixed(1)));
     }
@@ -121,6 +130,13 @@ export function Health({ onNavigate, isActive, showHints }: { onNavigate: (s: Sc
     if (key.rightArrow) {
       if (currentDial === 'spend')      setMonthlySpend((s) => s + SPEND_STEP);
       if (currentDial === 'savings')    setMonthlySavings((s) => s + SPEND_STEP);
+      if (currentDial === 'pretax') {
+        setPretaxSavings((s) => {
+          const newValue = s + SPEND_STEP;
+          void setSetting(PRETAX_MONTHLY_KEY, String(newValue));
+          return newValue;
+        });
+      }
       if (currentDial === 'withdrawal') setWithdrawal((w) => parseFloat(Math.min(10, w + WITHDRAW_STEP).toFixed(1)));
       if (currentDial === 'growth')     setGrowth((g) => parseFloat(Math.min(20, g + GROWTH_STEP).toFixed(1)));
       return;
@@ -128,6 +144,13 @@ export function Health({ onNavigate, isActive, showHints }: { onNavigate: (s: Sc
     if (key.leftArrow) {
       if (currentDial === 'spend')      setMonthlySpend((s) => Math.max(SPEND_STEP, s - SPEND_STEP));
       if (currentDial === 'savings')    setMonthlySavings((s) => s - SPEND_STEP);
+      if (currentDial === 'pretax') {
+        setPretaxSavings((s) => {
+          const newValue = Math.max(0, s - SPEND_STEP);
+          void setSetting(PRETAX_MONTHLY_KEY, String(newValue));
+          return newValue;
+        });
+      }
       if (currentDial === 'withdrawal') setWithdrawal((w) => parseFloat(Math.max(0.5, w - WITHDRAW_STEP).toFixed(1)));
       if (currentDial === 'growth')     setGrowth((g) => parseFloat(Math.max(0, g - GROWTH_STEP).toFixed(1)));
       return;
@@ -135,6 +158,10 @@ export function Health({ onNavigate, isActive, showHints }: { onNavigate: (s: Sc
     if (input === 'r') {
       if (currentDial === 'spend')      setMonthlySpend(Math.max(SPEND_STEP, Math.round(data.avgMonthlyExpenses / SPEND_STEP) * SPEND_STEP));
       if (currentDial === 'savings')    setMonthlySavings(Math.round(data.monthlySavings / SPEND_STEP) * SPEND_STEP);
+      if (currentDial === 'pretax') {
+        setPretaxSavings(0);
+        void setSetting(PRETAX_MONTHLY_KEY, '0');
+      }
       if (currentDial === 'withdrawal') setWithdrawal(DEFAULT_WITHDRAWAL);
       if (currentDial === 'growth')     setGrowth(DEFAULT_GROWTH);
       return;
@@ -148,11 +175,11 @@ export function Health({ onNavigate, isActive, showHints }: { onNavigate: (s: Sc
   const annualSpend    = monthlySpend * 12;
   const fireNumber     = annualSpend / (withdrawal / 100);
   const fireProgress   = fireNumber > 0 ? Math.max(0, data.netWorth) / fireNumber : 0;
-  const years          = yearsToFire(data.netWorth, monthlySavings, fireNumber, growth);
+  const years          = yearsToFire(data.netWorth, monthlySavings + pretaxSavings, fireNumber, growth);
   const coast          = coastYears(data.netWorth, fireNumber, growth);
 
   const savingsRate = data.monthlyIncome > 0
-    ? (monthlySavings / data.monthlyIncome) * 100
+    ? ((monthlySavings + pretaxSavings) / data.monthlyIncome) * 100
     : null;
 
   const netCash        = data.cash - data.totalDebt;
@@ -163,6 +190,7 @@ export function Health({ onNavigate, isActive, showHints }: { onNavigate: (s: Sc
   const defaultSavings  = Math.round(data.monthlySavings / SPEND_STEP) * SPEND_STEP;
   const spendChanged    = monthlySpend !== defaultSpend;
   const savingsChanged  = monthlySavings !== defaultSavings;
+  const pretaxChanged   = pretaxSavings !== 0;
   const withdrawChanged = withdrawal !== DEFAULT_WITHDRAWAL;
   const growthChanged   = growth !== DEFAULT_GROWTH;
 
@@ -205,6 +233,7 @@ export function Health({ onNavigate, isActive, showHints }: { onNavigate: (s: Sc
                     : savingsRate >= 50
                       ? 'FIRE pace'
                       : 'on track'}
+            {pretaxSavings > 0 ? `  (+${fmt(pretaxSavings)}/mo pretax)` : ''}
           </Text>
         </Box>
         <Box gap={3}>
@@ -365,6 +394,15 @@ export function Health({ onNavigate, isActive, showHints }: { onNavigate: (s: Sc
             : currentDial === 'savings'
               ? (savingsChanged ? `default ${fmt(defaultSavings)} · [r] reset` : `avg surplus past 12 mo  ← → ±${fmt(SPEND_STEP)}`)
               : `avg surplus past 12 mo${savingsChanged ? ' (modified)' : ''}`}
+        />
+        <DialRow
+          label="Pretax savings" value={fmt(pretaxSavings)} selected={currentDial === 'pretax'}
+          editing={editMode && currentDial === 'pretax'} editBuffer={editBuffer}
+          description={editMode && currentDial === 'pretax'
+            ? 'Enter confirm  ·  Esc cancel'
+            : currentDial === 'pretax'
+              ? (pretaxChanged ? `default $0 · [r] reset` : `401k/HSA — not in transactions  ← → ±${fmt(SPEND_STEP)}`)
+              : `401k/HSA — not in transactions${pretaxChanged ? ' (modified)' : ''}`}
         />
         <DialRow
           label="Withdrawal rate" value={fmtPct(withdrawal)} selected={currentDial === 'withdrawal'}

--- a/tui/Health.tsx
+++ b/tui/Health.tsx
@@ -131,11 +131,9 @@ export function Health({ onNavigate, isActive, showHints }: { onNavigate: (s: Sc
       if (currentDial === 'spend')      setMonthlySpend((s) => s + SPEND_STEP);
       if (currentDial === 'savings')    setMonthlySavings((s) => s + SPEND_STEP);
       if (currentDial === 'pretax') {
-        setPretaxSavings((s) => {
-          const newValue = s + SPEND_STEP;
-          void setSetting(PRETAX_MONTHLY_KEY, String(newValue));
-          return newValue;
-        });
+        const newValue = pretaxSavings + SPEND_STEP;
+        setPretaxSavings(newValue);
+        void setSetting(PRETAX_MONTHLY_KEY, String(newValue));
       }
       if (currentDial === 'withdrawal') setWithdrawal((w) => parseFloat(Math.min(10, w + WITHDRAW_STEP).toFixed(1)));
       if (currentDial === 'growth')     setGrowth((g) => parseFloat(Math.min(20, g + GROWTH_STEP).toFixed(1)));
@@ -145,11 +143,9 @@ export function Health({ onNavigate, isActive, showHints }: { onNavigate: (s: Sc
       if (currentDial === 'spend')      setMonthlySpend((s) => Math.max(SPEND_STEP, s - SPEND_STEP));
       if (currentDial === 'savings')    setMonthlySavings((s) => s - SPEND_STEP);
       if (currentDial === 'pretax') {
-        setPretaxSavings((s) => {
-          const newValue = Math.max(0, s - SPEND_STEP);
-          void setSetting(PRETAX_MONTHLY_KEY, String(newValue));
-          return newValue;
-        });
+        const newValue = Math.max(0, pretaxSavings - SPEND_STEP);
+        setPretaxSavings(newValue);
+        void setSetting(PRETAX_MONTHLY_KEY, String(newValue));
       }
       if (currentDial === 'withdrawal') setWithdrawal((w) => parseFloat(Math.max(0.5, w - WITHDRAW_STEP).toFixed(1)));
       if (currentDial === 'growth')     setGrowth((g) => parseFloat(Math.max(0, g - GROWTH_STEP).toFixed(1)));
@@ -233,7 +229,7 @@ export function Health({ onNavigate, isActive, showHints }: { onNavigate: (s: Sc
                     : savingsRate >= 50
                       ? 'FIRE pace'
                       : 'on track'}
-            {pretaxSavings > 0 ? `  (+${fmt(pretaxSavings)}/mo pretax)` : ''}
+            {savingsRate !== null && pretaxSavings > 0 ? `  (+${fmt(pretaxSavings)}/mo pretax)` : ''}
           </Text>
         </Box>
         <Box gap={3}>

--- a/tui/Health.tsx
+++ b/tui/Health.tsx
@@ -178,6 +178,9 @@ export function Health({ onNavigate, isActive, showHints }: { onNavigate: (s: Sc
   const savingsRate = grossIncome > 0
     ? ((monthlySavings + pretaxSavings) / grossIncome) * 100
     : null;
+  const rawSavingsRate = data.monthlyIncome > 0
+    ? (monthlySavings / data.monthlyIncome) * 100
+    : null;
 
   const netCash        = data.cash - data.totalDebt;
   const remainingDebt  = Math.max(0, data.totalDebt - data.cash);
@@ -230,13 +233,18 @@ export function Health({ onNavigate, isActive, showHints }: { onNavigate: (s: Sc
                     : savingsRate >= 50
                       ? 'FIRE pace'
                       : 'on track'}
-            {savingsRate !== null && pretaxSavings > 0 ? `  (+${fmt(pretaxSavings)}/mo pretax)` : ''}
+            {savingsRate !== null && pretaxSavings > 0 && rawSavingsRate !== null
+              ? `  (${fmtPct(rawSavingsRate)} take-home)`
+              : ''}
           </Text>
         </Box>
         <Box gap={3}>
           <Text dimColor>{'Monthly income'.padEnd(L)}</Text>
           <Text bold>{fmt(grossIncome).padStart(V)}</Text>
-          <Text dimColor>avg past 12 months</Text>
+          <Text dimColor>
+            {'avg past 12 months'}
+            {pretaxSavings > 0 ? `  (${fmt(data.monthlyIncome)} take-home)` : ''}
+          </Text>
         </Box>
       </Box>
 

--- a/tui/Health.tsx
+++ b/tui/Health.tsx
@@ -174,8 +174,9 @@ export function Health({ onNavigate, isActive, showHints }: { onNavigate: (s: Sc
   const years          = yearsToFire(data.netWorth, monthlySavings + pretaxSavings, fireNumber, growth);
   const coast          = coastYears(data.netWorth, fireNumber, growth);
 
-  const savingsRate = data.monthlyIncome > 0
-    ? ((monthlySavings + pretaxSavings) / data.monthlyIncome) * 100
+  const grossIncome = data.monthlyIncome + pretaxSavings;
+  const savingsRate = grossIncome > 0
+    ? ((monthlySavings + pretaxSavings) / grossIncome) * 100
     : null;
 
   const netCash        = data.cash - data.totalDebt;
@@ -234,7 +235,7 @@ export function Health({ onNavigate, isActive, showHints }: { onNavigate: (s: Sc
         </Box>
         <Box gap={3}>
           <Text dimColor>{'Monthly income'.padEnd(L)}</Text>
-          <Text bold>{fmt(data.monthlyIncome).padStart(V)}</Text>
+          <Text bold>{fmt(grossIncome).padStart(V)}</Text>
           <Text dimColor>avg past 12 months</Text>
         </Box>
       </Box>


### PR DESCRIPTION
## Summary

- Adds `PRETAX_MONTHLY_KEY = 'pretax_monthly'` constant to `core/settings.ts`
- Exposes `getSetting`/`setSetting` via a new `settings` namespace in `gui/main/registry.ts`
- Adds a **"Pretax savings"** dial to both TUI and GUI Health screens (positioned between Monthly savings and Withdrawal rate)
- Persists the value to the `settings` table on every change so it survives restarts
- `savingsRate` and `yearsToFire` calculations now use `monthlySavings + pretaxContribution`
- Snapshot section shows `(+$X/mo pretax)` in the savings rate hint when a non-zero value is set

Closes #112.

## Test plan

- [ ] Open Health screen in TUI — "Pretax savings" dial appears between Monthly savings and Withdrawal rate
- [ ] Arrow-key or type a value (e.g. 500); savings rate increases accordingly
- [ ] Press `r` to reset pretax to 0
- [ ] Restart the app — pretax value is restored from DB
- [ ] Repeat verification in GUI (Electron): DollarDial renders in Assumptions section, reset button appears when non-zero, value persists across reloads
- [ ] Snapshot hint shows `(+$500/mo pretax)` when pretax is set, disappears when 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)