### PR TITLE
feat: on-demand transaction refresh from the Links tab

### DIFF
--- a/core/transactions-refresh.ts
+++ b/core/transactions-refresh.ts
@@ -1,0 +1,179 @@
+import { getPlaidClient, plaidErrorMessage } from './plaid.js';
+import { db } from './db.js';
+import { decryptToken } from './crypto.js';
+import { syncTransactions, describeSyncProgress, type SyncItemResult, type SyncProgress } from './sync.js';
+
+/**
+ * On-demand transaction refresh for one Plaid item.
+ *
+ * `/transactions/refresh` asks Plaid to go poll the bank right now instead of
+ * waiting for its next scheduled extraction. The 200 means the extraction was
+ * *queued*, not that it finished — Plaid signals completion with a webhook, and
+ * this app has none. So the only completion signal available is
+ * /transactions/sync eventually returning something, which is what the polling
+ * below does.
+ *
+ * Two consequences worth keeping in mind when changing this file:
+ *   - "no new transactions" and "refresh still running" are indistinguishable
+ *     from here. Never report the refresh as complete; report what sync returned.
+ *   - refresh fetches the *newest* transactions. It does not widen the item's
+ *     history window (fixed at item creation, and update mode cannot change it),
+ *     so it can only recover recent transactions, never old ones.
+ *
+ * Plaid bills per /transactions/refresh call on most plans, so the request is
+ * made exactly once per invocation; only the free /transactions/sync is polled.
+ *
+ * Calls `syncTransactions` directly rather than going through `syncAll`: this is
+ * inherently one-item work, and syncAll's 15-minute debounce would skip every
+ * check after the first.
+ */
+
+/** Waits before each post-refresh sync check. Banks routinely take a minute or
+ *  more to answer an on-demand extraction, so the tail is long and the total
+ *  budget is a little under four minutes. */
+export const POLL_DELAYS_MS = [15_000, 30_000, 60_000, 120_000];
+
+export type RefreshProgress =
+  | { phase: 'requesting' }
+  // `until` is a wall-clock deadline, not a duration, so a caller can re-render
+  // this same step every second and get a live countdown for free.
+  | { phase: 'waiting'; attempt: number; attempts: number; until: number }
+  | { phase: 'checking'; attempt: number; attempts: number }
+  | { phase: 'sync'; attempt: number; attempts: number; step: SyncProgress };
+
+/** Human-readable form of a progress step, shared by every caller that renders it. */
+export function describeRefreshProgress(p: RefreshProgress): string {
+  switch (p.phase) {
+    case 'requesting':
+      return 'Asking your bank for new transactions…';
+    case 'waiting': {
+      const secs = Math.max(0, Math.round((p.until - Date.now()) / 1000));
+      // Deliberately "requested", not "complete" — see the module comment.
+      return `Refresh requested — next check in ${secs}s (check ${p.attempt} of ${p.attempts})…`;
+    }
+    case 'checking':
+      return `Checking for new transactions (check ${p.attempt} of ${p.attempts})…`;
+    case 'sync':
+      return describeSyncProgress(p.step);
+  }
+}
+
+export type RefreshResult = {
+  itemId: string;
+  /** Totals across every check that ran, not just the last one. */
+  added: number;
+  modified: number;
+  removed: number;
+  /** How many sync checks actually ran. 0 means the refresh request itself failed. */
+  checks: number;
+  /** The caller aborted mid-poll. Counts still reflect the checks that did run. */
+  cancelled: boolean;
+  /** Set when the refresh request or a sync check failed. */
+  error?: string;
+  /**
+   * The last check's outcome in syncAll's shape, for feeding core/sync-status so
+   * a refresh maintains the ⚠ badge like any other sync: a failed check raises
+   * it, a clean one clears a stale one. Empty when no check ran — passing an
+   * empty list to mergeSyncResult would clear the badge without having earned it.
+   */
+  syncResults: SyncItemResult[];
+};
+
+/** One-line summary of a finished refresh, for the caller's status line. */
+export function describeRefreshResult(r: RefreshResult): string {
+  const found = [
+    r.added > 0 ? `${r.added} new transaction${r.added === 1 ? '' : 's'}` : null,
+    r.modified > 0 ? `${r.modified} updated` : null,
+  ].filter(Boolean).join(', ');
+
+  if (r.cancelled) {
+    return found
+      ? `Stopped checking — found ${found}`
+      : 'Stopped checking. The refresh may still be running at your bank — press [s] to sync later.';
+  }
+  if (found) return `Done — ${found}`;
+  return 'No new transactions yet — the refresh may still be running at your bank. Try [s] sync again in a few minutes.';
+}
+
+/** Resolves true when the full delay elapsed, false when `signal` aborted first. */
+function sleep(ms: number, signal?: AbortSignal): Promise<boolean> {
+  if (signal?.aborted) return Promise.resolve(false);
+  return new Promise((resolve) => {
+    let timer: NodeJS.Timeout;
+    const onAbort = () => { clearTimeout(timer); resolve(false); };
+    timer = setTimeout(() => { signal?.removeEventListener('abort', onAbort); resolve(true); }, ms);
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+/**
+ * Requests an on-demand refresh for `itemId`, then polls /transactions/sync on a
+ * backoff until something lands, the checks run out, or `signal` aborts.
+ *
+ * Returns rather than throws for the expected failures (unknown item, Plaid
+ * rejecting the refresh, the item failing to sync) so a caller can render one
+ * status line for every outcome.
+ */
+export async function refreshTransactions(
+  itemId: string,
+  opts: { onProgress?: (p: RefreshProgress) => void; signal?: AbortSignal } = {},
+): Promise<RefreshResult> {
+  const { onProgress, signal } = opts;
+  const result: RefreshResult = {
+    itemId, added: 0, modified: 0, removed: 0, checks: 0, cancelled: false, syncResults: [],
+  };
+
+  const itemRes = await db.execute({
+    sql: 'SELECT access_token FROM plaid_items WHERE item_id = ?',
+    args: [itemId],
+  });
+  if (itemRes.rows.length === 0) {
+    return { ...result, error: `No linked institution found for item ${itemId}.` };
+  }
+  const accessToken = decryptToken((itemRes.rows[0] as unknown as { access_token: string }).access_token);
+
+  onProgress?.({ phase: 'requesting' });
+  try {
+    await getPlaidClient().transactionsRefresh({ access_token: accessToken });
+  } catch (err) {
+    // Covers the ones users actually hit: Plaid not configured, the plan not
+    // including on-demand refresh, the institution not supporting it, a rate
+    // limit, and an item needing update mode.
+    return { ...result, error: plaidErrorMessage(err) };
+  }
+
+  const attempts = POLL_DELAYS_MS.length;
+  for (let i = 0; i < attempts; i++) {
+    const attempt = i + 1;
+    const delayMs = POLL_DELAYS_MS[i]!;
+
+    onProgress?.({ phase: 'waiting', attempt, attempts, until: Date.now() + delayMs });
+    if (!(await sleep(delayMs, signal))) {
+      result.cancelled = true;
+      return result;
+    }
+
+    onProgress?.({ phase: 'checking', attempt, attempts });
+    result.checks = attempt;
+    try {
+      const sync = await syncTransactions(accessToken, itemId,
+        (step) => onProgress?.({ phase: 'sync', attempt, attempts, step }));
+
+      result.added += sync.added;
+      result.modified += sync.modified;
+      result.removed += sync.removed;
+      result.syncResults = [{ itemId, ...sync, skipped: false }];
+
+      // `modified` counts too: a refresh that only flips pending → posted still
+      // means the extraction landed, and there's nothing more to wait for.
+      if (sync.added > 0 || sync.modified > 0) return result;
+    } catch (err) {
+      // A failing item won't start working on the next check — stop and report.
+      const error = plaidErrorMessage(err);
+      result.syncResults = [{ itemId, added: 0, modified: 0, removed: 0, dupes: 0, skipped: false, error }];
+      return { ...result, error };
+    }
+  }
+
+  return result;
+}

--- a/tests/gui-bridge-parity.test.ts
+++ b/tests/gui-bridge-parity.test.ts
@@ -59,6 +59,14 @@ const EXPECTED_UNBRIDGED: Record<string, string> = {
   getSyncFailures: 'GUI will surface sync status in its own layer',
   onSyncStatus: 'GUI will surface sync status in its own layer',
 
+  // On-demand /transactions/refresh (core/transactions-refresh.ts) — TUI-only for
+  // now. Bridging it needs more than a registry entry: the poll runs for minutes
+  // and streams progress, so the GUI needs a progress channel and a cancel path
+  // rather than a single request/response call. Remove these when that lands.
+  refreshTransactions: 'TUI-only; GUI needs a streaming progress + cancel channel, not a plain bridge call',
+  describeRefreshProgress: 'TUI-only; renderer will format its own progress once refresh is bridged',
+  describeRefreshResult: 'TUI-only; renderer will format its own result once refresh is bridged',
+
   // Generic settings access — GUI uses typed wrappers (settings.getPretaxMonthly /
   // settings.setPretaxMonthly) rather than the raw getSetting/setSetting functions.
   getSetting: 'GUI exposes typed wrappers (getPretaxMonthly/setPretaxMonthly) via settings namespace instead of generic access',

--- a/tests/transactions-refresh.test.ts
+++ b/tests/transactions-refresh.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+vi.mock('../core/db.js', async () => {
+  const { makeTestDb } = await import('./helpers/makeTestDb.js');
+  return { db: await makeTestDb() };
+});
+
+vi.mock('../core/plaid.js', () => ({
+  getPlaidClient: vi.fn(),
+  plaidErrorMessage: (err: unknown) => (err instanceof Error ? err.message : String(err)),
+}));
+
+vi.mock('../core/crypto.js', () => ({
+  decryptToken: (v: string) => `decrypted:${v}`,
+  encryptToken: (v: string) => v,
+}));
+
+// The poll's job is deciding *when* to sync and what to report; syncTransactions
+// has its own coverage in sync.test.ts. describeSyncProgress stays real so the
+// progress passthrough is exercised for what it actually renders.
+vi.mock('../core/sync.js', async (importActual) => {
+  const actual = await importActual<typeof import('../core/sync.js')>();
+  return { ...actual, syncTransactions: vi.fn() };
+});
+
+import { db } from '../core/db.js';
+import { getPlaidClient } from '../core/plaid.js';
+import { syncTransactions } from '../core/sync.js';
+import {
+  refreshTransactions, describeRefreshResult, describeRefreshProgress,
+  POLL_DELAYS_MS, type RefreshProgress,
+} from '../core/transactions-refresh.js';
+
+const ITEM = 'item-1';
+
+/** No transactions found — what every check returns until one doesn't. */
+const nothing = { added: 0, modified: 0, removed: 0, dupes: 0 };
+
+let transactionsRefresh: ReturnType<typeof vi.fn>;
+
+beforeEach(async () => {
+  vi.useFakeTimers();
+  await db.execute('DELETE FROM plaid_items');
+  await db.execute({
+    sql: `INSERT INTO plaid_items (item_id, access_token, institution_name) VALUES (?, ?, ?)`,
+    args: [ITEM, 'token-1', 'Test Bank'],
+  });
+  transactionsRefresh = vi.fn().mockResolvedValue({ data: { request_id: 'req-1' } });
+  vi.mocked(getPlaidClient).mockReturnValue({ transactionsRefresh } as never);
+  vi.mocked(syncTransactions).mockResolvedValue(nothing);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+/** Runs `p` to completion, advancing past every poll delay it waits on. */
+async function runPoll<T>(p: Promise<T>): Promise<T> {
+  for (const ms of POLL_DELAYS_MS) await vi.advanceTimersByTimeAsync(ms);
+  return p;
+}
+
+describe('refreshTransactions', () => {
+  it('sends the decrypted access token to /transactions/refresh exactly once', async () => {
+    const result = await runPoll(refreshTransactions(ITEM));
+
+    expect(transactionsRefresh).toHaveBeenCalledTimes(1);
+    expect(transactionsRefresh).toHaveBeenCalledWith({ access_token: 'decrypted:token-1' });
+    expect(result.error).toBeUndefined();
+  });
+
+  it('stops checking as soon as a sync returns something', async () => {
+    vi.mocked(syncTransactions)
+      .mockResolvedValueOnce(nothing)
+      .mockResolvedValueOnce({ added: 3, modified: 1, removed: 0, dupes: 0 });
+
+    const result = await runPoll(refreshTransactions(ITEM));
+
+    expect(syncTransactions).toHaveBeenCalledTimes(2);
+    expect(result).toMatchObject({ added: 3, modified: 1, checks: 2, cancelled: false });
+  });
+
+  it('counts a pending → posted update as something landing', async () => {
+    vi.mocked(syncTransactions).mockResolvedValueOnce({ added: 0, modified: 2, removed: 0, dupes: 0 });
+
+    const result = await runPoll(refreshTransactions(ITEM));
+
+    expect(syncTransactions).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({ added: 0, modified: 2, checks: 1 });
+  });
+
+  it('gives up after the last delay when nothing ever arrives', async () => {
+    const result = await runPoll(refreshTransactions(ITEM));
+
+    expect(syncTransactions).toHaveBeenCalledTimes(POLL_DELAYS_MS.length);
+    expect(result).toMatchObject({ added: 0, checks: POLL_DELAYS_MS.length, cancelled: false });
+    expect(result.error).toBeUndefined();
+  });
+
+  it('waits the full backoff between checks', async () => {
+    const p = refreshTransactions(ITEM);
+
+    // The refresh request itself resolves first; no check has run yet.
+    await vi.advanceTimersByTimeAsync(0);
+    expect(syncTransactions).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(POLL_DELAYS_MS[0]! - 1);
+    expect(syncTransactions).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(syncTransactions).toHaveBeenCalledTimes(1);
+
+    await runPoll(p);
+  });
+
+  it('reports a failed refresh request and never polls', async () => {
+    transactionsRefresh.mockRejectedValue(new Error('RATE_LIMIT_EXCEEDED'));
+
+    const result = await refreshTransactions(ITEM);
+
+    expect(result.error).toBe('RATE_LIMIT_EXCEEDED');
+    expect(result.checks).toBe(0);
+    expect(syncTransactions).not.toHaveBeenCalled();
+  });
+
+  it('stops on a failing sync rather than retrying an item that is broken', async () => {
+    vi.mocked(syncTransactions).mockRejectedValue(new Error('ITEM_LOGIN_REQUIRED'));
+
+    const result = await runPoll(refreshTransactions(ITEM));
+
+    expect(syncTransactions).toHaveBeenCalledTimes(1);
+    expect(result.error).toBe('ITEM_LOGIN_REQUIRED');
+    expect(result.checks).toBe(1);
+  });
+
+  it('reports an unknown item without calling Plaid', async () => {
+    const result = await refreshTransactions('item-missing');
+
+    expect(result.error).toContain('item-missing');
+    expect(transactionsRefresh).not.toHaveBeenCalled();
+  });
+
+  it('aborting mid-wait cancels without running another check', async () => {
+    const controller = new AbortController();
+    const p = refreshTransactions(ITEM, { signal: controller.signal });
+
+    // Land one check, then abort during the wait before the second.
+    await vi.advanceTimersByTimeAsync(POLL_DELAYS_MS[0]!);
+    expect(syncTransactions).toHaveBeenCalledTimes(1);
+
+    controller.abort();
+    const result = await runPoll(p);
+
+    expect(result.cancelled).toBe(true);
+    expect(syncTransactions).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports progress for the request, each wait, and each check', async () => {
+    const steps: RefreshProgress[] = [];
+    await runPoll(refreshTransactions(ITEM, { onProgress: (p) => steps.push(p) }));
+
+    expect(steps[0]).toEqual({ phase: 'requesting' });
+    expect(steps.filter((s) => s.phase === 'waiting')).toHaveLength(POLL_DELAYS_MS.length);
+    expect(steps.filter((s) => s.phase === 'checking')).toHaveLength(POLL_DELAYS_MS.length);
+  });
+
+  it('passes each sync step through so the caller can render it', async () => {
+    vi.mocked(syncTransactions).mockImplementation(async (_token, _id, onProgress) => {
+      onProgress?.({ phase: 'transactions', page: 1, fetched: 1200 });
+      return nothing;
+    });
+
+    const steps: RefreshProgress[] = [];
+    await runPoll(refreshTransactions(ITEM, { onProgress: (p) => steps.push(p) }));
+
+    const syncStep = steps.find((s) => s.phase === 'sync');
+    expect(syncStep).toBeDefined();
+    expect(describeRefreshProgress(syncStep!)).toContain('1,200 so far');
+  });
+
+  describe('syncResults (feeds the ⚠ badge)', () => {
+    it('carries a failed check so the badge can be raised', async () => {
+      vi.mocked(syncTransactions).mockRejectedValue(new Error('ITEM_LOGIN_REQUIRED'));
+
+      const result = await runPoll(refreshTransactions(ITEM));
+
+      expect(result.syncResults).toEqual([
+        { itemId: ITEM, added: 0, modified: 0, removed: 0, dupes: 0, skipped: false, error: 'ITEM_LOGIN_REQUIRED' },
+      ]);
+    });
+
+    it('carries a clean check so a stale badge can be cleared', async () => {
+      vi.mocked(syncTransactions).mockResolvedValueOnce({ added: 1, modified: 0, removed: 0, dupes: 0 });
+
+      const result = await runPoll(refreshTransactions(ITEM));
+
+      expect(result.syncResults).toEqual([
+        { itemId: ITEM, added: 1, modified: 0, removed: 0, dupes: 0, skipped: false },
+      ]);
+    });
+
+    it('stays empty when the refresh request failed, so no badge is touched', async () => {
+      transactionsRefresh.mockRejectedValue(new Error('RATE_LIMIT_EXCEEDED'));
+
+      const result = await refreshTransactions(ITEM);
+
+      expect(result.syncResults).toEqual([]);
+    });
+  });
+});
+
+describe('describeRefreshProgress', () => {
+  it('counts down as the deadline approaches rather than repeating the delay', () => {
+    const step: RefreshProgress = { phase: 'waiting', attempt: 1, attempts: 4, until: Date.now() + 60_000 };
+    expect(describeRefreshProgress(step)).toContain('next check in 60s');
+
+    vi.advanceTimersByTime(45_000);
+    expect(describeRefreshProgress(step)).toContain('next check in 15s');
+  });
+
+  it('says the refresh was requested, never that it completed', () => {
+    const step: RefreshProgress = { phase: 'waiting', attempt: 1, attempts: 4, until: Date.now() + 15_000 };
+    const text = describeRefreshProgress(step);
+    expect(text).toContain('Refresh requested');
+    expect(text.toLowerCase()).not.toContain('complete');
+  });
+});
+
+describe('describeRefreshResult', () => {
+  const base = { itemId: ITEM, added: 0, modified: 0, removed: 0, checks: 4, cancelled: false, syncResults: [] };
+
+  it('does not claim the refresh finished when nothing turned up', () => {
+    const text = describeRefreshResult(base);
+    expect(text).toContain('may still be running');
+    expect(text.toLowerCase()).not.toContain('complete');
+  });
+
+  it('reports what landed', () => {
+    expect(describeRefreshResult({ ...base, added: 1 })).toBe('Done — 1 new transaction');
+    expect(describeRefreshResult({ ...base, added: 2, modified: 1 })).toBe('Done — 2 new transactions, 1 updated');
+  });
+
+  it('distinguishes a cancelled poll from an exhausted one', () => {
+    expect(describeRefreshResult({ ...base, cancelled: true })).toContain('Stopped checking');
+    expect(describeRefreshResult({ ...base, cancelled: true, added: 2 })).toBe('Stopped checking — found 2 new transactions');
+  });
+});

--- a/tests/tui/screens.test.tsx
+++ b/tests/tui/screens.test.tsx
@@ -30,6 +30,7 @@ import { Tags } from '../../tui/Tags.js';
 import { Rules } from '../../tui/Rules.js';
 import { Accounts, extractLinkUrl } from '../../tui/Accounts.js';
 import * as accountsApi from '../../core/accounts.js';
+import * as refreshApi from '../../core/transactions-refresh.js';
 import * as syncApi from '../../core/sync.js';
 import * as dedupApi from '../../core/dedup.js';
 import { Health } from '../../tui/Health.js';
@@ -2185,6 +2186,133 @@ describe('Accounts', () => {
       // It moved to the Links tab; the accounts hint must not still advertise it.
       expect(flat(r)).not.toContain('update link');
       expect(flat(r)).not.toContain('repair link');
+    });
+
+    // ── Refresh ([r]) ─────────────────────────────────────────────────────────
+    // Plaid bills per /transactions/refresh call, so the confirmation gate is as
+    // much a part of the feature as the keypress. [r] was "repair link" until
+    // update mode renamed it to [u], which is a second reason nothing may fire
+    // on the bare keypress.
+    describe('refresh ([r])', () => {
+      /** Puts the cursor on a connection row with the refresh action available. */
+      async function linksWithItem(days: number | null = null) {
+        await db.execute({
+          sql: 'INSERT INTO plaid_items (item_id, access_token, institution_name, last_synced_at, days_requested) VALUES (?, ?, ?, ?, ?)',
+          args: ['item-a', 'tok', 'Chase', Date.now(), days],
+        });
+        await addAccount('acct-1', 'item-a');
+        await addAccount('acct-2', 'item-a');
+      }
+
+      it('advertises [r] on a connection row', async () => {
+        await linksWithItem();
+        const r = accounts();
+        await tabTo(r, 'links');
+        expect(flat(r)).toContain('[r] refresh');
+      });
+
+      it('asks for confirmation and says Plaid charges before doing anything', async () => {
+        await linksWithItem();
+        const spy = vi.spyOn(refreshApi, 'refreshTransactions');
+
+        const r = accounts();
+        await tabTo(r, 'links');
+        r.stdin.write('r');
+
+        await waitFor(() => expect(flat(r)).toContain('Plaid charges for each refresh'));
+        // Item-scoped, and the panel says so rather than implying one account.
+        expect(flat(r)).toContain('all 2 accounts on this connection');
+        expect(spy).not.toHaveBeenCalled();
+      });
+
+      it('names the connection history window it cannot reach past', async () => {
+        await linksWithItem(730);
+        const r = accounts();
+        await tabTo(r, 'links');
+        r.stdin.write('r');
+
+        await waitFor(() => expect(flat(r)).toContain('730-day history window'));
+      });
+
+      it('[n] backs out without spending a refresh', async () => {
+        await linksWithItem();
+        const spy = vi.spyOn(refreshApi, 'refreshTransactions');
+
+        const r = accounts();
+        await tabTo(r, 'links');
+        r.stdin.write('r');
+        await waitFor(() => expect(flat(r)).toContain('Plaid charges for each refresh'));
+        r.stdin.write('n');
+
+        await waitFor(() => expect(flat(r)).not.toContain('Plaid charges for each refresh'));
+        expect(spy).not.toHaveBeenCalled();
+      });
+
+      it('[y] refreshes the selected item and reports it as requested, not complete', async () => {
+        await linksWithItem();
+        let report: ((p: refreshApi.RefreshProgress) => void) | undefined;
+        vi.spyOn(refreshApi, 'refreshTransactions').mockImplementation((_id, opts) => {
+          report = opts?.onProgress;
+          return new Promise(() => {});   // still polling; the tab stays in-flight
+        });
+
+        const r = accounts();
+        await tabTo(r, 'links');
+        r.stdin.write('r');
+        await waitFor(() => expect(flat(r)).toContain('Plaid charges for each refresh'));
+        r.stdin.write('y');
+
+        await waitFor(() => expect(flat(r)).toContain('Asking your bank'));
+        expect(refreshApi.refreshTransactions).toHaveBeenCalledWith('item-a', expect.anything());
+
+        report?.({ phase: 'waiting', attempt: 1, attempts: 4, until: Date.now() + 15_000 });
+        await waitFor(() => {
+          const f = flat(r);
+          expect(f).toContain('Refresh requested');
+          expect(f).toContain('check 1 of 4');
+          expect(f.toLowerCase()).not.toContain('refresh complete');
+        });
+      });
+
+      it('reports the outcome when the poll finds nothing', async () => {
+        await linksWithItem();
+        vi.spyOn(refreshApi, 'refreshTransactions').mockResolvedValue({
+          itemId: 'item-a', added: 0, modified: 0, removed: 0, checks: 4, cancelled: false, syncResults: [],
+        });
+
+        const r = accounts();
+        await tabTo(r, 'links');
+        r.stdin.write('r');
+        await waitFor(() => expect(flat(r)).toContain('Plaid charges for each refresh'));
+        r.stdin.write('y');
+
+        await waitFor(() => expect(flat(r)).toContain('No new transactions yet'));
+      });
+
+      it('Esc aborts an in-flight poll instead of leaving the tab', async () => {
+        await linksWithItem();
+        let started = false;
+        vi.spyOn(refreshApi, 'refreshTransactions').mockImplementation((id, opts) => {
+          started = true;
+          return new Promise((resolve) => {
+            opts?.signal?.addEventListener('abort', () => resolve({
+              itemId: id, added: 0, modified: 0, removed: 0, checks: 1, cancelled: true, syncResults: [],
+            }));
+          });
+        });
+
+        const r = accounts();
+        await tabTo(r, 'links');
+        r.stdin.write('r');
+        await waitFor(() => expect(flat(r)).toContain('Plaid charges for each refresh'));
+        r.stdin.write('y');
+        await waitFor(() => expect(started).toBe(true));
+
+        r.stdin.write('\x1b');
+        await waitFor(() => expect(flat(r)).toContain('Stopped checking'));
+        // Still on Links — Esc was consumed by the poll, not by the tab.
+        expect(flat(r)).toContain('[u] update link');
+      });
     });
   });
 });

--- a/tui/Accounts.tsx
+++ b/tui/Accounts.tsx
@@ -5,6 +5,10 @@ import { useRefreshKey } from './RefreshContext.js';
 import { spawn } from 'node:child_process';
 import { syncAll, describeSyncProgress, type SyncItemResult, type SyncProgress } from '../core/sync.js';
 import { setSyncResult, mergeSyncResult } from '../core/sync-status.js';
+import {
+  refreshTransactions, describeRefreshProgress, describeRefreshResult,
+  POLL_DELAYS_MS, type RefreshProgress,
+} from '../core/transactions-refresh.js';
 import { plaidErrorMessage } from '../core/plaid.js';
 import { useSyncStatus } from './SyncStatusContext.js';
 import { getCsvPlaidDupeCandidates, type DupePair } from '../core/dedup.js';
@@ -172,6 +176,23 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
   // Links view state — one row per Plaid connection, not per account.
   const [linkedItems, setLinkedItems] = useState<LinkedItem[]>([]);
   const [itemCursor, setItemCursor] = useState(0);
+  // Refresh mode gates the billed Plaid call behind a confirmation; the poll
+  // that follows reports through syncStatus, so it shares the status line and
+  // blocks [s] the way a sync does. Progress is held as a step rather than a
+  // string: the waiting step carries a deadline, so re-rendering it on a timer
+  // turns it into a live countdown.
+  const [linksMode, setLinksMode] = useState<'list' | 'confirm-refresh'>('list');
+  const [refreshProgress, setRefreshProgress] = useState<RefreshProgress | null>(null);
+  const refreshAbortRef = useRef<AbortController | null>(null);
+  const [, setRefreshTick] = useState(0);
+  useEffect(() => {
+    if (refreshProgress?.phase !== 'waiting') return;
+    const t = setInterval(() => setRefreshTick((n) => n + 1), 1000);
+    return () => clearInterval(t);
+  }, [refreshProgress]);
+  // Abort an in-flight poll if the screen goes away mid-refresh, so its timer
+  // and its sync don't outlive the component.
+  useEffect(() => () => refreshAbortRef.current?.abort(), []);
 
   // Dupes view state
   const [dupes, setDupes] = useState<DupePair[]>([]);
@@ -355,6 +376,44 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
       setSyncMsg(`Sync failed — ${plaidErrorMessage(err)}`);
       setSyncStatus('error');
     });
