### PR TITLE
fix: re-read the tag panel's marks when the tagged row leaves the filter

### DIFF
--- a/tests/tui/screens.test.tsx
+++ b/tests/tui/screens.test.tsx
@@ -783,6 +783,58 @@ describe('Transactions', () => {
       expect(f).toContain('Saved:');
     });
   });
+
+  // The tag panel titles itself with whatever row the cursor is on, so its
+  // applied-tag marks have to track that row too. Under a "lacks" filter the
+  // row leaves the list the moment it's tagged and the next one slides into
+  // the same index — the marks must re-read for the new row instead of still
+  // showing the tag that was just applied to the old one.
+  const LACKS_BOTH = { tags: [{ name: 'travel', mode: 'lacks' as const }, { name: 'work', mode: 'lacks' as const }] };
+
+  it('tag panel re-reads the tags when tagging drops the row out of a lacks filter', async () => {
+    const r = render(
+      <W>
+        <FilterProvider initial={LACKS_BOTH}>
+          <Transactions onNavigate={noop} showHints={false} initialFilter={MAY_DATE_FILTER} />
+        </FilterProvider>
+      </W>,
+    );
+    await waitFor(() => expect(frame(r)).toContain('Trader Joes')); // newest May row
+    r.stdin.write('g');
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).toContain('Space/Enter toggle'); // panel open
+      expect(f).toContain('○ travel');
+    });
+    r.stdin.write(' '); // apply 'travel' → the row no longer satisfies the filter
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).not.toContain('Trader Joes'); // dropped from the list and the panel title
+      expect(f).toContain('Amazon');          // next row slid into the cursor
+      expect(f).toContain('○ travel');        // ...and it does not carry the tag
+    });
+  });
+
+  it('tag panel closes when tagging empties the list', async () => {
+    const r = render(
+      <W>
+        <FilterProvider initial={LACKS_BOTH}>
+          <Transactions onNavigate={noop} showHints={false} initialFilter={{ from: '2026-05-14', to: '2026-05-14' }} />
+        </FilterProvider>
+      </W>,
+    );
+    await waitFor(() => expect(frame(r)).toContain('Trader Joes'));
+    r.stdin.write('g');
+    await waitFor(() => expect(frame(r)).toContain('Space/Enter toggle'));
+    r.stdin.write(' '); // the only row leaves the filter
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).toContain('0 transactions');
+      expect(f).not.toContain('Space/Enter toggle'); // panel gone
+    });
+    r.stdin.write('/'); // ...and list-mode keys work again rather than typing into the panel
+    await waitFor(() => expect(frame(r)).toContain('Esc cancel'));
+  });
 });
 
 // ── Trends ────────────────────────────────────────────────────────────────────

--- a/tui/Transactions.tsx
+++ b/tui/Transactions.tsx
@@ -78,9 +78,12 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
   const [editPattern, setEditPattern] = useState('');
   const [editMatchType, setEditMatchType] = useState<'name' | 'regex'>('name');
 
-  // Tag panel state
+  // Tag panel state. The applied-tag set is kept together with the transaction
+  // it was read for: the panel acts on whatever row the cursor is on, and that
+  // row can change out from under an open panel (see the sync effect below), so
+  // the marks are only meaningful while the two ids agree.
   const [allTags, setAllTags] = useState<TagOption[]>([]);
-  const [txTagIds, setTxTagIds] = useState<Set<number>>(new Set());
+  const [tagState, setTagState] = useState<{ txId: string; ids: Set<number> } | null>(null);
   const [tagCursor, setTagCursor] = useState(0);
   const [tagInput, setTagInput] = useState('');
 
@@ -95,6 +98,12 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
       setTxs(rows);
       if (!keepCursor) setCursor(0);
       else setCursor((c) => Math.min(c, Math.max(0, rows.length - 1)));
+      // The tag panel acts on the selected row, so it cannot outlive an empty
+      // list: tagging the last row out of a 'lacks' filter would otherwise
+      // leave it open, drawing nothing while swallowing every keypress. Closed
+      // here rather than in an effect so it lands in the same commit as the
+      // rows — no render in between where the panel is open but empty.
+      if (rows.length === 0) setMode((m) => (m === 'tag' ? 'list' : m));
     });
   }
 
@@ -109,6 +118,10 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
   }, [mode, editField]);
 
   const selected = txs[cursor];
