### PR TITLE
feat: update link credentials in place with Plaid update mode

### DIFF
--- a/core/plaid-link-flow.ts
+++ b/core/plaid-link-flow.ts
@@ -1,0 +1,185 @@
+import { db } from './db.js';
+import { createLinkToken, exchangePublicToken } from './plaid.js';
+import { encryptToken, decryptToken } from './crypto.js';
+import { MIN_DAYS_REQUESTED, MAX_DAYS_REQUESTED } from './settings.js';
+
+/**
+ * The parts of the Plaid Link flow that are identical everywhere: the browser
+ * pages, the link_token request, and what to persist when the user finishes.
+ *
+ * Only the transport differs between hosts — `scripts/link.ts` runs a fixed-port
+ * server and reports progress on stdout for the TUI to parse, while
+ * `gui/main/plaid-link.ts` uses an ephemeral port, a timeout and a cancel hook.
+ * Those stay with their callers; everything below is shared so the two can't
+ * drift apart on the details that actually matter.
+ */
+
+/** Clamp a requested history window to Plaid's accepted bounds. */
+export function clampDaysRequested(days: number): number {
+  return Math.max(MIN_DAYS_REQUESTED, Math.min(MAX_DAYS_REQUESTED, Math.round(days)));
+}
+
+export type LinkFlowOptions = {
+  /**
+   * Update the credentials on an existing connection rather than add a new one.
+   * Puts Link in update mode, which keeps the Item's accounts and transactions
+   * instead of creating duplicates under a fresh Item.
+   */
+  updateItemId?: string;
+  /** History window for a new Item. Ignored in update mode — see createLinkToken. */
+  daysRequested?: number;
+};
+
+/**
+ * Creates the link_token for a flow, resolving the stored access token first
+ * when this is an update. Throws if the item to update isn't in the database.
+ */
+export async function createFlowLinkToken(opts: LinkFlowOptions = {}): Promise<string> {
+  const { updateItemId, daysRequested } = opts;
+  let accessToken: string | undefined;
+
+  if (updateItemId) {
+    const res = await db.execute({
+      sql: 'SELECT access_token FROM plaid_items WHERE item_id = ?',
+      args: [updateItemId],
+    });
+    if (res.rows.length === 0) throw new Error(`No linked institution found for item ${updateItemId}`);
+    accessToken = decryptToken((res.rows[0] as unknown as { access_token: string }).access_token);
+  }
+
+  return createLinkToken('local-user', daysRequested, accessToken);
+}
+
+export type LinkCallbackResult = {
+  itemId: string;
+  institutionName: string | null;
+  /** True when this re-authorized an existing Item rather than adding one. */
+  updateMode: boolean;
+};
+
+/**
+ * Handles the JSON body Link posts back on success: exchanges the public token
+ * and stores the Item, or — in update mode — does neither.
+ *
+ * Update mode leaves the access_token and item_id unchanged, so Plaid says the
+ * exchange need not be repeated. Skipping the write matters for a second reason:
+ * update mode must omit days_requested, so re-running the upsert would blank the
+ * stored history window of a perfectly good Item.
+ */
+export async function completeLink(body: string, opts: LinkFlowOptions = {}): Promise<LinkCallbackResult> {
+  const { updateItemId, daysRequested } = opts;
+  const { public_token, institution } = JSON.parse(body);
+  const institutionName: string | null = institution?.name ?? null;
+
+  if (updateItemId) {
+    return { itemId: updateItemId, institutionName, updateMode: true };
+  }
+
+  const { accessToken, itemId } = await exchangePublicToken(public_token);
+  await db.execute({
+    sql: `INSERT INTO plaid_items (item_id, access_token, institution_name, days_requested)
+          VALUES (?, ?, ?, ?)
+          ON CONFLICT(item_id) DO UPDATE SET access_token=excluded.access_token, institution_name=excluded.institution_name, days_requested=excluded.days_requested`,
+    args: [itemId, encryptToken(accessToken), institutionName, daysRequested ?? null],
+  });
+  return { itemId, institutionName, updateMode: false };
+}
+
+/** The page that hosts Plaid Link itself, served at the flow's root URL. */
+export function linkPage(linkToken: string, opts: { updateMode?: boolean } = {}): string {
+  const updateMode = !!opts.updateMode;
+  return `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Fungible — ${updateMode ? 'Update Link' : 'Connect Bank'}</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: -apple-system, sans-serif; background: #0f0f0f; color: #e0e0e0; display: flex; align-items: center; justify-content: center; height: 100vh; }
+    .card { background: #1a1a1a; border: 1px solid #2a2a2a; border-radius: 12px; padding: 40px; text-align: center; max-width: 380px; }
+    h1 { font-size: 1.4rem; margin-bottom: 8px; color: #fff; }
+    p { color: #888; font-size: 0.9rem; margin-bottom: 28px; }
+    button { background: #00d4aa; color: #000; border: none; border-radius: 8px; padding: 12px 28px; font-size: 1rem; font-weight: 600; cursor: pointer; }
+    button:hover { background: #00bfa0; }
+    .status { margin-top: 20px; font-size: 0.85rem; color: #888; }
+    .success { color: #00d4aa; }
+    .error { color: #ff6b6b; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h1>fungible</h1>
+    <p>${updateMode
+      ? 'Sign in again to update the credentials for this link. Your existing accounts and transactions are kept.'
+      : 'Connect your bank account to start tracking expenses.'}</p>
+    <button id="connect-btn">${updateMode ? 'Update Credentials' : 'Connect Bank'}</button>
+    <div class="status" id="status"></div>
+  </div>
+
+  <script src="https://cdn.plaid.com/link/v2/stable/link-initialize.js"></script>
+  <script>
+    const btn = document.getElementById('connect-btn');
+    const status = document.getElementById('status');
+
+    btn.addEventListener('click', () => {
+      const handler = Plaid.create({
+        token: '${linkToken}',
+        onSuccess: async (publicToken, metadata) => {
+          btn.disabled = true;
+          status.textContent = '${updateMode ? 'Updating' : 'Connecting'}...';
+          try {
+            const res = await fetch('/callback', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ public_token: publicToken, institution: metadata.institution }),
+            });
+            if (res.ok) {
+              status.className = 'status success';
+              status.textContent = '${updateMode ? 'Link updated' : 'Connected'}! You can close this window.';
+              btn.textContent = 'Done';
+            } else {
+              throw new Error(await res.text());
+            }
+          } catch (e) {
+            status.className = 'status error';
+            status.textContent = 'Error: ' + e.message;
+            btn.disabled = false;
+          }
+        },
+        onExit: (err) => {
+          if (err) {
+            status.className = 'status error';
+            status.textContent = err.display_message || 'Exited without connecting.';
+          }
+        },
+      });
+      handler.open();
+    });
+  </script>
+</body>
+</html>`;
+}
+
+/** Confirmation page served once the callback has been handled. */
+export function successPage(opts: { updateMode?: boolean; returnTo: string }): string {
+  const updateMode = !!opts.updateMode;
+  return `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>${updateMode ? 'Link updated' : 'Connected'}</title>
+  <style>
+    body { font-family: -apple-system, sans-serif; background: #0f0f0f; color: #e0e0e0; display: flex; align-items: center; justify-content: center; height: 100vh; }
+    .card { background: #1a1a1a; border: 1px solid #2a2a2a; border-radius: 12px; padding: 40px; text-align: center; }
+    h1 { color: #00d4aa; margin-bottom: 8px; }
+    p { color: #888; font-size: 0.9rem; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h1>${updateMode ? 'Link updated!' : 'Connected!'}</h1>
+    <p>You can close this window and return to ${opts.returnTo}.</p>
+  </div>
+</body>
+</html>`;
+}

--- a/core/plaid.ts
+++ b/core/plaid.ts
@@ -29,15 +29,34 @@ export function getPlaidClient(): PlaidApi {
   return new PlaidApi(config);
 }
 