+  }
+
+  /** Ask this connection's bank to go look for new transactions now, then watch
+   *  for what turns up. Item-scoped, like every other action on this tab. */
+  function startRefresh(item: LinkedItem) {
+    setLinksMode('list');
+    const controller = new AbortController();
+    refreshAbortRef.current = controller;
+    setSyncStatus('syncing');
+    setSyncMsg('');
+    setRefreshProgress({ phase: 'requesting' });
+
+    refreshTransactions(item.item_id, { signal: controller.signal, onProgress: setRefreshProgress })
+      .then((result) => {
+        refreshAbortRef.current = null;
+        setRefreshProgress(null);
+        // A check that ran is a real sync outcome: it raises this item's ⚠ badge
+        // when it failed and clears a stale one when it didn't. Scoped to this
+        // item, so another connection's failure survives.
+        if (result.syncResults.length > 0) mergeSyncResult(result.syncResults, [item.item_id]);
+        loadAccounts();
+        if (result.error) {
+          setSyncStatus('error');
+          setSyncMsg(`Refresh failed — ${result.error}`);
+          return;
+        }
+        setSyncMsg(describeRefreshResult(result));
+        setSyncStatus('done');
+        // Longer than a sync's 4s: this message is the whole answer to a
+        // four-minute wait, and the no-luck case tells the user what to do next.
+        setTimeout(() => { setSyncStatus('idle'); setSyncMsg(''); }, 10000);
+      })
+      .catch((err) => {
+        refreshAbortRef.current = null;
+        setRefreshProgress(null);
+        setSyncMsg(`Refresh failed — ${plaidErrorMessage(err)}`);
+        setSyncStatus('error');
+      });
   }
 
   function saveNewAcct() {
@@ -659,6 +718,14 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
     // act on the item, and doing them from an account row implied a scope the
     // action never had.
     if (mainView === 'links') {
+      if (linksMode === 'confirm-refresh') {
+        if (key.escape || input === 'n') { setLinksMode('list'); return; }
+        if (input === 'y' && linkedItems[itemCursor]) { startRefresh(linkedItems[itemCursor]); return; }
+        return;
+      }
+      // Esc stops an in-flight refresh rather than leaving the tab — the poll
+      // runs for minutes and this is the only way out of it.
+      if (key.escape && refreshAbortRef.current) { refreshAbortRef.current.abort(); return; }
       if (key.escape) { setMainView('accounts'); return; }
       if (key.tab) { setMainView('add-data'); return; }
       if (key.upArrow)   { setItemCursor((c) => Math.max(0, c - 1)); return; }
@@ -670,6 +737,13 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
         setMainView('add-data');
         setAddStep('link-plaid');
         startPlaidLink(defaultDays, linkedItems[itemCursor].item_id);
+        return;
+      }
+      // Confirmed rather than immediate: Plaid bills per /transactions/refresh
+      // call. Also worth the gate because [r] was "repair link" one release ago
+      // — muscle memory lands on a confirmation, not a charge.
+      if (input === 'r' && linkedItems[itemCursor] && syncStatus !== 'syncing') {
+        setLinksMode('confirm-refresh');
         return;
       }
       if (input === 's' && syncStatus !== 'syncing') { forceSync(); return; }
@@ -851,6 +925,10 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
   // ─── Render ──────────────────────────────────────────────────────────────────
 
   const selectedAcct = linkedAccounts[acctCursor];
+  const selectedItem = linkedItems[itemCursor];
+  // A running refresh owns the Links status line; its text is re-derived every
+  // render so the countdown in the waiting step actually counts down.
+  const linksStatusLine = refreshProgress ? describeRefreshProgress(refreshProgress) : syncMsg;
   // Placeholders aren't accounts yet, so the footer names them separately
   // rather than inflating the account count.
   const awaitingCount = linkedAccounts.filter((a) => a.awaitingFirstSync).length;
@@ -879,8 +957,10 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
             ? `↑↓ select  ·  Enter edit${selectedAcct?.id.startsWith('manual-') ? '  ·  [v] update value' : ''}  ·  [x] delete  ·  [s] sync`
             : mainView === 'accounts' && acctMode === 'edit'
             ? '↑↓ field  ·  ← → change  ·  Enter save  ·  Esc cancel'
+            : mainView === 'links' && refreshProgress
+            ? 'Esc stop checking'
             : mainView === 'links'
-            ? '↑↓ select  ·  [u] update link  ·  [s] sync'
+            ? '↑↓ select  ·  [u] update link  ·  [r] refresh  ·  [s] sync'
             : mainView === 'dupes'
             ? '↑↓ select  ·  [x] delete CSV copy  ·  [X] delete all'
             : ''}