+
+  // Marks describe the row they were read for and no other, so an in-flight
+  // read shows nothing applied rather than the previous row's tags.
+  const selectedTagIds = tagState && tagState.txId === selected?.id ? tagState.ids : null;
 
   function openEdit() {
     if (!selected) return;
@@ -125,35 +138,43 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
 
   function openTagPanel() {
     if (!selected) return;
-    void Promise.all([getTagOptions(), getTransactionTagIds(selected.id)]).then(([tags, tagIds]) => {
+    const txId = selected.id;
+    void Promise.all([getTagOptions(), getTransactionTagIds(txId)]).then(([tags, ids]) => {
       setAllTags(tags);
-      setTxTagIds(tagIds);
+      setTagState({ txId, ids });
       setTagInput('');
       setTagCursor(0);
       setMode('tag');
     });
   }
 
-  function toggleTag(tagId: number) {
+  /** Optimistic edit of the open panel's marks; dropped if the cursor already moved on. */
+  function patchTagState(txId: string, edit: (ids: Set<number>) => Set<number>) {
+    setTagState((s) => (s && s.txId === txId ? { txId, ids: edit(s.ids) } : s));
+  }
+
+  async function toggleTag(tagId: number) {
     if (!selected) return;
-    if (txTagIds.has(tagId)) {
-      removeTagFromTransaction(selected.id, tagId);
-      setTxTagIds((s) => { const n = new Set(s); n.delete(tagId); return n; });
-    } else {
-      addTagToTransaction(selected.id, tagId);
-      setTxTagIds((s) => new Set([...s, tagId]));
-    }
+    const txId = selected.id;
+    const had = selectedTagIds?.has(tagId) ?? false;
+    patchTagState(txId, (ids) => {
+      const n = new Set(ids);
+      if (had) n.delete(tagId); else n.add(tagId);
+      return n;
+    });
+    // Await the write so the reload below sees it — otherwise a row that the
+    // filter now excludes can survive the refresh.
+    await (had ? removeTagFromTransaction(txId, tagId) : addTagToTransaction(txId, tagId));
     load(search, true);
   }
 
   function createAndApplyTag(name: string) {
     if (!selected) return;
-    void getOrCreateTag(name).then((tagId) => {
-      void addTagToTransaction(selected.id, tagId);
-      void Promise.all([getTagOptions(), getTransactionTagIds(selected.id)]).then(([tags, tagIds]) => {
-        setAllTags(tags);
-        setTxTagIds(tagIds);
-      });
+    const txId = selected.id;
+    void getOrCreateTag(name).then(async (tagId) => {
+      await addTagToTransaction(txId, tagId);
+      patchTagState(txId, (ids) => new Set(ids).add(tagId));
+      setAllTags(await getTagOptions());
       setTagInput('');
       setTagCursor(0);
       load(search, true);
@@ -225,6 +246,20 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
     ? allTags.filter((t) => t.name.toLowerCase().includes(tagInput.toLowerCase()))
     : allTags;
 
+  // The tag panel is titled with — and acts on — the row under the cursor, and
+  // that row moves while the panel is open: tagging a transaction that a
+  // 'lacks' filter selects against drops it from the list, sliding the next one
+  // into the same index. Re-read the marks for the row the panel now names
+  // instead of leaving the tag just applied to the old row on screen.
+  useEffect(() => {
+    if (mode !== 'tag' || !selected) return;
+    if (tagState?.txId === selected.id) return;
+    const txId = selected.id;
+    let cancelled = false;
+    void getTransactionTagIds(txId).then((ids) => { if (!cancelled) setTagState({ txId, ids }); });
+    return () => { cancelled = true; };
+  }, [mode, selected?.id, tagState?.txId]);
+
   useInput((input, key) => {
     if (mode === 'search') {
       if (key.escape) { setSearchInput(''); setSearch(''); setMode('list'); return; }
@@ -247,7 +282,7 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
       if (input === ' ' || key.return) {
         const t = filteredTags[tagCursor];
         if (t) {
-          toggleTag(t.id);
+          void toggleTag(t.id);
         } else if (tagInput.trim() && key.return) {
           createAndApplyTag(tagInput.trim());
         }
@@ -556,7 +591,7 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
           ) : (
             filteredTags.map((t, i) => {
               const isSelected = i === tagCursor;
-              const has = txTagIds.has(t.id);
+              const has = selectedTagIds?.has(t.id) ?? false;
               return (
                 <SelectableRow key={t.id} selected={isSelected}>
                   <Text color={has ? C_POSITIVE : undefined} dimColor={!isSelected && !has}>


### PR DESCRIPTION
Filter the transactions page so it lacks two tags, leaving more than one row. Press `g` on the top row and tag it. The row correctly drops out of the filter and the cursor moves to the next transaction — but the tag panel re-titles itself with that new transaction while still showing the tag you just applied as set on it:

```
Tags  Amazon
▶ ● travel
  ○ work
```

Amazon does not have `travel`. Worse than cosmetic: the next Space would call `removeTagFromTransaction` on Amazon, silently un-tagging the wrong row.

## Cause

The panel's title and its actions both read `txs[cursor]`, which changes when the list reloads, but the applied-tag set `txTagIds` was plain state that nothing re-read.

## Fix

The tag set is now stored together with the transaction id it was read for (`{ txId, ids }`), so the two can be checked for agreement:

- An effect re-reads the tags whenever the row under the cursor changes while the panel is open.
- Marks render as unset while that read is in flight, rather than showing the previous row's tags — a brief false `○` instead of a false `●`.
- Tag writes are now awaited before the reload. Previously the read could race the write, letting a row the filter excludes survive the refresh.
- The panel closes when tagging empties the list. Before, it stayed in tag mode drawing nothing while swallowing every keypress until Esc. This is done in the same commit as the row update, so no keypress falls into a gap.

The `g` workflow is unchanged otherwise: the tag cursor and filter text stay put, so you can hold Space and walk a filtered queue — the marks just tell the truth about each row now.

The Electron GUI's `TagModal` takes the transaction as a prop and re-reads on `[tx.id]`, so it never had this bug and is untouched.

## Test plan

Two regression tests in `tests/tui/screens.test.tsx`, both verified to fail on `dev` without the source change and pass with it:

- `tag panel re-reads the tags when tagging drops the row out of a lacks filter`
- `tag panel closes when tagging empties the list`

`npm run typecheck` clean; full suite 763/763 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