-export async function createLinkToken(userId: string, daysRequested?: number) {
+/**
+ * Creates a link_token for the Link flow.
+ *
+ * Passing `accessToken` puts Link in *update mode*, which re-authorizes an
+ * existing Item in place. This is the difference between updating a connection
+ * and replacing it: update mode keeps the Item's `item_id`, `account_id`s and
+ * `transaction_id`s, so nothing downstream sees new accounts or duplicate
+ * transactions. Creating a link_token without it always mints a brand-new Item,
+ * even when the user re-authenticates at the same bank.
+ *
+ * Update mode forbids `products` and every product-specific parameter, which
+ * includes `transactions.days_requested` — so `daysRequested` is ignored when
+ * updating. That window is fixed when the Item is created and cannot be
+ * widened later. See https://plaid.com/docs/link/update-mode/
+ */
+export async function createLinkToken(userId: string, daysRequested?: number, accessToken?: string) {
   const response = await getPlaidClient().linkTokenCreate({
     user: { client_user_id: userId },
     client_name: 'Fungible',
-    products: [Products.Transactions],
     country_codes: [CountryCode.Us],
     language: 'en',
-    // Omitting transactions lets Plaid apply its 90-day default
-    ...(daysRequested ? { transactions: { days_requested: daysRequested } } : {}),
+    ...(accessToken
+      ? { access_token: accessToken }
+      : {
+          products: [Products.Transactions],
+          // Omitting transactions lets Plaid apply its 90-day default
+          ...(daysRequested ? { transactions: { days_requested: daysRequested } } : {}),
+        }),
   });
   return response.data.link_token;
 }

--- a/core/queries.ts
+++ b/core/queries.ts
@@ -691,7 +691,7 @@ export async function getLinkedAccounts(): Promise<LinkedAccount[]> {
  * One row per Plaid connection, for the Links view.
  *
  * Deliberately item-shaped rather than account-shaped: the things this view
- * exists to manage — the sync cursor, the history window, credential repair,
+ * exists to manage — the sync cursor, the history window, updating credentials,
  * replacing a connection — are all properties of the item, not of the accounts
  * hanging off it. getLinkedAccounts answers a different question and flattens
  * the item away.

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -174,14 +174,27 @@ The **rule form** is a single panel with fields navigated by `↑ ↓`: Pattern,
 
 | Key | Action |
 |-----|--------|
-| `Tab` | Cycle views: Accounts → Add Data → Dupes |
+| `Tab` | Cycle views: Accounts → Links → Add Data → Dupes |
 | `↑ ↓` | Select account |
 | `Enter` | Edit selected account (nickname, type, subtype, APR — navigated with `↑ ↓`, `← →` to cycle) |
 | `v` | Update value (manual assets only) |
-| `r` | Repair Plaid link for selected account |
 | `s` | Force sync (bypasses 15-min cooldown) |
 | `x` | Delete selected account |
 | `l` | Link a new bank account via Plaid |
+
+**Links** tab lists one row per Plaid connection rather than per account, since a
+single connection can back many accounts.
+
+| Key | Action |
+|-----|--------|
+| `↑ ↓` | Select connection |
+| `u` | Update link — update creds for link, keeping its accounts and transactions |
+| `s` | Force sync (bypasses 15-min cooldown) |
+
+`[u]` runs Plaid in update mode, which re-authorizes the existing connection in
+place. Use it when a connection shows ⚠ sync failed because its login expired.
+It does not create new accounts or re-download transactions, and it cannot widen
+the history window — that is fixed when the connection is first created.
 
 **Add Data** options: `[l]` link bank via Plaid, `[c]` import CSV, `[m]` add manual asset (house, car, etc.), `[s]` force sync.
 

--- a/gui/main/bridge.ts
+++ b/gui/main/bridge.ts
@@ -8,7 +8,7 @@ import { registry } from './registry.js';
 const plaid = {
   isConfigured: async (): Promise<boolean> => isPlaidConfigured(),
   getDefaultDaysRequested,
-  linkBank: (daysRequested?: number) => runPlaidLink(daysRequested),
+  linkBank: (daysRequested?: number, updateItemId?: string) => runPlaidLink(daysRequested, updateItemId),
 };
 
 const files = {

--- a/gui/main/plaid-link.ts
+++ b/gui/main/plaid-link.ts
@@ -1,108 +1,17 @@
 import http from 'node:http';
 import { shell } from 'electron';
-import { db } from '../../core/db.js';
-import { createLinkToken, exchangePublicToken, isPlaidConfigured } from '../../core/plaid.js';
-import { encryptToken } from '../../core/crypto.js';
+import {
+  clampDaysRequested, completeLink, createFlowLinkToken, linkPage, successPage,
+} from '../../core/plaid-link-flow.js';
 import { notifyChange } from '../../core/refresh.js';
+import { isPlaidConfigured } from '../../core/plaid.js';
 
-// Browser-based Plaid Link flow, adapted from scripts/link.ts. Uses the system
-// browser (bank OAuth redirects often reject embedded webviews) and an
-// ephemeral localhost callback server.
+// Browser-based Plaid Link flow. Uses the system browser (bank OAuth redirects
+// often reject embedded webviews) and an ephemeral localhost callback server.
+// The pages and the persistence live in core/plaid-link-flow.ts, shared with
+// scripts/link.ts; only the server lifecycle below is Electron-specific.
 
-function linkPage(linkToken: string) {
-  return `<!DOCTYPE html>
-<html>
-<head>
-  <meta charset="utf-8" />
-  <title>Fungible — Connect Bank</title>
-  <style>
-    * { box-sizing: border-box; margin: 0; padding: 0; }
-    body { font-family: -apple-system, sans-serif; background: #0f0f0f; color: #e0e0e0; display: flex; align-items: center; justify-content: center; height: 100vh; }
-    .card { background: #1a1a1a; border: 1px solid #2a2a2a; border-radius: 12px; padding: 40px; text-align: center; max-width: 380px; }
-    h1 { font-size: 1.4rem; margin-bottom: 8px; color: #fff; }
-    p { color: #888; font-size: 0.9rem; margin-bottom: 28px; }
-    button { background: #00d4aa; color: #000; border: none; border-radius: 8px; padding: 12px 28px; font-size: 1rem; font-weight: 600; cursor: pointer; }
-    button:hover { background: #00bfa0; }
-    .status { margin-top: 20px; font-size: 0.85rem; color: #888; }
-    .success { color: #00d4aa; }
-    .error { color: #ff6b6b; }
-  </style>
-</head>
-<body>
-  <div class="card">
-    <h1>fungible</h1>
-    <p>Connect your bank account to start tracking expenses.</p>
-    <button id="connect-btn">Connect Bank</button>
-    <div class="status" id="status"></div>
-  </div>
-
-  <script src="https://cdn.plaid.com/link/v2/stable/link-initialize.js"></script>
-  <script>
-    const btn = document.getElementById('connect-btn');
-    const status = document.getElementById('status');
-
-    btn.addEventListener('click', () => {
-      const handler = Plaid.create({
-        token: '${linkToken}',
-        onSuccess: async (publicToken, metadata) => {
-          btn.disabled = true;
-          status.textContent = 'Connecting...';
-          try {
-            const res = await fetch('/callback', {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ public_token: publicToken, institution: metadata.institution }),
-            });
-            if (res.ok) {
-              status.className = 'status success';
-              status.textContent = 'Connected! You can close this window.';
-              btn.textContent = 'Done';
-            } else {
-              throw new Error(await res.text());
-            }
-          } catch (e) {
-            status.className = 'status error';
-            status.textContent = 'Error: ' + e.message;
-            btn.disabled = false;
-          }
-        },
-        onExit: (err) => {
-          if (err) {
-            status.className = 'status error';
-            status.textContent = err.display_message || 'Exited without connecting.';
-          }
-        },
-      });
-      handler.open();
-    });
-  </script>
-</body>
-</html>`;
-}
-
-function successPage() {
-  return `<!DOCTYPE html>
-<html>
-<head>
-  <meta charset="utf-8" />
-  <title>Connected</title>
-  <style>
-    body { font-family: -apple-system, sans-serif; background: #0f0f0f; color: #e0e0e0; display: flex; align-items: center; justify-content: center; height: 100vh; }
-    .card { background: #1a1a1a; border: 1px solid #2a2a2a; border-radius: 12px; padding: 40px; text-align: center; }
-    h1 { color: #00d4aa; margin-bottom: 8px; }
-    p { color: #888; font-size: 0.9rem; }
-  </style>
-</head>
-<body>
-  <div class="card">
-    <h1>Connected!</h1>
-    <p>You can close this window and return to fungible.</p>
-  </div>
-</body>
-</html>`;
-}
-
-let activeLink: Promise<{ institutionName: string | null }> | null = null;
+let activeLink: Promise<{ institutionName: string | null; updateMode: boolean }> | null = null;
 let cancelActive: (() => void) | null = null;
 
 const MAX_CALLBACK_BODY = 1_000_000;
@@ -113,9 +22,17 @@ export function cancelActivePlaidLink() {
   cancelActive?.();
 }
 
-/** Starts the link flow in the system browser. Resolves when a bank is
- *  connected, rejects on timeout (10 min) or server failure. */
-export function runPlaidLink(daysRequested?: number): Promise<{ institutionName: string | null }> {
+/**
+ * Starts the link flow in the system browser. Resolves when a bank is
+ * connected, rejects on timeout (10 min) or server failure.
+ *
+ * Passing `updateItemId` updates the credentials on that existing connection
+ * instead of adding a new one, keeping its accounts and transactions intact.
+ */
+export function runPlaidLink(
+  daysRequested?: number,
+  updateItemId?: string,
+): Promise<{ institutionName: string | null; updateMode: boolean }> {
   if (activeLink) return activeLink;
   if (!isPlaidConfigured()) {
     return Promise.reject(new Error('Plaid is not configured — set PLAID_CLIENT_ID and PLAID_SECRET in ~/.fungible/.env'));
@@ -123,14 +40,13 @@ export function runPlaidLink(daysRequested?: number): Promise<{ institutionName:
 
   activeLink = new Promise((resolve, reject) => {
     void (async () => {
-      const days =
-        daysRequested !== undefined ? Math.max(30, Math.min(730, Math.round(daysRequested))) : undefined;
-      const linkToken = await createLinkToken('local-user', days);
+      const days = daysRequested !== undefined ? clampDaysRequested(daysRequested) : undefined;
+      const linkToken = await createFlowLinkToken({ updateItemId, daysRequested: days });
 
       const server = http.createServer((req, res) => {
         if (req.method === 'GET' && req.url === '/') {
           res.writeHead(200, { 'Content-Type': 'text/html' });
-          res.end(linkPage(linkToken));
+          res.end(linkPage(linkToken, { updateMode: !!updateItemId }));
           return;
         }
 
@@ -149,22 +65,13 @@ export function runPlaidLink(daysRequested?: number): Promise<{ institutionName:
           req.on('end', async () => {
             if (overflow) return;
             try {
-              const { public_token, institution } = JSON.parse(body);
-              const { accessToken, itemId } = await exchangePublicToken(public_token);
-              const institutionName = institution?.name ?? null;
-
-              await db.execute({
-                sql: `INSERT INTO plaid_items (item_id, access_token, institution_name, days_requested)
-                      VALUES (?, ?, ?, ?)
-                      ON CONFLICT(item_id) DO UPDATE SET access_token=excluded.access_token, institution_name=excluded.institution_name, days_requested=excluded.days_requested`,
-                args: [itemId, encryptToken(accessToken), institutionName, days ?? null],
-              });
+              const { institutionName, updateMode } = await completeLink(body, { updateItemId, daysRequested: days });
 
               res.writeHead(200, { 'Content-Type': 'text/html' });
-              res.end(successPage());
+              res.end(successPage({ updateMode, returnTo: 'fungible' }));
               finish();
               notifyChange();
-              resolve({ institutionName });
+              resolve({ institutionName, updateMode });
             } catch (e) {
               res.writeHead(500, { 'Content-Type': 'text/plain' });
               res.end(e instanceof Error ? e.message : String(e));

--- a/gui/renderer/src/screens/Accounts.tsx
+++ b/gui/renderer/src/screens/Accounts.tsx
@@ -4,7 +4,7 @@ import { useQuery } from '../hooks/useQuery.js';
 import { useStatus } from '../hooks/useStatus.js';
 import { useSyncStatus } from '../hooks/useSyncStatus.js';
 import { Modal } from '../components/Modal.js';
-import type { LinkedAccount, CsvAccount } from '../../../../core/queries.js';
+import type { LinkedAccount, CsvAccount, LinkedItem } from '../../../../core/queries.js';
 import { SUBTYPE_DISPLAY, ACCOUNT_TYPES, SUBTYPES, MONTHS } from '../constants.js';
 import { useScreenKeys } from '../hooks/useScreenKeys.js';
 import { KeyHints } from '../components/KeyHints.js';
@@ -42,6 +42,9 @@ export function Accounts() {
   const [manualOpen, setManualOpen] = useState(false);
   const [csvOpen, setCsvOpen] = useState(false);
   const [linkOpen, setLinkOpen] = useState(false);
+  // The connection whose credentials are being updated, if any. Distinct from
+  // linkOpen: that adds a new item, this re-authorizes an existing one.
+  const [updateItem, setUpdateItem] = useState<LinkedItem | null>(null);
   const [syncing, setSyncing] = useState(false);
   const plaidConfigured = useQuery(() => api.plaid.isConfigured(), []) ?? false;
   // Item ids that failed the most recent sync (from either the startup or the
@@ -239,10 +242,10 @@ export function Accounts() {
                     <td className={styles.tdActions}>
                       <button
                         className={styles.rowBtn}
-                        title="Reconnect this institution through Plaid"
-                        onClick={() => setLinkOpen(true)}
+                        title="Update creds for link, keeping its accounts and transactions"
+                        onClick={() => setUpdateItem(item)}
                       >
-                        repair
+                        update link
                       </button>
                     </td>
                   </tr>
@@ -446,6 +449,22 @@ export function Accounts() {
         />
       )}
 
+      {updateItem && (
+        <LinkBankModal
+          updateItem={updateItem}
+          onClose={() => setUpdateItem(null)}
+          onLinked={(institution) => {
+            setUpdateItem(null);
+            // Syncing here is what clears the ⚠ badge: the item's last recorded
+            // sync is the failure that prompted the update, and nothing else
+            // refreshes that state.
+            showStatus(`Updated ${institution ?? 'link'} — syncing…`, 4000);
+            reload();
+            void forceSync();
+          }}
+        />
+      )}
+
       {statusEl}
     </div>
   );
@@ -456,9 +475,14 @@ export function Accounts() {
 function LinkBankModal({
   onClose,
   onLinked,
+  updateItem,
 }: {
   onClose: () => void;
   onLinked: (institution: string | null) => void;
+  /** Set to update an existing connection's credentials instead of adding one.
+   *  Update mode keeps the item's accounts and transactions, and cannot change
+   *  the history window — so the days field is not offered. */
+  updateItem?: LinkedItem;
 }) {
   const [days, setDays] = useState('');
   const [defaultDays, setDefaultDays] = useState(730);
@@ -473,30 +497,57 @@ function LinkBankModal({
   }, []);
 
   async function start() {
-    const n = parseInt(days, 10);
-    if (isNaN(n) || n < 30 || n > 730) {
-      setError('Enter a whole number from 30 to 730');
-      return;
+    let n: number | undefined;
+    if (!updateItem) {
+      n = parseInt(days, 10);
+      if (isNaN(n) || n < 30 || n > 730) {
+        setError('Enter a whole number from 30 to 730');
+        return;
+      }
     }
     setError('');
     setRunning(true);
     try {
-      const { institutionName } = await api.plaid.linkBank(n);
-      onLinked(institutionName);
+      const { institutionName } = await api.plaid.linkBank(n, updateItem?.item_id);
+      onLinked(institutionName ?? updateItem?.institution_name ?? null);
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Link failed');
+      setError(e instanceof Error ? e.message : updateItem ? 'Update failed' : 'Link failed');
       setRunning(false);
     }
   }
 
   return (
-    <Modal title="Link a bank" onClose={onClose}>
+    <Modal title={updateItem ? 'Update link' : 'Link a bank'} onClose={onClose}>
       {running ? (
         <div>
           <p className="accent">⟳ Complete the Plaid flow in your browser, then return here.</p>
-          <p className="dim">This window updates automatically once the bank is connected.</p>
+          <p className="dim">
+            {updateItem
+              ? 'Sign in with the same bank. Your existing accounts and transactions are kept.'
+              : 'This window updates automatically once the bank is connected.'}
+          </p>
           {error && <p className="neg">{error}</p>}
         </div>
+      ) : updateItem ? (
+        <>
+          <p>
+            Update creds for <strong>{updateItem.institution_name ?? 'this link'}</strong>, keeping its accounts and
+            transactions.
+          </p>
+          <p className="dim">
+            Plaid reopens this connection so you can sign in again. Nothing is re-downloaded and no new accounts are
+            created — the history window stays at {updateItem.days_requested ? `${updateItem.days_requested} days` : 'its default'}.
+          </p>
+          {error && <p className="neg">{error}</p>}
+          <div className={styles.modalActions}>
+            <button className={styles.btnSecondary} onClick={onClose}>
+              Cancel
+            </button>
+            <button className={styles.btnPrimary} onClick={() => void start()}>
+              Open Plaid in browser
+            </button>
+          </div>
+        </>
       ) : (
         <>
           <div className={styles.formGrid}>

--- a/scripts/link.ts
+++ b/scripts/link.ts
@@ -1,104 +1,12 @@
 import 'dotenv/config';
 import http from 'node:http';
 import { execFile } from 'node:child_process';
-import { initDb, db } from '../core/db.js';
-import { createLinkToken, exchangePublicToken } from '../core/plaid.js';
-import { encryptToken } from '../core/crypto.js';
+import { initDb } from '../core/db.js';
+import {
+  clampDaysRequested, completeLink, createFlowLinkToken, linkPage, successPage,
+} from '../core/plaid-link-flow.js';
 
 const PORT = 4747;
-
-function linkPage(linkToken: string) {
-  return `<!DOCTYPE html>
-<html>
-<head>
-  <meta charset="utf-8" />
-  <title>Fungible — Connect Bank</title>
-  <style>
-    * { box-sizing: border-box; margin: 0; padding: 0; }
-    body { font-family: -apple-system, sans-serif; background: #0f0f0f; color: #e0e0e0; display: flex; align-items: center; justify-content: center; height: 100vh; }
-    .card { background: #1a1a1a; border: 1px solid #2a2a2a; border-radius: 12px; padding: 40px; text-align: center; max-width: 380px; }
-    h1 { font-size: 1.4rem; margin-bottom: 8px; color: #fff; }
-    p { color: #888; font-size: 0.9rem; margin-bottom: 28px; }
-    button { background: #00d4aa; color: #000; border: none; border-radius: 8px; padding: 12px 28px; font-size: 1rem; font-weight: 600; cursor: pointer; }
-    button:hover { background: #00bfa0; }
-    .status { margin-top: 20px; font-size: 0.85rem; color: #888; }
-    .success { color: #00d4aa; }
-    .error { color: #ff6b6b; }
-  </style>
-</head>
-<body>
-  <div class="card">
-    <h1>fungible</h1>
-    <p>Connect your bank account to start tracking expenses.</p>
-    <button id="connect-btn">Connect Bank</button>
-    <div class="status" id="status"></div>
-  </div>
-
-  <script src="https://cdn.plaid.com/link/v2/stable/link-initialize.js"></script>
-  <script>
-    const btn = document.getElementById('connect-btn');
-    const status = document.getElementById('status');
-
-    btn.addEventListener('click', () => {
-      const handler = Plaid.create({
-        token: '${linkToken}',
-        onSuccess: async (publicToken, metadata) => {
-          btn.disabled = true;
-          status.textContent = 'Connecting...';
-          try {
-            const res = await fetch('/callback', {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ public_token: publicToken, institution: metadata.institution }),
-            });
-            if (res.ok) {
-              status.className = 'status success';
-              status.textContent = 'Connected! You can close this window.';
-              btn.textContent = 'Done';
-            } else {
-              throw new Error(await res.text());
-            }
-          } catch (e) {
-            status.className = 'status error';
-            status.textContent = 'Error: ' + e.message;
-            btn.disabled = false;
-          }
-        },
-        onExit: (err) => {
-          if (err) {
-            status.className = 'status error';
-            status.textContent = err.display_message || 'Exited without connecting.';
-          }
-        },
-      });
-      handler.open();
-    });
-  </script>
-</body>
-</html>`;
-}
-
-function successPage() {
-  return `<!DOCTYPE html>
-<html>
-<head>
-  <meta charset="utf-8" />
-  <title>Connected</title>
-  <style>
-    body { font-family: -apple-system, sans-serif; background: #0f0f0f; color: #e0e0e0; display: flex; align-items: center; justify-content: center; height: 100vh; }
-    .card { background: #1a1a1a; border: 1px solid #2a2a2a; border-radius: 12px; padding: 40px; text-align: center; }
-    h1 { color: #00d4aa; margin-bottom: 8px; }
-    p { color: #888; font-size: 0.9rem; }
-  </style>
-</head>
-<body>
-  <div class="card">
-    <h1>Connected!</h1>
-    <p>You can close this window and return to the terminal.</p>
-  </div>
-</body>
-</html>`;
-}
 
 // History window (days of transactions Plaid backfills) is set by the TUI via
 // PLAID_DAYS_REQUESTED. It's locked at Item creation and can't be changed later.
@@ -107,7 +15,7 @@ function resolveDaysRequested(): number | undefined {
   if (!raw) return undefined;
   const n = parseInt(raw, 10);
   if (isNaN(n)) return undefined;
-  return Math.max(30, Math.min(730, n));
+  return clampDaysRequested(n);
 }
 
 /** Single-line progress line. The TUI pipes this stdout straight into the link
@@ -118,14 +26,18 @@ function log(msg: string) {
 
 async function main() {
   await initDb();
-  log('Creating Plaid link token…');
+  // Set by the TUI's [u] update link to re-authorize an existing connection in
+  // place rather than link a new one.
+  const updateItemId = process.env.PLAID_UPDATE_ITEM_ID || undefined;
   const daysRequested = resolveDaysRequested();
-  const linkToken = await createLinkToken('local-user', daysRequested);
+
+  log(updateItemId ? 'Creating Plaid update-mode link token…' : 'Creating Plaid link token…');
+  const linkToken = await createFlowLinkToken({ updateItemId, daysRequested });
 
   const server = http.createServer(async (req, res) => {
     if (req.method === 'GET' && req.url === '/') {
       res.writeHead(200, { 'Content-Type': 'text/html' });
-      res.end(linkPage(linkToken));
+      res.end(linkPage(linkToken, { updateMode: !!updateItemId }));
       return;
     }
 
@@ -134,26 +46,18 @@ async function main() {
       req.on('data', (chunk) => { body += chunk; });
       req.on('end', async () => {
         try {
-          const { public_token, institution } = JSON.parse(body);
-          const institutionName = institution?.name ?? null;
           // Each of these is a single line on purpose: the TUI renders only the
           // last line of a stdout chunk (tui/Accounts.tsx), so a multi-line log
           // would hide everything but its final line.
-          log(`Account link received from ${institutionName ?? 'Plaid'} — exchanging token…`);
-          const { accessToken, itemId } = await exchangePublicToken(public_token);
-
-          log('Saving institution…');
-          await db.execute({
-            sql: `INSERT INTO plaid_items (item_id, access_token, institution_name, days_requested)
-                  VALUES (?, ?, ?, ?)
-                  ON CONFLICT(item_id) DO UPDATE SET access_token=excluded.access_token, institution_name=excluded.institution_name, days_requested=excluded.days_requested`,
-            args: [itemId, encryptToken(accessToken), institutionName, daysRequested ?? null],
-          });
+          log(updateItemId
+            ? 'Credentials received — updating link…'
+            : 'Account link received from Plaid — exchanging token…');
+          const { itemId, institutionName, updateMode } = await completeLink(body, { updateItemId, daysRequested });
 
           res.writeHead(200, { 'Content-Type': 'text/html' });
-          res.end(successPage());
+          res.end(successPage({ updateMode, returnTo: 'the terminal' }));
 
-          log(`✓ Connected: ${institutionName ?? itemId} — returning to fungible…`);
+          log(`✓ ${updateMode ? 'Link updated' : 'Connected'}: ${institutionName ?? itemId} — returning to fungible…`);
 
           setTimeout(() => server.close(), 1000);
         } catch (e: any) {

--- a/scripts/sandbox-relink-check.ts
+++ b/scripts/sandbox-relink-check.ts
@@ -1,0 +1,87 @@
+import { config } from 'dotenv';
+import { join } from 'node:path';
+import { DATA_DIR } from '../core/paths.js';
+config({ path: join(DATA_DIR, '.env'), quiet: true });
+
+import { initDb, db } from '../core/db.js';
+import { getPlaidClient, plaidErrorMessage } from '../core/plaid.js';
+import { decryptToken } from '../core/crypto.js';
+
+/**
+ * Dev helper for verifying that updating a Plaid link re-authorizes the
+ * existing Item instead of creating a second one.
+ *
+ * Sandbox only, and it refuses to run anywhere else: `--break` deliberately
+ * invalidates an Item's login so the update flow has something to fix.
+ *
+ *   node --import tsx/esm scripts/sandbox-relink-check.ts            # snapshot
+ *   node --import tsx/esm scripts/sandbox-relink-check.ts --break    # force re-auth
+ *
+ * Take a snapshot, break the item, then update it in the TUI with [u] on the
+ * Links tab and snapshot again: every count should be identical. A new item,
+ * account or transaction total means the update created a fresh Item rather
+ * than re-authorizing the old one.
+ */
+
+type ItemRow = { item_id: string; access_token: string; institution_name: string | null };
+
+async function snapshot(): Promise<void> {
+  const items = (await db.execute(
+    'SELECT item_id, institution_name, days_requested FROM plaid_items ORDER BY item_id',
+  )).rows as unknown as { item_id: string; institution_name: string | null; days_requested: number | null }[];
+
+  const counts = (await db.execute(`
+    SELECT
+      (SELECT COUNT(*) FROM plaid_items)   AS items,
+      (SELECT COUNT(*) FROM accounts)      AS accounts,
+      (SELECT COUNT(*) FROM transactions)  AS transactions
+  `)).rows[0] as unknown as { items: number; accounts: number; transactions: number };
+
+  console.log(`\nItems: ${counts.items}  ·  Accounts: ${counts.accounts}  ·  Transactions: ${counts.transactions}`);
+  for (const item of items) {
+    const perItem = (await db.execute({
+      sql: `SELECT COUNT(*) AS n FROM accounts WHERE item_id = ?`,
+      args: [item.item_id],
+    })).rows[0] as unknown as { n: number };
+    console.log(
+      `  ${item.item_id}  ${item.institution_name ?? '(unnamed)'}` +
+      `  — ${perItem.n} account(s), days_requested=${item.days_requested ?? 'default'}`,
+    );
+  }
+  console.log('');
+}
+
+async function breakLogin(): Promise<void> {
+  const items = (await db.execute('SELECT item_id, access_token, institution_name FROM plaid_items')).rows as unknown as ItemRow[];
+  if (items.length === 0) throw new Error('No linked items — link a sandbox bank first.');
+
+  const wanted = process.argv.find((a) => a.startsWith('--item='))?.slice('--item='.length);
+  const item = wanted ? items.find((i) => i.item_id === wanted) : items[0];
+  if (!item) throw new Error(`Item ${wanted} not found. Known: ${items.map((i) => i.item_id).join(', ')}`);
+  if (!wanted && items.length > 1) {
+    throw new Error(`Multiple items linked — pick one with --item=<id>: ${items.map((i) => i.item_id).join(', ')}`);
+  }
+
+  await getPlaidClient().sandboxItemResetLogin({ access_token: decryptToken(item.access_token) });
+  console.log(`\n✓ Login invalidated for ${item.institution_name ?? item.item_id}.`);
+  console.log('  The next sync will fail with ITEM_LOGIN_REQUIRED — that is expected.\n');
+  console.log('  Now: open the TUI (npm run dev) → Accounts → Tab to Links → select this bank → press [u].');
+  console.log('  Sign in with the sandbox credentials user_good / pass_good.');
+  console.log('  Then re-run this script with no flags and compare the counts above.\n');
+}
+
+async function main() {
+  const env = process.env.PLAID_ENV ?? 'sandbox';
+  if (env !== 'sandbox') {
+    throw new Error(`Refusing to run against PLAID_ENV="${env}" — this script is sandbox-only.`);
+  }
+
+  await initDb();
+  await snapshot();
+  if (process.argv.includes('--break')) await breakLogin();
+}
+
+main().catch((e) => {
+  console.error('Error:', plaidErrorMessage(e));
+  process.exit(1);
+});

--- a/tests/gui/accounts-update-link.test.tsx
+++ b/tests/gui/accounts-update-link.test.tsx
@@ -1,0 +1,250 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import React from 'react';
+import { cleanup, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+vi.mock('../../core/db.js', async () => {
+  const { makeTestDb } = await import('../helpers/makeTestDb.js');
+  return { db: await makeTestDb() };
+});
+
+import { db } from '../../core/db.js';
+import { installBridge, renderScreen } from './helpers/renderGui.js';
+import { Accounts } from '../../gui/renderer/src/screens/Accounts.js';
+
+/**
+ * Overrides bridge calls for one test and records what each was called with.
+ *
+ * Three of these matter here. plaid.linkBank drives the whole feature and its
+ * default harness stub throws; its recorded arguments are the point, since
+ * passing days or omitting the item id is exactly the bug this fixed —
+ * /link/token/create without an access_token mints a new Item rather than
+ * re-authorizing the existing one. plaid.isConfigured must be true or the
+ * add-a-bank card renders disabled. And sync.syncAll is left pending on
+ * purpose: a successful update fires it, and letting it settle would overwrite
+ * the "Updated …" toast with the sync's own message before it could be read.
+ */
+function stubBridge(overrides: Record<string, (...args: unknown[]) => unknown>) {
+  const calls: Record<string, unknown[][]> = {};
+  const bridge = window.__bridge as unknown as {
+    call: (ns: string, fn: string, args: unknown[]) => Promise<unknown>;
+  };
+  const inner = bridge.call.bind(bridge);
+  bridge.call = async (ns, fn, args) => {
+    const key = `${ns}.${fn}`;
+    if (key in overrides) {
+      (calls[key] ??= []).push(args);
+      return overrides[key](...args);
+    }
+    return inner(ns, fn, args);
+  };
+  return {
+    callsTo: (key: string) => calls[key] ?? [],
+  };
+}
+
+/** The common stub set: Plaid configured, linkBank succeeding, sync left
+ *  pending so the post-update toast stays readable. */
+const linkBankStubs = (
+  linkBank: (...args: unknown[]) => unknown = async () => ({ institutionName: 'Chase' }),
+) => stubBridge({
+  'plaid.linkBank': linkBank,
+  'plaid.isConfigured': async () => true,
+  'sync.syncAll': () => new Promise(() => {}),
+});
+
+const addItem = (itemId: string, institution: string | null, daysRequested: number | null = null) =>
+  db.execute({
+    sql: `INSERT INTO plaid_items (item_id, access_token, institution_name, last_synced_at, days_requested)
+          VALUES (?, ?, ?, ?, ?)`,
+    args: [itemId, 'tok', institution, Date.now(), daysRequested],
+  });
+
+const addAccount = (id: string, itemId: string) =>
+  db.execute({
+    sql: `INSERT INTO accounts (id, name, type, subtype, item_id) VALUES (?, ?, 'depository', 'checking', ?)`,
+    args: [id, id, itemId],
+  });
+
+/** Renders the screen and opens the Links tab, where the action lives. */
+async function links() {
+  renderScreen(<Accounts />);
+  await userEvent.click(await screen.findByRole('button', { name: /^Links/ }));
+}
+
+/** The common case: one connection, sitting on the Links tab. */
+async function openUpdateModal(daysRequested: number | null = null) {
+  await addItem('item-a', 'Chase', daysRequested);
+  await addAccount('acct-1', 'item-a');
+  await links();
+  await userEvent.click(await screen.findByRole('button', { name: 'update link' }));
+  await waitFor(() => expect(screen.getByText('Update link')).toBeTruthy());
+}
+
+beforeEach(async () => {
+  for (const tbl of ['transaction_tags', 'tag_rule_suppressions', 'transactions', 'accounts',
+                     'balance_history', 'sync_state', 'plaid_items']) {
+    await db.execute(`DELETE FROM ${tbl}`);
+  }
+  installBridge();
+});
+
+afterEach(() => cleanup());
+
+describe('GUI Accounts — update link', () => {
+  it('offers "update link" on a connection row, not "repair"', async () => {
+    await addItem('item-a', 'Chase');
+    await addAccount('acct-1', 'item-a');
+    await links();
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'update link' })).toBeTruthy());
+    // The old name described the ordinary add-a-bank flow this replaced.
+    expect(screen.queryByRole('button', { name: 'repair' })).toBeNull();
+  });
+
+  it('names the connection being updated', async () => {
+    await openUpdateModal();
+    expect(screen.getByText(/keeping its accounts and transactions/)).toBeTruthy();
+    // Scoped to the modal's own emphasis: the row behind it also says "Chase".
+    expect(screen.getByText('Chase', { selector: 'strong' })).toBeTruthy();
+  });
+
+  // The window is fixed when the item is created and update mode cannot widen
+  // it, so offering the field would promise something Plaid rejects.
+  it('does not offer the history-window field', async () => {
+    await openUpdateModal(730);
+    expect(screen.queryByText('History (days)')).toBeNull();
+  });
+
+  it('names the history window it is leaving alone', async () => {
+    await openUpdateModal(730);
+    expect(screen.getByText(/history window stays at 730 days/)).toBeTruthy();
+  });
+
+  it('says the window keeps its default when none was recorded', async () => {
+    await openUpdateModal();
+    expect(screen.getByText(/history window stays at its default/)).toBeTruthy();
+  });
+
+  // The whole point of the feature: an update must carry the item id so Plaid
+  // re-authorizes this Item, and must not send a history window, which update
+  // mode forbids.
+  it('sends the item id and no history window', async () => {
+    const b = linkBankStubs();
+    await openUpdateModal(730);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Open Plaid in browser' }));
+
+    await waitFor(() => expect(b.callsTo('plaid.linkBank')).toHaveLength(1));
+    expect(b.callsTo('plaid.linkBank')[0]).toEqual([undefined, 'item-a']);
+  });
+
+  it('reports the update, closes the modal, and resyncs the connection', async () => {
+    const b = linkBankStubs();
+    await openUpdateModal();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Open Plaid in browser' }));
+
+    await waitFor(() => expect(screen.getByText(/Updated Chase/)).toBeTruthy());
+    expect(screen.queryByText('Update link')).toBeNull();
+    // The resync is what clears the badge: the item's last recorded sync is the
+    // failure that sent the user here, and nothing else refreshes that state.
+    expect(b.callsTo('sync.syncAll')).toHaveLength(1);
+  });
+
+  // Update mode's callback skips the public-token exchange, so Plaid need not
+  // hand back an institution name — the row already knows it.
+  it('falls back to the stored institution name when Plaid returns none', async () => {
+    linkBankStubs(async () => ({ institutionName: null }));
+    await openUpdateModal();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Open Plaid in browser' }));
+
+    await waitFor(() => expect(screen.getByText(/Updated Chase/)).toBeTruthy());
+  });
+
+  // The generic wording is only reachable for a non-Error rejection: an Error's
+  // own message wins, even an empty one. Thrown as a bare string here for that
+  // reason, not because the real flow is expected to.
+  it('reports a failed update as an update, not a failed link', async () => {
+    linkBankStubs(async () => {
+      throw 'no Error instance';
+    });
+    await openUpdateModal();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Open Plaid in browser' }));
+
+    await waitFor(() => expect(screen.getByText('Update failed')).toBeTruthy());
+    expect(screen.queryByText('Link failed')).toBeNull();
+  });
+
+  it('surfaces the reason when Plaid gives one', async () => {
+    linkBankStubs(async () => {
+      throw new Error('INSTITUTION_DOWN');
+    });
+    await openUpdateModal();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Open Plaid in browser' }));
+
+    await waitFor(() => expect(screen.getByText('INSTITUTION_DOWN')).toBeTruthy());
+  });
+
+  it('Cancel closes without touching Plaid', async () => {
+    const b = linkBankStubs();
+    await openUpdateModal();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    await waitFor(() => expect(screen.queryByText('Update link')).toBeNull());
+    expect(b.callsTo('plaid.linkBank')).toHaveLength(0);
+  });
+
+  // The modal is shared with the add-a-bank flow, so update mode's changes have
+  // to leave that path alone: it still asks for a window and sends no item id.
+  describe('the add-a-bank path it shares a modal with', () => {
+    it('still offers the history-window field', async () => {
+      linkBankStubs();
+      renderScreen(<Accounts />);
+      await userEvent.click(await screen.findByRole('button', { name: 'Add Data' }));
+      await userEvent.click(await screen.findByText('Link a bank'));
+
+      await waitFor(() => expect(screen.getByText('History (days)')).toBeTruthy());
+      expect(screen.queryByText(/keeping its accounts and transactions/)).toBeNull();
+    });
+
+    it('still sends a history window and no item id', async () => {
+      const b = linkBankStubs();
+      renderScreen(<Accounts />);
+      await userEvent.click(await screen.findByRole('button', { name: 'Add Data' }));
+      await userEvent.click(await screen.findByText('Link a bank'));
+      await waitFor(() => expect(screen.getByText('History (days)')).toBeTruthy());
+
+      // Prefilled from getDefaultDaysRequested — typing without clearing would
+      // append and then truncate straight back to the default.
+      const input = screen.getByText('History (days)').closest('div')!.querySelector('input')!;
+      await userEvent.clear(input);
+      await userEvent.type(input, '365');
+      await userEvent.click(screen.getByRole('button', { name: 'Open Plaid in browser' }));
+
+      await waitFor(() => expect(b.callsTo('plaid.linkBank')).toHaveLength(1));
+      expect(b.callsTo('plaid.linkBank')[0]).toEqual([365, undefined]);
+    });
+
+    it('still rejects a window outside Plaid\'s range', async () => {
+      const b = linkBankStubs();
+      renderScreen(<Accounts />);
+      await userEvent.click(await screen.findByRole('button', { name: 'Add Data' }));
+      await userEvent.click(await screen.findByText('Link a bank'));
+      await waitFor(() => expect(screen.getByText('History (days)')).toBeTruthy());
+
+      const input = screen.getByText('History (days)').closest('div')!.querySelector('input')!;
+      await userEvent.clear(input);
+      await userEvent.type(input, '20');
+      await userEvent.click(screen.getByRole('button', { name: 'Open Plaid in browser' }));
+
+      await waitFor(() => expect(screen.getByText(/whole number from 30 to 730/)).toBeTruthy());
+      expect(b.callsTo('plaid.linkBank')).toHaveLength(0);
+    });
+  });
+});

--- a/tests/gui/accounts.test.tsx
+++ b/tests/gui/accounts.test.tsx
@@ -311,12 +311,12 @@ describe('GUI Accounts — Links tab', () => {
     });
   });
 
-  it('repair opens the Plaid link flow', async () => {
+  it('update link opens the Plaid link flow', async () => {
     await addItem('item-a', 'Chase', Date.now());
     await addAccount('acct-1', 'item-a');
     await links();
 
-    await userEvent.click(await screen.findByRole('button', { name: 'repair' }));
+    await userEvent.click(await screen.findByRole('button', { name: 'update link' }));
 
     await waitFor(() => expect(screen.getByRole('button', { name: 'Open Plaid in browser' })).toBeTruthy());
   });

--- a/tests/plaid-link-flow.test.ts
+++ b/tests/plaid-link-flow.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('../core/db.js', async () => {
+  const { makeTestDb } = await import('./helpers/makeTestDb.js');
+  return { db: await makeTestDb() };
+});
+
+vi.mock('../core/plaid.js', () => ({
+  createLinkToken: vi.fn().mockResolvedValue('link-tok'),
+  exchangePublicToken: vi.fn().mockResolvedValue({ accessToken: 'access-new', itemId: 'item-new' }),
+}));
+
+vi.mock('../core/crypto.js', () => ({
+  encryptToken: (t: string) => `enc(${t})`,
+  decryptToken: (t: string) => t.replace(/^enc\((.*)\)$/, '$1'),
+}));
+
+import { db } from '../core/db.js';
+import { createLinkToken, exchangePublicToken } from '../core/plaid.js';
+import { completeLink, createFlowLinkToken } from '../core/plaid-link-flow.js';
+
+const CALLBACK_BODY = JSON.stringify({
+  public_token: 'public-abc',
+  institution: { name: 'Tartan Bank' },
+});
+
+async function itemRow(itemId: string) {
+  const res = await db.execute({ sql: 'SELECT * FROM plaid_items WHERE item_id = ?', args: [itemId] });
+  return res.rows[0] as unknown as
+    { item_id: string; access_token: string; institution_name: string | null; days_requested: number | null } | undefined;
+}
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  await db.execute('DELETE FROM plaid_items');
+});
+
+describe('createFlowLinkToken', () => {
+  it('sends no access token when adding a bank', async () => {
+    await createFlowLinkToken({ daysRequested: 365 });
+    expect(createLinkToken).toHaveBeenCalledWith('local-user', 365, undefined);
+  });
+
+  it('sends the stored access token in update mode, decrypted', async () => {
+    await db.execute({
+      sql: `INSERT INTO plaid_items (item_id, access_token, institution_name, days_requested) VALUES (?, ?, ?, ?)`,
+      args: ['item-1', 'enc(access-existing)', 'Tartan Bank', 365],
+    });
+    await createFlowLinkToken({ updateItemId: 'item-1' });
+    expect(createLinkToken).toHaveBeenCalledWith('local-user', undefined, 'access-existing');
+  });
+
+  it('refuses to update an item that is not in the database', async () => {
+    await expect(createFlowLinkToken({ updateItemId: 'item-missing' })).rejects.toThrow(/item-missing/);
+  });
+});
+
+describe('completeLink', () => {
+  it('exchanges and stores the item when adding a bank', async () => {
+    const result = await completeLink(CALLBACK_BODY, { daysRequested: 365 });
+
+    expect(exchangePublicToken).toHaveBeenCalledWith('public-abc');
+    expect(result).toEqual({ itemId: 'item-new', institutionName: 'Tartan Bank', updateMode: false });
+    expect(await itemRow('item-new')).toMatchObject({
+      access_token: 'enc(access-new)',
+      institution_name: 'Tartan Bank',
+      days_requested: 365,
+    });
+  });
+
+  it('does not exchange the public token in update mode', async () => {
+    await db.execute({
+      sql: `INSERT INTO plaid_items (item_id, access_token, institution_name, days_requested) VALUES (?, ?, ?, ?)`,
+      args: ['item-1', 'enc(access-existing)', 'Tartan Bank', 365],
+    });
+
+    const result = await completeLink(CALLBACK_BODY, { updateItemId: 'item-1' });
+
+    expect(exchangePublicToken).not.toHaveBeenCalled();
+    expect(result).toEqual({ itemId: 'item-1', institutionName: 'Tartan Bank', updateMode: true });
+  });
+
+  // An update carries no days_requested (update mode forbids it), so writing the
+  // row would blank the history window stored when the Item was created.
+  it('leaves the existing item row untouched in update mode', async () => {
+    await db.execute({
+      sql: `INSERT INTO plaid_items (item_id, access_token, institution_name, days_requested) VALUES (?, ?, ?, ?)`,
+      args: ['item-1', 'enc(access-existing)', 'Tartan Bank', 365],
+    });
+
+    await completeLink(CALLBACK_BODY, { updateItemId: 'item-1' });
+
+    expect(await itemRow('item-1')).toMatchObject({
+      access_token: 'enc(access-existing)',
+      days_requested: 365,
+    });
+  });
+
+  // The whole point of update mode: updating a link must not leave a second Item
+  // behind, because a new Item means new account and transaction ids.
+  it('adds no second item row in update mode', async () => {
+    await db.execute({
+      sql: `INSERT INTO plaid_items (item_id, access_token, institution_name, days_requested) VALUES (?, ?, ?, ?)`,
+      args: ['item-1', 'enc(access-existing)', 'Tartan Bank', 365],
+    });
+
+    await completeLink(CALLBACK_BODY, { updateItemId: 'item-1' });
+
+    const all = await db.execute('SELECT item_id FROM plaid_items');
+    expect(all.rows.map((r) => (r as unknown as { item_id: string }).item_id)).toEqual(['item-1']);
+  });
+});

--- a/tests/plaid-link-token.test.ts
+++ b/tests/plaid-link-token.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { LinkTokenCreateRequest } from 'plaid';
+
+const linkTokenCreate = vi.fn().mockResolvedValue({ data: { link_token: 'link-tok' } });
+
+vi.mock('plaid', async () => {
+  const actual = await vi.importActual<typeof import('plaid')>('plaid');
+  return { ...actual, PlaidApi: vi.fn().mockImplementation(() => ({ linkTokenCreate })) };
+});
+
+import { Products } from 'plaid';
+import { createLinkToken } from '../core/plaid.js';
+
+/** The request body handed to Plaid by the most recent createLinkToken call. */
+function lastRequest(): LinkTokenCreateRequest {
+  return linkTokenCreate.mock.calls.at(-1)![0] as LinkTokenCreateRequest;
+}
+
+beforeEach(() => {
+  linkTokenCreate.mockClear();
+  process.env.PLAID_CLIENT_ID = 'test-client';
+  process.env.PLAID_SECRET = 'test-secret';
+  process.env.PLAID_ENV = 'sandbox';
+});
+
+describe('createLinkToken', () => {
+  it('requests the Transactions product when adding a new bank', async () => {
+    await createLinkToken('local-user');
+    const req = lastRequest();
+    expect(req.products).toEqual([Products.Transactions]);
+    expect(req.access_token).toBeUndefined();
+  });
+
+  it('passes the history window through when adding', async () => {
+    await createLinkToken('local-user', 365);
+    expect(lastRequest().transactions).toEqual({ days_requested: 365 });
+  });
+
+  // The regression this whole change exists to prevent: without access_token,
+  // Plaid mints a brand-new Item on every update, giving every account and
+  // transaction fresh ids and duplicating the entire history window.
+  it('switches to update mode when given an access token', async () => {
+    await createLinkToken('local-user', undefined, 'access-abc');
+    expect(lastRequest().access_token).toBe('access-abc');
+  });
+
+  // Plaid rejects (or silently mis-handles) a product-specific parameter in
+  // update mode, and the TUI passes its default day count on update regardless,
+  // so the omission has to survive both arguments being present at once.
+  it('omits products and days_requested in update mode even if days are supplied', async () => {
+    await createLinkToken('local-user', 365, 'access-abc');
+    const req = lastRequest();
+    expect(req.products).toBeUndefined();
+    expect(req.transactions).toBeUndefined();
+    expect(req.access_token).toBe('access-abc');
+  });
+});

--- a/tests/tui/accounts-update-link.test.tsx
+++ b/tests/tui/accounts-update-link.test.tsx
@@ -1,0 +1,156 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import React from 'react';
+import { EventEmitter } from 'node:events';
+import { render, cleanup } from 'ink-testing-library';
+
+vi.mock('../../core/db.js', async () => {
+  const { makeTestDb } = await import('../helpers/makeTestDb.js');
+  return { db: await makeTestDb() };
+});
+
+// The link flow runs in a spawned child. Stand in for it so a test can drive the
+// exit code directly instead of launching Plaid.
+const spawned: { args: string[]; env: NodeJS.ProcessEnv; child: FakeChild }[] = [];
+
+class FakeChild extends EventEmitter {
+  stdout = new EventEmitter();
+  stderr = new EventEmitter();
+}
+
+vi.mock('node:child_process', () => ({
+  spawn: (_cmd: string, args: string[], opts: { env: NodeJS.ProcessEnv }) => {
+    const child = new FakeChild();
+    spawned.push({ args, env: opts.env, child });
+    return child;
+  },
+}));
+
+vi.mock('../../core/sync.js', () => ({ syncAll: vi.fn().mockResolvedValue([]) }));
+
+import { db } from '../../core/db.js';
+import { syncAll } from '../../core/sync.js';
+import { Accounts } from '../../tui/Accounts.js';
+import { RefreshProvider } from '../../tui/RefreshContext.js';
+import { TypingContext } from '../../tui/TypingContext.js';
+
+const ANSI_RE = /\x1b\[[0-9;]*[mGKHFABCDJ]/g;
+const flat = (r: ReturnType<typeof render>) =>
+  (r.lastFrame() ?? '').replace(ANSI_RE, '').replace(/\s+/g, ' ');
+
+async function waitFor(assertion: () => void, timeout = 1000): Promise<void> {
+  const deadline = Date.now() + timeout;
+  let lastErr: unknown;
+  while (Date.now() < deadline) {
+    try { assertion(); return; } catch (e) { lastErr = e; }
+    await new Promise((res) => setTimeout(res, 30));
+  }
+  throw lastErr;
+}
+
+function renderAccounts() {
+  return render(
+    <RefreshProvider>
+      <TypingContext.Provider value={() => {}}>
+        <Accounts onNavigate={() => {}} showHints={false} />
+      </TypingContext.Provider>
+    </RefreshProvider>,
+  );
+}
+
+/** Tab from the Accounts view to the Links view and wait for it to render. */
+async function toLinks(r: ReturnType<typeof render>) {
+  r.stdin.write('\t');
+  await waitFor(() => expect(flat(r)).toContain('connection'));
+}
+
+/** Finish the most recently spawned link process with the given exit code. */
+function finishLink(code: number) {
+  spawned.at(-1)!.child.emit('close', code);
+}
+
+beforeEach(async () => {
+  spawned.length = 0;
+  vi.mocked(syncAll).mockClear();
+  for (const t of ['transactions', 'balance_history', 'accounts', 'plaid_items', 'sync_state']) {
+    await db.execute(`DELETE FROM ${t}`);
+  }
+  await db.execute(
+    `INSERT INTO plaid_items (item_id, access_token, institution_name, last_synced_at) VALUES ('item-1', 'enc(tok)', 'Chase', 1750000000000)`,
+  );
+  await db.execute(
+    `INSERT INTO accounts (id, name, type, subtype, item_id) VALUES ('acct-1', 'Chase Checking', 'depository', 'checking', 'item-1')`,
+  );
+});
+
+afterEach(() => cleanup());
+
+describe('Accounts — update link', () => {
+  it('offers update link on a connection row', async () => {
+    const r = renderAccounts();
+    await toLinks(r);
+    expect(flat(r)).toContain('[u] update link');
+    expect(flat(r)).toContain('update creds for link, keeping its accounts and transactions');
+  });
+
+  it('puts the item id in the child environment so Link runs in update mode', async () => {
+    const r = renderAccounts();
+    await toLinks(r);
+
+    r.stdin.write('u');
+    await waitFor(() => expect(spawned).toHaveLength(1));
+
+    expect(spawned[0].env.PLAID_UPDATE_ITEM_ID).toBe('item-1');
+  });
+
+  // An update cannot change the history window — it is fixed when the item is
+  // created — so the days prompt that the add flow shows must be skipped.
+  it('skips the history-window prompt and goes straight to Plaid', async () => {
+    const r = renderAccounts();
+    await toLinks(r);
+
+    r.stdin.write('u');
+    await waitFor(() => expect(flat(r)).toContain('Update Link Credentials'));
+    expect(flat(r)).not.toContain('Transaction History Window');
+  });
+
+  // Without this, the row keeps its ⚠ badge and the banner still reads "sync
+  // failed" after an update that actually worked — the item's last recorded sync
+  // is the failure that sent the user here in the first place.
+  it('syncs just this item once the update succeeds', async () => {
+    const r = renderAccounts();
+    await toLinks(r);
+
+    r.stdin.write('u');
+    await waitFor(() => expect(spawned).toHaveLength(1));
+    expect(syncAll).not.toHaveBeenCalled();
+
+    finishLink(0);
+    await waitFor(() => expect(syncAll).toHaveBeenCalled());
+    // Scoped to the updated item, so other connections' failures are untouched.
+    expect(vi.mocked(syncAll).mock.calls[0][1]).toEqual(['item-1']);
+  });
+
+  it('does not sync when the update fails', async () => {
+    const r = renderAccounts();
+    await toLinks(r);
+
+    r.stdin.write('u');
+    await waitFor(() => expect(spawned).toHaveLength(1));
+
+    finishLink(1);
+    await waitFor(() => expect(flat(r)).toContain('exited with code 1'));
+    expect(syncAll).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when there are no connections to update', async () => {
+    await db.execute(`DELETE FROM accounts`);
+    await db.execute(`DELETE FROM plaid_items`);
+    const r = renderAccounts();
+    r.stdin.write('\t');
+    await waitFor(() => expect(flat(r)).toContain('No bank connections yet.'));
+
+    r.stdin.write('u');
+    await new Promise((res) => setTimeout(res, 100));
+    expect(spawned).toHaveLength(0);
+  });
+});

--- a/tests/tui/screens.test.tsx
+++ b/tests/tui/screens.test.tsx
@@ -2086,8 +2086,9 @@ describe('Accounts', () => {
 
   // ── Links tab ──────────────────────────────────────────────────────────────
   // Connection-level view: one row per Plaid item, not per account. The actions
-  // that belong to an item (repair now, update mode and replace later) live here
-  // rather than on an account row, where they implied a scope they never had.
+  // that belong to an item (updating its credentials now, replacing a connection
+  // later) live here rather than on an account row, where they implied a scope
+  // they never had.
   describe('links tab', () => {
     beforeEach(async () => {
       await db.execute('DELETE FROM accounts');
@@ -2158,14 +2159,15 @@ describe('Accounts', () => {
       expect(flat(r)).not.toContain('full replay pending');
     });
 
-    it('[r] opens the link flow from the Links view', async () => {
+    // Pressing [u] spawns the Plaid subprocess, so the behaviour it drives is
+    // covered in tests/tui/accounts-update-link.test.tsx, which mocks the spawn.
+    it('offers [u] update link on a connection row', async () => {
       await addItem('item-a', 'Chase', Date.now());
       await addAccount('acct-1', 'item-a');
 
       const r = accounts();
       await tabTo(r, 'links');
-      r.stdin.write('r');
-      await waitFor(() => expect(flat(r)).toContain('Transaction History Window'));
+      expect(flat(r)).toContain('[u] update link');
     });
 
     it('empty state points at Add Data', async () => {
@@ -2174,14 +2176,15 @@ describe('Accounts', () => {
       expect(flat(r)).toContain('No bank connections yet.');
     });
 
-    it('repair is no longer offered from an account row', async () => {
+    it('the link action is no longer offered from an account row', async () => {
       await addItem('item-a', 'Chase', Date.now());
       await addAccount('acct-1', 'item-a');
 
       const r = accounts({ showHints: true });
       await waitFor(() => expect(flat(r)).toContain('acct-1'));
       // It moved to the Links tab; the accounts hint must not still advertise it.
-      expect(flat(r)).not.toContain('[r] repair link');
+      expect(flat(r)).not.toContain('update link');
+      expect(flat(r)).not.toContain('repair link');
     });
   });
 });

--- a/tui/Accounts.tsx
+++ b/tui/Accounts.tsx
@@ -117,6 +117,9 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
   // Last stderr text from the link subprocess. Read from the long-lived close
   // handler, so it's a ref rather than state.
   const linkErrRef = useRef('');
+  // Whether the Plaid panel is adding a connection or updating an existing
+  // one's credentials — the two flows share the panel but not the wording.
+  const [linkMode, setLinkMode] = useState<'add' | 'update'>('add');
   const [daysInput, setDaysInput] = useState(String(MAX_DAYS_REQUESTED));
   const [daysError, setDaysError] = useState('');
   // Default history window derived from the start date set during setup.
@@ -331,10 +334,10 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
   /** Sync just the given items — used right after a link so the new institution
    *  syncs immediately. Mirrors forceSync but merges its outcome so another
    *  institution's failure badge survives a scoped run. */
-  function syncItems(itemIds: string[]) {
+  function syncItems(itemIds: string[], startMsg = 'Syncing new institution…') {
     syncStatusRef.current = 'syncing';   // visible before the re-render lands
     setSyncStatus('syncing');
-    setSyncMsg('Syncing new institution…');
+    setSyncMsg(startMsg);
     syncAll(true, itemIds, reportProgress).then((results) => {
       const failed = results.filter((r) => r.error);
       mergeSyncResult(results, itemIds);
@@ -406,7 +409,12 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
     }
   }
 
-  function startPlaidLink(days = 730) {
+  // `updateItemId` re-authorizes that Item in place (Plaid update mode) instead
+  // of linking a new one, which is what keeps its accounts and transactions
+  // intact. The history window can't be changed on an update, so `days` is only
+  // meaningful when adding.
+  function startPlaidLink(days = 730, updateItemId?: string) {
+    setLinkMode(updateItemId ? 'update' : 'add');
     setLinkStatus('running');
     setLinkMsg('Opening browser…');
     setLinkUrl('');
@@ -419,7 +427,11 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
       script,
     ], {
       cwd: new URL('..', import.meta.url).pathname,
-      env: { ...process.env, PLAID_DAYS_REQUESTED: String(days) },
+      env: {
+        ...process.env,
+        PLAID_DAYS_REQUESTED: String(days),
+        ...(updateItemId ? { PLAID_UPDATE_ITEM_ID: updateItemId } : {}),
+      },
     });
     child.stdout.on('data', (data: Buffer) => {
       const chunk = data.toString();
@@ -439,15 +451,26 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
     child.on('close', (code: number) => {
       if (code === 0) {
         setLinkStatus('done');
-        setLinkMsg('Bank connected! Press Enter to continue.');
-        // The reload surfaces the institution's placeholder row immediately —
-        // that alone answers "did it work?" even if the sync is slow. The
-        // placeholders *are* the items needing a first sync, so the ids come
-        // from the loaded list rather than out of the link subprocess's stdout.
-        void loadAccounts().then((accts) => {
-          const itemIds = [...new Set(accts.filter((a) => a.awaitingFirstSync).map((a) => a.item_id!))];
-          if (itemIds.length > 0 && syncStatusRef.current !== 'syncing') syncItems(itemIds);
-        });
+        if (updateItemId) {
+          // The item almost certainly got here by failing to sync, so its badge
+          // and the global banner still show state from before the update.
+          // Syncing just this item clears them and picks up whatever was missed
+          // while the credentials were stale — mergeSyncResult scopes the clear
+          // to the attempted item, leaving other items' failures alone.
+          setLinkMsg('Link updated! Press Enter to continue.');
+          void loadAccounts();
+          if (syncStatusRef.current !== 'syncing') syncItems([updateItemId], 'Syncing updated link…');
+        } else {
+          setLinkMsg('Bank connected! Press Enter to continue.');
+          // The reload surfaces the institution's placeholder row immediately —
+          // that alone answers "did it work?" even if the sync is slow. The
+          // placeholders *are* the items needing a first sync, so the ids come
+          // from the loaded list rather than out of the link subprocess's stdout.
+          void loadAccounts().then((accts) => {
+            const itemIds = [...new Set(accts.filter((a) => a.awaitingFirstSync).map((a) => a.item_id!))];
+            if (itemIds.length > 0 && syncStatusRef.current !== 'syncing') syncItems(itemIds);
+          });
+        }
       } else if (code !== null) {
         setLinkStatus('error');
         // Keep the stderr reason if we captured one — it says *why* the link
@@ -640,11 +663,13 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
       if (key.tab) { setMainView('add-data'); return; }
       if (key.upArrow)   { setItemCursor((c) => Math.max(0, c - 1)); return; }
       if (key.downArrow) { setItemCursor((c) => Math.min(linkedItems.length - 1, c + 1)); return; }
-      if (input === 'r' && linkedItems[itemCursor]) {
+      // Update link goes straight to Plaid in update mode: it re-authorizes this
+      // connection, so there's no history window to ask about (that's fixed when
+      // the item is created) and no new accounts or transactions to create.
+      if (input === 'u' && linkedItems[itemCursor]) {
         setMainView('add-data');
-        setDaysInput(String(defaultDays));
-        setDaysError('');
-        setAddStep('link-days');
+        setAddStep('link-plaid');
+        startPlaidLink(defaultDays, linkedItems[itemCursor].item_id);
         return;
       }
       if (input === 's' && syncStatus !== 'syncing') { forceSync(); return; }
@@ -855,7 +880,7 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
             : mainView === 'accounts' && acctMode === 'edit'
             ? '↑↓ field  ·  ← → change  ·  Enter save  ·  Esc cancel'
             : mainView === 'links'
-            ? '↑↓ select  ·  [r] repair link  ·  [s] sync'
+            ? '↑↓ select  ·  [u] update link  ·  [s] sync'
             : mainView === 'dupes'
             ? '↑↓ select  ·  [x] delete CSV copy  ·  [X] delete all'
             : ''}
@@ -1028,8 +1053,8 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
               {syncMsg && <Text color={syncStatus === 'syncing' ? C_WARNING : syncStatus === 'error' ? C_NEGATIVE : C_POSITIVE}>{syncMsg}<Text dimColor>{syncElapsed}</Text></Text>}
 
               <Box marginTop={1} flexDirection="column">
-                <Text dimColor>[r] repair link  — reconnect this institution through Plaid</Text>
-                <Text dimColor>[s] sync        — re-sync every connection now</Text>
+                <Text dimColor>[u] update link  — update creds for link, keeping its accounts and transactions</Text>
+                <Text dimColor>[s] sync         — re-sync every connection now</Text>
               </Box>
             </>
           )}
@@ -1101,7 +1126,7 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
 
           {addStep === 'link-plaid' && (
             <Box flexDirection="column" marginTop={1} gap={1}>
-              <Text bold>Link Bank Account</Text>
+              <Text bold>{linkMode === 'update' ? 'Update Link Credentials' : 'Link Bank Account'}</Text>
               <Text color={linkStatus === 'done' ? C_POSITIVE : linkStatus === 'error' ? C_NEGATIVE : C_WARNING}>
                 {linkStatus === 'running' ? '⟳ ' : ''}{linkMsg}<Text dimColor>{linkElapsed}</Text>
               </Text>
@@ -1110,6 +1135,9 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
               )}
               {linkStatus === 'running' && (
                 <Text dimColor>Complete the Plaid flow in your browser, then return here.</Text>
+              )}
+              {linkStatus === 'running' && linkMode === 'update' && (
+                <Text dimColor>Your existing accounts and transactions are kept — sign in with the same bank.</Text>
               )}
               {/* The post-link sync runs while this panel is still on screen, so
                   its steps have to be reported here too — otherwise the panel


### PR DESCRIPTION
> [!IMPORTANT]
> This is a stacked PR. Until the two below land, the diff here also shows their commits.
> 
> - [ ] #135 — `feature/accounts-sync-state`
> - [ ] #148 — `feat/accounts-links-tab` (builds on #135; adds the Links tab this PR's action lives on)
> 
> Only the top commit, `feat: update link credentials in place with Plaid update mode`, belongs to this PR.

## The bug

The Links tab's `[r] repair link` ran the ordinary add-a-bank flow, so `/link/token/create` was called without an `access_token`. That never enters update mode — Plaid mints a brand-new Item. Because `account_id`s and `transaction_id`s are Item-scoped, reconnecting a bank produced:

- duplicate account rows for every account on the connection
- the entire history window re-downloaded as duplicate transactions
- manual edits (`manual_category`, `display_name`, `ignored`, tags) stranded on the old rows
- account settings (`nickname`, `owner`, `apr`, `excluded`) reset to defaults on the new rows — including a previously excluded account silently rejoining net worth

`deduplicateCsvVsPlaid` cannot see any of it: it matches `csv.id LIKE 'csv-%'` against a Plaid row **on the same `account_id`**, and these duplicates are Plaid-vs-Plaid across two different account ids.

#148 was explicit that its `[r]` was a placeholder — "it is not yet repair… it puts it where real update mode will replace it." This is that replacement.

## The fix

`createLinkToken` takes an optional `accessToken`. When set it passes `access_token` and omits `products` and `transactions.days_requested`, both of which [update mode forbids](https://plaid.com/docs/link/update-mode/):

> No products should be added to the `products` array and no product-specific request parameters should be specified when creating a `link_token` for update mode…

The callback also skips the public-token exchange and the `plaid_items` write:

> You do not need to repeat the `/item/public_token/exchange` process when a user uses Link in update mode. The Item's `access_token` has not changed.

Skipping the write is load-bearing for a second reason: update mode must send no `days_requested`, so re-running the upsert would blank the stored history window of a working Item.

## Naming

`[r] repair link` becomes `[u] update link` — "update creds for link, keeping its accounts and transactions" — which is what it now actually does. The rename runs through the internals too (`updateItemId`, `PLAID_UPDATE_ITEM_ID`, `LinkCallbackResult.updateMode`) and the browser pages.

## Behaviour

`[u]` skips the history-window prompt, since that window is fixed at Item creation and an update cannot widen it. On success it syncs **that one item**, so the ⚠ badge and the banner stop showing the failure that sent the user there; `mergeSyncResult` (from #135) scopes the clear to the attempted item, leaving other connections' failures alone.

## Deduplication of the link flow

The flow was duplicated between `scripts/link.ts` and `gui/main/plaid-link.ts`, and this change would otherwise have to be made twice. The pages, `link_token` creation and callback persistence move to `core/plaid-link-flow.ts`. The server lifecycle stays with each caller — fixed vs ephemeral port, stdout progress vs promise, timeout/cancel hooks — since those are genuinely different rather than accidentally duplicated. `scripts/link.ts` drops from 190 lines to 74.

## GUI

The Links row button becomes `update link` and opens the modal in update mode: no history-window field, an explanation naming the institution, and the item id passed through `bridge.linkBank`. On success it syncs, which is what clears the badge.

## Tests

848 passing, typecheck clean.

- `tests/plaid-link-token.test.ts` — the request shape, including that `products`/`transactions` stay omitted **when a day count is also supplied**, which is the real call path
- `tests/plaid-link-flow.test.ts` — update mode never exchanges, leaves `days_requested` intact, and leaves exactly one `plaid_items` row
- `tests/tui/accounts-update-link.test.tsx` — `PLAID_UPDATE_ITEM_ID` reaches the child, the days prompt is skipped, success syncs with `['item-1']` specifically, failure does not sync

Both behavioural assertions were checked against the unfixed code and fail there.

## Verifying against a real Plaid sandbox

`scripts/sandbox-relink-check.ts` snapshots item/account/transaction counts and can invalidate a login via `/sandbox/item/reset_login`. Snapshot, break, `[u]`, snapshot again — every count should be identical. Sandbox-only; it refuses to run against any other `PLAID_ENV`.

I have exercised this against live Plaid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