@@ -1050,10 +1130,39 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
                 {linkedItems.length} connection{linkedItems.length !== 1 ? 's' : ''}
                 {failingItems.size > 0 && <Text color={C_NEGATIVE}>  ·  {failingItems.size} failing</Text>}
               </Text>
-              {syncMsg && <Text color={syncStatus === 'syncing' ? C_WARNING : syncStatus === 'error' ? C_NEGATIVE : C_POSITIVE}>{syncMsg}<Text dimColor>{syncElapsed}</Text></Text>}
+              {linksStatusLine && <Text color={syncStatus === 'syncing' ? C_WARNING : syncStatus === 'error' ? C_NEGATIVE : C_POSITIVE}>{linksStatusLine}<Text dimColor>{syncElapsed}</Text></Text>}
+
+              {linksMode === 'confirm-refresh' && selectedItem && (
+                <ModalPanel borderColor={C_WARNING}>
+                  <Text bold color={C_WARNING}>Refresh transactions — Plaid charges for each refresh</Text>
+                  <Box marginTop={1} flexDirection="column">
+                    <Text>
+                      <Text color={C_ACCENT}>{selectedItem.institution_name ?? '(unknown institution)'}</Text>
+                      <Text dimColor>  — all {selectedItem.account_count} account{selectedItem.account_count !== 1 ? 's' : ''} on this connection</Text>
+                    </Text>
+                    <Text dimColor>Asks your bank to go look for new transactions right now.</Text>
+                    <Box marginTop={1} flexDirection="column">
+                      <Text dimColor>Only worth it if you're missing <Text bold>recent</Text> transactions and want the bank re-checked.</Text>
+                      {/* The window is fixed at item creation and update mode cannot
+                          widen it, so name it here rather than leaving the limit abstract. */}
+                      <Text dimColor>
+                        It can't reach past this connection's {selectedItem.days_requested ? `${selectedItem.days_requested}-day` : '90-day'} history window.
+                      </Text>
+                      <Text dimColor>
+                        Then checks for new transactions {POLL_DELAYS_MS.length} times over about {Math.round(POLL_DELAYS_MS.reduce((a, b) => a + b, 0) / 60000)} minutes. Esc stops the checks.
+                      </Text>
+                    </Box>
+                  </Box>
+                  <Box marginTop={1} gap={4}>
+                    <Text color={C_WARNING}>[y] Yes, refresh</Text>
+                    <Text color={C_POSITIVE}>[n] / Esc cancel</Text>
+                  </Box>
+                </ModalPanel>
+              )}
 
               <Box marginTop={1} flexDirection="column">
                 <Text dimColor>[u] update link  — update creds for link, keeping its accounts and transactions</Text>
+                <Text dimColor>[r] refresh      — ask this bank for new transactions now (Plaid charges)</Text>
                 <Text dimColor>[s] sync         — re-sync every connection now</Text>
               </Box>
             </>


### PR DESCRIPTION
> [!IMPORTANT]
> This is a stacked PR. Until the three below land, the diff here also shows their commits.
>
> - [ ] #135 — `feature/accounts-sync-state`
> - [ ] #148 — `feat/accounts-links-tab` (builds on #135; adds the Links tab this PR's action lives on)
> - [ ] #149 — `feat/update-link-credentials` (builds on #148; frees `[r]` by renaming repair to `[u]`)
>
> Only the top commit, `feat: on-demand transaction refresh from the Links tab`, belongs to this PR.

## The problem

A connection can be missing **recent** transactions — the bank has them, Plaid hasn't extracted them yet. `[s]` doesn't help: it re-runs `/transactions/sync`, which returns whatever Plaid already pulled on its own schedule. There was no way to ask Plaid to go look now.

## What this adds

`[r] refresh` on a Links row: one `/transactions/refresh` for that connection, then `/transactions/sync` polled at **15s / 30s / 60s / 120s**, stopping early as soon as something lands.

It goes on this tab for the reason #148 gave for moving the others here — refresh acts on the **item**, and one item can back a dozen accounts. The confirm panel names the account count so the scope is on screen rather than implied.

## Why it never says "refresh complete"

[Plaid signals refresh completion with a webhook](https://plaid.com/docs/api/products/transactions/#transactionsrefresh) and this app has none. The 200 from `/transactions/refresh` means the extraction was *queued*, not that it finished, so the poll is the only completion signal available. Two consequences, both load-bearing in the copy and the code:

- **"no new transactions" and "refresh still running" are indistinguishable from here.** Nothing reports the refresh as complete — the status line says `Refresh requested — next check in 47s (check 1 of 4)…` and then reports what sync actually returned. Two tests pin that the strings never claim completion.
- **Refresh fetches the newest transactions; it cannot widen the history window.** That window is fixed at item creation, and update mode can't change it either (#149). So the panel names it from `days_requested` — `It can't reach past this connection's 730-day history window.` — rather than leaving the limit abstract. Recovering older transactions is a different operation entirely.

## The cost gate

Plaid bills per `/transactions/refresh` call on most plans, so `[r]` opens a confirmation and nothing is spent until `y`. Only the free `/transactions/sync` is polled.

The gate does double duty: `[r]` was **repair link** until #149 renamed it to `[u]`, so anyone with muscle memory from #148 lands on a confirmation rather than a charge.

```
Refresh transactions — Plaid charges for each refresh

  Chase  — all 2 accounts on this connection
  Asks your bank to go look for new transactions right now.

  Only worth it if you're missing recent transactions and want the bank re-checked.
  It can't reach past this connection's 730-day history window.
  Then checks for new transactions 4 times over about 4 minutes. Esc stops the checks.

  [y] Yes, refresh    [n] / Esc cancel
```

No cooldown — the confirmation is the gate.

## Behaviour during the poll

It runs for close to four minutes, which drives three choices:

- It reports through `syncStatus`, so it shares the Links status line and blocks `[s]` the way a sync does.
- The waiting step carries a **wall-clock deadline rather than a duration**, so re-rendering it on a 1s timer gives a live countdown for free — a static "next check in 120s" would look hung.
- **Esc aborts the poll** instead of leaving the tab, and the hint line switches to `Esc stop checking` while it runs. An unmount aborts it too, so no timer or sync outlives the screen.

Each check is a real sync outcome, so its result feeds `mergeSyncResult` scoped to the one item: a failed check raises that connection's ⚠ badge, a clean one clears a stale badge, and other connections' failures are untouched.

It calls `syncTransactions` directly rather than `syncAll` — this is inherently one-item work, and `syncAll`'s 15-minute debounce would skip every check after the first.

## GUI

TUI only. Bridging this needs more than a registry entry — the poll streams progress for minutes and needs a cancel path, not a single request/response call — so the three new functions are recorded in `gui-bridge-parity`'s `EXPECTED_UNBRIDGED` with that reason.

## Tests

**874 passing**, `npm run typecheck` clean on both configs.

- `tests/transactions-refresh.test.ts` — 19 on fake timers: backoff timing (nothing fires at delay−1ms), early exit on `added` or `modified`, exhaustion, a failed refresh request never polling, stopping on a failing sync instead of retrying a broken item, abort mid-wait, the countdown, sync-step passthrough, the `syncResults` that drive the badge, and two pinning the copy never claims completion.
- `tests/tui/screens.test.tsx` — 7 in the links tab block per CONTRIBUTING's TUI requirement: `[r]` confirms before calling Plaid, `[n]` spends nothing, `[y]` refreshes the selected item and reports it as requested, the window is named, the no-luck outcome, and Esc aborting without leaving the tab.

I have exercised this against production Plaid and it did update the sync date in the Item Debugger in the Plaid developer dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)