### PR TITLE
feat: delete a connection's sync cursor and resync from the Links tab

### DIFF
--- a/core/sync.ts
+++ b/core/sync.ts
@@ -162,6 +162,32 @@ export async function syncTransactions(accessToken: string, itemId: string, onPr
   return { added: added.length, modified: modified.length, removed: removedIds.length, dupes };
 }
 
+/**
+ * Forget how far we have consumed an item's /transactions/sync change feed, so
+ * the next sync starts from the beginning and Plaid resends every transaction it
+ * currently holds as `added`. Pair it with a scoped syncAll(true, [itemId]) to
+ * resync immediately.
+ *
+ * What this recovers is rows *this app* lost while Plaid kept them: an account
+ * deleted via deleteAccount (which cascades to its transactions), a row removed
+ * by deleteTransaction, or a database rebuilt against a still-live item. Every
+ * write in syncTransactions is an upsert, so the resync is idempotent and leaves
+ * manual categories and tag suppressions alone.
+ *
+ * What it cannot recover is anything Plaid no longer has — including the rows we
+ * deleted *because* Plaid reported them `removed`. Those are absent from the
+ * replayed feed for the same reason they were deleted, so cursor-zero changes
+ * nothing about them. Only a relinked item can bring those back, and only if the
+ * bank still reports them.
+ *
+ * Note the corollary, which the confirmation copy warns about: a deliberate
+ * deleteTransaction leaves no tombstone, so replaying the feed resurrects rows
+ * the user meant to be rid of.
+ */
+export async function deleteSyncCursor(itemId: string): Promise<void> {
+  await db.execute({ sql: 'DELETE FROM sync_state WHERE account_id = ?', args: [itemId] });
+}
+
 const DEBOUNCE_MS = 15 * 60 * 1000;
 
 export type SyncItemResult = {

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -189,12 +189,37 @@ single connection can back many accounts.
 |-----|--------|
 | `↑ ↓` | Select connection |
 | `u` | Update link — update creds for link, keeping its accounts and transactions |
+| `d` | Delete sync cursor — re-download this connection's full history (free) |
+| `r` | Refresh — ask this bank for new transactions now (Plaid charges) |
 | `s` | Force sync (bypasses 15-min cooldown) |
 
 `[u]` runs Plaid in update mode, which re-authorizes the existing connection in
 place. Use it when a connection shows ⚠ sync failed because its login expired.
 It does not create new accounts or re-download transactions, and it cannot widen
 the history window — that is fixed when the connection is first created.
+
+`[d]` and `[r]` both go after missing transactions, but they fix different
+causes, and only one of them costs money.
+
+`[d]` deletes the stored `/transactions/sync` cursor, so the next sync starts
+from the beginning of the item's history and Plaid resends everything it holds.
+Use it to recover rows this app lost while Plaid kept them — an account you
+deleted, transactions you deleted, or a database rebuilt against a live
+connection. Writes are upserts, so existing rows are updated rather than
+duplicated and manual categories and tags survive. Two things to know: a
+transaction you deleted by hand comes back (nothing records that you meant it
+gone), and anything Plaid itself no longer has stays gone, including the rows
+this app deleted *because* Plaid reported them removed. Plaid does not bill for
+it; the cost is the time the resync takes. A connection with no stored cursor
+shows `· sync cursor cleared` until its next sync.
+
+`[r]` calls `/transactions/refresh`, asking the bank to run an extraction right
+now rather than waiting for its next scheduled one, then polls for about four
+minutes to see what lands (`Esc` stops the polling). **Plaid bills per call on
+most plans.** It only reaches transactions the bank has not reported yet —
+roughly the last day — and cannot widen the history window. If what you are
+missing is older than that, Plaid almost certainly already has it, which makes
+`[d]` the free fix and `[r]` a wasted charge.
 
 **Add Data** options: `[l]` link bank via Plaid, `[c]` import CSV, `[m]` add manual asset (house, car, etc.), `[s]` force sync.
 

--- a/gui/main/registry.ts
+++ b/gui/main/registry.ts
@@ -92,8 +92,8 @@ import {
 import { getCsvPlaidDupeCandidates } from '../../core/dedup.js';
 import { applyCategoriesToAll } from '../../core/categorize.js';
 import { loadProfile, saveProfile, householdMembers } from '../../core/profile.js';
-import { syncAll } from '../../core/sync.js';
-import { setSyncResult, getSyncFailures } from '../../core/sync-status.js';
+import { syncAll, deleteSyncCursor } from '../../core/sync.js';
+import { setSyncResult, mergeSyncResult, getSyncFailures } from '../../core/sync-status.js';
 import { loadHistory, deleteHistoryEntry, CANVAS_SPEC_PATH } from '../../core/canvas-history.js';
 import type { CanvasSpec } from '../../core/canvas-spec.js';
 import { writeEnvFile, type EnvUpdates } from '../../core/env-file.js';
@@ -223,6 +223,16 @@ export const registry = {
       const results = await syncAll(force);
       setSyncResult(results);
       return results;
+    },
+    // Delete one item's cursor and resync it, so Plaid resends its full history.
+    // Composed here rather than in the renderer so the two steps can't be
+    // interleaved with another sync, and merged rather than set so the other
+    // institutions keep their failure badges.
+    deleteCursorAndResync: async (itemId: string) => {
+      await deleteSyncCursor(itemId);
+      const results = await syncAll(true, [itemId]);
+      mergeSyncResult(results, [itemId]);
+      return results[0];
     },
     // Initial hydration for a renderer that mounts after a background sync failed.
     getStatus: async () => getSyncFailures(),

--- a/gui/renderer/src/screens/Accounts.tsx
+++ b/gui/renderer/src/screens/Accounts.tsx
@@ -45,6 +45,8 @@ export function Accounts() {
   // The connection whose credentials are being updated, if any. Distinct from
   // linkOpen: that adds a new item, this re-authorizes an existing one.
   const [updateItem, setUpdateItem] = useState<LinkedItem | null>(null);
+  // The connection whose sync cursor is about to be deleted, if any.
+  const [cursorItem, setCursorItem] = useState<LinkedItem | null>(null);
   const [syncing, setSyncing] = useState(false);
   const plaidConfigured = useQuery(() => api.plaid.isConfigured(), []) ?? false;
   // Item ids that failed the most recent sync (from either the startup or the
@@ -72,6 +74,32 @@ export function Accounts() {
       reload();
     } catch {
       showStatus('Sync failed', 3000);
+    } finally {
+      setSyncing(false);
+    }
+  }
+
+  /** Delete one connection's sync cursor, then resync it so Plaid resends
+   *  everything it holds. Both steps run in main so they can't be interleaved
+   *  with another sync. */
+  async function deleteCursorAndResync(item: LinkedItem) {
+    if (syncing) return;
+    const label = item.institution_name ?? 'connection';
+    setCursorItem(null);
+    setSyncing(true);
+    try {
+      const result = await api.sync.deleteCursorAndResync(item.item_id);
+      if (result?.error) {
+        showStatus(`Resync failed: ${label} — ${result.error}`, 8000);
+      } else {
+        // `added` counts everything the replayed feed returned, existing rows
+        // included — re-downloaded, not new.
+        const n = result?.added ?? 0;
+        showStatus(`${label} — re-downloaded ${n.toLocaleString()} transaction${n === 1 ? '' : 's'}`, 6000);
+      }
+      reload();
+    } catch {
+      showStatus(`Resync failed: ${label}`, 3000);
     } finally {
       setSyncing(false);
     }
@@ -219,7 +247,7 @@ export function Accounts() {
                     <td className={styles.tdName}>
                       {item.institution_name ?? '(unknown institution)'}
                       {!item.hasCursor && !item.awaitingFirstSync && (
-                        <span className="dim" title="No sync cursor stored — the next sync replays this connection's full history"> · full replay pending</span>
+                        <span className="dim" title="No sync cursor stored — the next sync re-downloads this connection's full history"> · sync cursor cleared</span>
                       )}
                     </td>
                     <td className="num dim">{item.account_count}</td>
@@ -247,6 +275,18 @@ export function Accounts() {
                       >
                         update link
                       </button>
+                      {/* Hidden until the first sync lands: that sync starts from
+                          scratch already, so there is no cursor to delete. */}
+                      {!item.awaitingFirstSync && (
+                        <button
+                          className={styles.rowBtn}
+                          disabled={syncing}
+                          title="Re-download this connection's full history from Plaid (free)"
+                          onClick={() => setCursorItem(item)}
+                        >
+                          delete sync cursor
+                        </button>
+                      )}
                     </td>
                   </tr>
                 ))}
@@ -447,6 +487,40 @@ export function Accounts() {
             void forceSync();
           }}
         />
+      )}
+
+      {cursorItem && (
+        <Modal title="Delete sync cursor and resync" onClose={() => setCursorItem(null)} accent="var(--warning)">
+          <p>
+            <span className="accent">{cursorItem.institution_name ?? '(unknown institution)'}</span>{' '}
+            <span className="dim">
+              — all {cursorItem.account_count} account{cursorItem.account_count === 1 ? '' : 's'} on this connection
+            </span>
+          </p>
+          <p className="dim">
+            Forgets how far we've read Plaid's change feed, so the next sync re-downloads every
+            transaction Plaid currently holds. Free — it costs only the time to resync.
+          </p>
+          <p className="dim">
+            Existing rows are updated in place, not duplicated, and your categories and tags are kept.{' '}
+            {/* deleteTransaction leaves no tombstone, so the replayed feed resurrects
+                deliberate deletions. The one destructive thing this does. */}
+            <strong>Transactions you deleted by hand will come back.</strong>{' '}
+            Transactions Plaid no longer has will not.
+          </p>
+          <div className={styles.modalActions}>
+            <button className={styles.btnSecondary} onClick={() => setCursorItem(null)}>
+              Cancel
+            </button>
+            <button
+              className={styles.btnPrimary}
+              disabled={syncing}
+              onClick={() => void deleteCursorAndResync(cursorItem)}
+            >
+              Delete cursor and resync
+            </button>
+          </div>
+        </Modal>
       )}
 
       {updateItem && (

--- a/tests/gui-bridge-parity.test.ts
+++ b/tests/gui-bridge-parity.test.ts
@@ -59,6 +59,12 @@ const EXPECTED_UNBRIDGED: Record<string, string> = {
   getSyncFailures: 'GUI will surface sync status in its own layer',
   onSyncStatus: 'GUI will surface sync status in its own layer',
 
+  // The GUI bridges the composed action (sync.deleteCursorAndResync) rather than
+  // the bare cursor delete. On its own it leaves the item mid-operation until
+  // something resyncs, so main runs both steps together where they cannot be
+  // interleaved with another sync.
+  deleteSyncCursor: 'GUI bridges the composed sync.deleteCursorAndResync instead',
+
   // On-demand /transactions/refresh (core/transactions-refresh.ts) — TUI-only for
   // now. Bridging it needs more than a registry entry: the poll runs for minutes
   // and streams progress, so the GUI needs a progress channel and a cancel path

--- a/tests/gui/accounts-links.test.tsx
+++ b/tests/gui/accounts-links.test.tsx
@@ -1,0 +1,224 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import React from 'react';
+import { cleanup, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+vi.mock('../../core/db.js', async () => {
+  const { makeTestDb } = await import('./../helpers/makeTestDb.js');
+  return { db: await makeTestDb() };
+});
+
+// The Links tab's actions all reach Plaid through the real registry, so the
+// client is stubbed rather than the bridge — that keeps deleteCursorAndResync's
+// composition (delete, then a scoped syncAll, then mergeSyncResult) under test
+// instead of mocked away.
+vi.mock('../../core/plaid.js', () => ({
+  getPlaidClient: vi.fn(),
+  plaidErrorMessage: (err: unknown) => (err instanceof Error ? err.message : String(err)),
+}));
+
+import { db } from '../../core/db.js';
+import { getPlaidClient } from '../../core/plaid.js';
+import { installBridge, renderScreen } from './helpers/renderGui.js';
+import { Accounts } from '../../gui/renderer/src/screens/Accounts.js';
+
+/** Plaid returning `added` rows and no removals, the shape a cursor-zero replay
+ *  produces. Returns the stub so a test can assert on the cursor it was sent. */
+function mockPlaid(added: object[] = []) {
+  const transactionsSync = vi.fn().mockResolvedValue({
+    data: { added, modified: [], removed: [], has_more: false, next_cursor: 'cursor-1' },
+  });
+  vi.mocked(getPlaidClient).mockReturnValue({
+    transactionsSync,
+    accountsGet: vi.fn().mockResolvedValue({ data: { accounts: [] } }),
+  } as never);
+  return transactionsSync;
+}
+
+const tx = (id: string) => ({
+  transaction_id: id, account_id: 'acct-1', date: '2026-08-01', name: 'Coffee',
+  merchant_name: null, amount: 4.5, pending: false,
+  personal_finance_category: { primary: 'FOOD_AND_DRINK' },
+});
+
+const addItem = (itemId: string, institution: string | null, lastSyncedAt: number | null) =>
+  db.execute({
+    sql: 'INSERT INTO plaid_items (item_id, access_token, institution_name, last_synced_at) VALUES (?, ?, ?, ?)',
+    args: [itemId, 'tok', institution, lastSyncedAt],
+  });
+
+const addAccount = (id: string, itemId: string) =>
+  db.execute({
+    sql: `INSERT INTO accounts (id, name, type, subtype, item_id) VALUES (?, ?, 'depository', 'checking', ?)`,
+    args: [id, id, itemId],
+  });
+
+const addCursor = (itemId: string, cursor = 'cur') =>
+  db.execute({ sql: 'INSERT INTO sync_state (account_id, cursor) VALUES (?, ?)', args: [itemId, cursor] });
+
+const storedCursor = async (itemId: string) =>
+  (await db.execute({ sql: 'SELECT cursor FROM sync_state WHERE account_id = ?', args: [itemId] })).rows;
+
+/** Renders the screen and switches to the Links tab. */
+async function links() {
+  renderScreen(<Accounts />);
+  await userEvent.click(await screen.findByRole('button', { name: 'Links' }));
+}
+
+/** One synced connection with two accounts and a stored cursor — the state in
+ *  which the action is offered. */
+async function seedSyncedItem() {
+  await addItem('item-a', 'Chase', Date.now());
+  await addAccount('acct-1', 'item-a');
+  await addAccount('acct-2', 'item-a');
+  await addCursor('item-a');
+}
+
+beforeEach(async () => {
+  for (const tbl of ['transaction_tags', 'tag_rule_suppressions', 'transactions', 'accounts',
+                     'balance_history', 'sync_state', 'plaid_items']) {
+    await db.execute(`DELETE FROM ${tbl}`);
+  }
+  installBridge();
+});
+
+afterEach(() => cleanup());
+
+describe('GUI Accounts — Links tab', () => {
+  it('lists one row per connection, with its account count', async () => {
+    await seedSyncedItem();
+    await links();
+    // Two accounts, one row — the whole point of the view.
+    await waitFor(() => expect(screen.getByText('Chase')).toBeTruthy());
+    const row = screen.getByText('Chase').closest('tr')!;
+    expect(row.textContent).toContain('2');
+  });
+
+  it('flags a connection with no stored cursor', async () => {
+    await addItem('item-a', 'Chase', Date.now());
+    await addAccount('acct-1', 'item-a');
+    await links();
+    await waitFor(() => expect(screen.getByText(/sync cursor cleared/)).toBeTruthy());
+  });
+
+  it('drops the flag once a cursor is stored', async () => {
+    await seedSyncedItem();
+    await links();
+    await waitFor(() => expect(screen.getByText('Chase')).toBeTruthy());
+    expect(screen.queryByText(/sync cursor cleared/)).toBeNull();
+  });
+
+  describe('delete sync cursor', () => {
+    it('offers the action on a connection row', async () => {
+      await seedSyncedItem();
+      await links();
+      await waitFor(() => expect(screen.getByRole('button', { name: 'delete sync cursor' })).toBeTruthy());
+    });
+
+    // Costs nothing at Plaid, so the gate is not about the bill: the replay
+    // resurrects transactions the user deleted on purpose.
+    it('asks for confirmation before deleting anything', async () => {
+      await seedSyncedItem();
+      const plaid = mockPlaid();
+      await links();
+
+      await userEvent.click(await screen.findByRole('button', { name: 'delete sync cursor' }));
+
+      await waitFor(() => expect(screen.getByText('Delete sync cursor and resync')).toBeTruthy());
+      // Item-scoped, and the modal says so rather than implying one account.
+      expect(screen.getByText(/all 2 accounts on this connection/)).toBeTruthy();
+      expect(plaid).not.toHaveBeenCalled();
+      expect(await storedCursor('item-a')).toHaveLength(1);
+    });
+
+    it('warns that hand-deleted transactions come back, and that Plaid gaps stay', async () => {
+      await seedSyncedItem();
+      mockPlaid();
+      await links();
+      await userEvent.click(await screen.findByRole('button', { name: 'delete sync cursor' }));
+
+      await waitFor(() => expect(screen.getByText('Delete sync cursor and resync')).toBeTruthy());
+      expect(screen.getByText(/Transactions you deleted by hand will come back/)).toBeTruthy();
+      expect(screen.getByText(/Transactions Plaid no longer has will not/)).toBeTruthy();
+      // The reason to reach for this rather than a billed refresh.
+      expect(screen.getByText(/Free/)).toBeTruthy();
+    });
+
+    it('Cancel backs out without touching the cursor', async () => {
+      await seedSyncedItem();
+      const plaid = mockPlaid();
+      await links();
+      await userEvent.click(await screen.findByRole('button', { name: 'delete sync cursor' }));
+      await waitFor(() => expect(screen.getByText('Delete sync cursor and resync')).toBeTruthy());
+
+      await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+      await waitFor(() => expect(screen.queryByText('Delete sync cursor and resync')).toBeNull());
+      expect(plaid).not.toHaveBeenCalled();
+      expect(await storedCursor('item-a')).toHaveLength(1);
+    });
+
+    it('confirming deletes the cursor and resyncs from the beginning of the feed', async () => {
+      await seedSyncedItem();
+      const plaid = mockPlaid([tx('tx-9')]);
+      await links();
+      await userEvent.click(await screen.findByRole('button', { name: 'delete sync cursor' }));
+      await waitFor(() => expect(screen.getByText('Delete sync cursor and resync')).toBeTruthy());
+
+      await userEvent.click(screen.getByRole('button', { name: 'Delete cursor and resync' }));
+
+      await waitFor(() => expect(screen.getByText(/re-downloaded 1 transaction/)).toBeTruthy());
+      // The point of the feature: the resync starts from cursor zero, not from
+      // where the last sync left off.
+      expect(plaid).toHaveBeenCalledTimes(1);
+      expect(plaid.mock.calls[0][0]).toMatchObject({ cursor: undefined });
+      // And the row Plaid resent actually landed.
+      const rows = await db.execute({ sql: 'SELECT id FROM transactions WHERE id = ?', args: ['tx-9'] });
+      expect(rows.rows).toHaveLength(1);
+    });
+
+    // "N new transactions" would be a lie: a cursor-zero replay reports every
+    // row Plaid holds as added, most of which the database already had.
+    it('reports the count as re-downloaded rather than new', async () => {
+      await seedSyncedItem();
+      mockPlaid([tx('tx-1'), tx('tx-2')]);
+      await links();
+      await userEvent.click(await screen.findByRole('button', { name: 'delete sync cursor' }));
+      await waitFor(() => expect(screen.getByText('Delete sync cursor and resync')).toBeTruthy());
+
+      await userEvent.click(screen.getByRole('button', { name: 'Delete cursor and resync' }));
+
+      await waitFor(() => expect(screen.getByText(/re-downloaded 2 transactions/)).toBeTruthy());
+      expect(screen.queryByText(/2 new transactions/)).toBeNull();
+    });
+
+    it('reports a failed resync instead of claiming success', async () => {
+      await seedSyncedItem();
+      vi.mocked(getPlaidClient).mockReturnValue({
+        transactionsSync: vi.fn().mockRejectedValue(new Error('ITEM_LOGIN_REQUIRED')),
+        accountsGet: vi.fn().mockResolvedValue({ data: { accounts: [] } }),
+      } as never);
+      await links();
+      await userEvent.click(await screen.findByRole('button', { name: 'delete sync cursor' }));
+      await waitFor(() => expect(screen.getByText('Delete sync cursor and resync')).toBeTruthy());
+
+      await userEvent.click(screen.getByRole('button', { name: 'Delete cursor and resync' }));
+
+      await waitFor(() => expect(screen.getByText(/Resync failed: Chase/)).toBeTruthy());
+      expect(screen.getByText(/ITEM_LOGIN_REQUIRED/)).toBeTruthy();
+      // The cursor is gone either way, which the row badge now reflects — the
+      // next sync will still start from the beginning.
+      expect(await storedCursor('item-a')).toHaveLength(0);
+    });
+
+    it('is not offered on a connection still awaiting its first sync', async () => {
+      // That sync starts from scratch already, so there is no cursor to delete.
+      await addItem('item-new', 'Capital One', null);
+      await links();
+
+      await waitFor(() => expect(screen.getByText(/awaiting first sync/)).toBeTruthy());
+      expect(screen.queryByRole('button', { name: 'delete sync cursor' })).toBeNull();
+    });
+  });
+});

--- a/tests/gui/accounts.test.tsx
+++ b/tests/gui/accounts.test.tsx
@@ -287,7 +287,7 @@ describe('GUI Accounts — Links tab', () => {
       await addAccount('acct-1', 'item-a');
       await links();
 
-      await waitFor(() => expect(screen.getByText(/full replay pending/)).toBeTruthy());
+      await waitFor(() => expect(screen.getByText(/sync cursor cleared/)).toBeTruthy());
     });
 
     it('drops the flag once a cursor is stored', async () => {
@@ -297,17 +297,17 @@ describe('GUI Accounts — Links tab', () => {
       await links();
 
       await waitFor(() => expect(screen.getByText('Chase')).toBeTruthy());
-      expect(screen.queryByText(/full replay pending/)).toBeNull();
+      expect(screen.queryByText(/sync cursor cleared/)).toBeNull();
     });
 
     // A fresh link has no cursor either, but its first sync starts from scratch
-    // anyway — saying "full replay pending" there would be noise.
+    // anyway — saying "sync cursor cleared" there would be noise.
     it('does not flag a connection awaiting its first sync', async () => {
       await addItem('item-new', 'Capital One', null);
       await links();
 
       await waitFor(() => expect(screen.getByText('Capital One')).toBeTruthy());
-      expect(screen.queryByText(/full replay pending/)).toBeNull();
+      expect(screen.queryByText(/sync cursor cleared/)).toBeNull();
     });
   });
 

--- a/tests/sync.test.ts
+++ b/tests/sync.test.ts
@@ -12,7 +12,7 @@ vi.mock('../core/plaid.js', () => ({
 
 import { db } from '../core/db.js';
 import { getPlaidClient } from '../core/plaid.js';
-import { syncTransactions, syncAll, describeSyncProgress, type SyncProgress } from '../core/sync.js';
+import { syncTransactions, syncAll, deleteSyncCursor, describeSyncProgress, type SyncProgress } from '../core/sync.js';
 
 type PlaidStub = { transactionsSync: ReturnType<typeof vi.fn>; accountsGet: ReturnType<typeof vi.fn> };
 
@@ -241,6 +241,98 @@ describe('sync progress reporting', () => {
     mockPlaid();
     const results = await syncAll(true, ['item-a']);
     expect(results[0].error).toBeUndefined();
+  });
+});
+
+describe('deleteSyncCursor', () => {
+  async function seedItem(itemId: string, cursor?: string) {
+    await db.execute({
+      sql: 'INSERT INTO plaid_items (item_id, access_token, institution_name) VALUES (?, ?, ?)',
+      args: [itemId, `tok-${itemId}`, itemId],
+    });
+    if (cursor !== undefined) {
+      await db.execute({ sql: 'INSERT INTO sync_state (account_id, cursor) VALUES (?, ?)', args: [itemId, cursor] });
+    }
+  }
+
+  it('drops the stored cursor', async () => {
+    await seedItem('item-a', 'stale');
+    await deleteSyncCursor('item-a');
+    const rows = await db.execute({ sql: 'SELECT cursor FROM sync_state WHERE account_id = ?', args: ['item-a'] });
+    expect(rows.rows).toHaveLength(0);
+  });
+
+  it('leaves other items\' cursors alone', async () => {
+    await seedItem('item-a', 'stale');
+    await seedItem('item-b', 'keep-me');
+    await deleteSyncCursor('item-a');
+    const rows = await db.execute({ sql: 'SELECT cursor FROM sync_state WHERE account_id = ?', args: ['item-b'] });
+    expect((rows.rows[0] as unknown as { cursor: string }).cursor).toBe('keep-me');
+  });
+
+  it('is a no-op for an item that has never synced', async () => {
+    await seedItem('item-a');
+    await expect(deleteSyncCursor('item-a')).resolves.toBeUndefined();
+  });
+
+  // The point of the whole feature: the next sync must start from the beginning
+  // of the change feed, not from where we left off.
+  it('makes the following sync request history from the beginning', async () => {
+    await seedItem('item-a', 'stale');
+    const plaid = mockPlaid();
+
+    await deleteSyncCursor('item-a');
+    await syncAll(true, ['item-a']);
+
+    expect(plaid.transactionsSync).toHaveBeenCalledTimes(1);
+    expect(plaid.transactionsSync.mock.calls[0][0]).toMatchObject({ cursor: undefined });
+  });
+
+  it('without the delete, the same sync resumes from the stored cursor', async () => {
+    await seedItem('item-a', 'stale');
+    const plaid = mockPlaid();
+
+    await syncAll(true, ['item-a']);
+
+    expect(plaid.transactionsSync.mock.calls[0][0]).toMatchObject({ cursor: 'stale' });
+  });
+
+  it('restores a transaction the database had lost but Plaid still holds', async () => {
+    await seedItem('item-a', 'stale');
+    mockPlaid([], [{
+      transaction_id: 'tx-9', account_id: 'acct-1', date: '2026-08-01', name: 'Coffee',
+      merchant_name: null, amount: 4.5, pending: false,
+      personal_finance_category: { primary: 'FOOD_AND_DRINK' },
+    }]);
+
+    await deleteSyncCursor('item-a');
+    const [result] = await syncAll(true, ['item-a']);
+
+    expect(result).toMatchObject({ itemId: 'item-a', added: 1 });
+    const rows = await db.execute({ sql: 'SELECT id FROM transactions WHERE id = ?', args: ['tx-9'] });
+    expect(rows.rows).toHaveLength(1);
+  });
+
+  // The limit the confirmation copy promises. A row deleted *because* Plaid
+  // reported it removed is absent from the replayed feed for the same reason it
+  // was deleted, so cursor-zero cannot bring it back. Pinned because the copy
+  // ("Transactions Plaid no longer has will not") depends on it.
+  it('does not restore a transaction Plaid itself no longer has', async () => {
+    await seedItem('item-a', 'stale');
+    await insertTx('tx-gone');
+    // First sync: Plaid reports it removed, so the row is deleted locally.
+    mockPlaid(['tx-gone']);
+    await syncAll(true, ['item-a']);
+    const afterRemoval = await db.execute({ sql: 'SELECT id FROM transactions WHERE id = ?', args: ['tx-gone'] });
+    expect(afterRemoval.rows).toHaveLength(0);
+
+    // Cursor-zero replay: Plaid's feed no longer contains it, so it stays gone.
+    mockPlaid();
+    await deleteSyncCursor('item-a');
+    await syncAll(true, ['item-a']);
+
+    const afterReplay = await db.execute({ sql: 'SELECT id FROM transactions WHERE id = ?', args: ['tx-gone'] });
+    expect(afterReplay.rows).toHaveLength(0);
   });
 });
 

--- a/tests/tui/screens.test.tsx
+++ b/tests/tui/screens.test.tsx
@@ -2141,23 +2141,23 @@ describe('Accounts', () => {
       expect(flat(r)).toContain('awaiting first sync');
     });
 
-    it('flags a connection with no stored cursor as due a full replay', async () => {
+    it('flags a connection with no stored cursor', async () => {
       await addItem('item-a', 'Chase', Date.now());
       await addAccount('acct-1', 'item-a');
 
       const r = accounts();
       await tabTo(r, 'links');
-      expect(flat(r)).toContain('full replay pending');
+      expect(flat(r)).toContain('sync cursor cleared');
     });
 
-    it('does not flag a replay once a cursor is stored', async () => {
+    it('drops the flag once a cursor is stored', async () => {
       await addItem('item-a', 'Chase', Date.now());
       await addAccount('acct-1', 'item-a');
       await db.execute({ sql: 'INSERT INTO sync_state (account_id, cursor) VALUES (?, ?)', args: ['item-a', 'cur'] });
 
       const r = accounts();
       await tabTo(r, 'links');
-      expect(flat(r)).not.toContain('full replay pending');
+      expect(flat(r)).not.toContain('sync cursor cleared');
     });
 
     // Pressing [u] spawns the Plaid subprocess, so the behaviour it drives is
@@ -2312,6 +2312,154 @@ describe('Accounts', () => {
         await waitFor(() => expect(flat(r)).toContain('Stopped checking'));
         // Still on Links — Esc was consumed by the poll, not by the tab.
         expect(flat(r)).toContain('[u] update link');
+      });
+
+      // The steer that makes [r] vs [d] a real choice rather than two buttons.
+      it('points at [d] for the restore case rather than selling a refresh', async () => {
+        await linksWithItem();
+        const r = accounts();
+        await tabTo(r, 'links');
+        r.stdin.write('r');
+
+        await waitFor(() => expect(flat(r)).toContain('Trying to get back transactions you deleted'));
+        const f = flat(r);
+        expect(f).toContain('[d] delete sync cursor');
+        // The whole reason to steer: the alternative is not billed.
+        expect(f).toContain('free');
+      });
+
+      // Cancelling only to press [d] is pure friction, so the confirmation takes
+      // it directly.
+      it('[d] from the refresh confirmation opens the cursor confirmation instead', async () => {
+        await linksWithItem();
+        const spy = vi.spyOn(refreshApi, 'refreshTransactions');
+
+        const r = accounts();
+        await tabTo(r, 'links');
+        r.stdin.write('r');
+        await waitFor(() => expect(flat(r)).toContain('Plaid charges for each refresh'));
+        r.stdin.write('d');
+
+        await waitFor(() => expect(flat(r)).toContain('Delete sync cursor and resync'));
+        expect(flat(r)).not.toContain('Plaid charges for each refresh');
+        expect(spy).not.toHaveBeenCalled();
+      });
+    });
+
+    // ── Delete sync cursor ([d]) ──────────────────────────────────────────────
+    // Costs nothing at Plaid, so the confirmation is not about the bill: a
+    // cursor-zero replay resurrects transactions the user deleted on purpose,
+    // and that is the surprise the gate exists to prevent.
+    describe('delete sync cursor ([d])', () => {
+      async function linksWithSyncedItem() {
+        await addItem('item-a', 'Chase', Date.now());
+        await addAccount('acct-1', 'item-a');
+        await addAccount('acct-2', 'item-a');
+        await db.execute({ sql: 'INSERT INTO sync_state (account_id, cursor) VALUES (?, ?)', args: ['item-a', 'cur'] });
+      }
+
+      it('advertises [d] on a connection row', async () => {
+        await linksWithSyncedItem();
+        const r = accounts();
+        await tabTo(r, 'links');
+        expect(flat(r)).toContain('[d] delete sync cursor');
+      });
+
+      it('asks for confirmation before deleting anything', async () => {
+        await linksWithSyncedItem();
+        const spy = vi.spyOn(syncApi, 'deleteSyncCursor');
+
+        const r = accounts();
+        await tabTo(r, 'links');
+        r.stdin.write('d');
+
+        await waitFor(() => expect(flat(r)).toContain('Delete sync cursor and resync'));
+        // Item-scoped, and the panel says so rather than implying one account.
+        expect(flat(r)).toContain('all 2 accounts on this connection');
+        expect(spy).not.toHaveBeenCalled();
+      });
+
+      it('warns that hand-deleted transactions come back, and that Plaid gaps stay', async () => {
+        await linksWithSyncedItem();
+        const r = accounts();
+        await tabTo(r, 'links');
+        r.stdin.write('d');
+
+        await waitFor(() => expect(flat(r)).toContain('Delete sync cursor and resync'));
+        const f = flat(r);
+        expect(f).toContain('Transactions you deleted by hand will come back');
+        expect(f).toContain('Transactions Plaid no longer has will not');
+        // The reason to reach for this over [r]: it does not cost anything.
+        expect(f).toContain('Free');
+      });
+
+      it('[n] backs out without touching the cursor', async () => {
+        await linksWithSyncedItem();
+        const spy = vi.spyOn(syncApi, 'deleteSyncCursor');
+
+        const r = accounts();
+        await tabTo(r, 'links');
+        r.stdin.write('d');
+        await waitFor(() => expect(flat(r)).toContain('Delete sync cursor and resync'));
+        r.stdin.write('n');
+
+        await waitFor(() => expect(flat(r)).not.toContain('Delete sync cursor and resync'));
+        expect(spy).not.toHaveBeenCalled();
+        const rows = await db.execute({ sql: 'SELECT cursor FROM sync_state WHERE account_id = ?', args: ['item-a'] });
+        expect(rows.rows).toHaveLength(1);
+      });
+
+      it('[y] deletes the cursor and resyncs just that item', async () => {
+        await linksWithSyncedItem();
+        vi.spyOn(syncApi, 'syncAll').mockResolvedValue([
+          { itemId: 'item-a', added: 1234, modified: 0, removed: 0, dupes: 0, skipped: false },
+        ]);
+
+        const r = accounts();
+        await tabTo(r, 'links');
+        r.stdin.write('d');
+        await waitFor(() => expect(flat(r)).toContain('Delete sync cursor and resync'));
+        r.stdin.write('y');
+
+        await waitFor(() => expect(flat(r)).toContain('re-downloaded 1,234 transactions'));
+        // Scoped to the selected item, and forced past the 15-minute debounce.
+        expect(syncApi.syncAll).toHaveBeenCalledWith(true, ['item-a'], expect.anything());
+        // The cursor really went, rather than the UI merely claiming it did.
+        const rows = await db.execute({ sql: 'SELECT cursor FROM sync_state WHERE account_id = ?', args: ['item-a'] });
+        expect(rows.rows).toHaveLength(0);
+      });
+
+      // "N new transactions" would be a lie here: a cursor-zero replay reports
+      // every row Plaid holds as added, most of which the database already had.
+      it('reports the count as re-downloaded rather than new', async () => {
+        await linksWithSyncedItem();
+        vi.spyOn(syncApi, 'syncAll').mockResolvedValue([
+          { itemId: 'item-a', added: 900, modified: 0, removed: 0, dupes: 0, skipped: false },
+        ]);
+
+        const r = accounts();
+        await tabTo(r, 'links');
+        r.stdin.write('d');
+        await waitFor(() => expect(flat(r)).toContain('Delete sync cursor and resync'));
+        r.stdin.write('y');
+
+        await waitFor(() => expect(flat(r)).toContain('re-downloaded 900 transactions'));
+        expect(flat(r)).not.toContain('900 new transactions');
+      });
+
+      it('does nothing on a connection still awaiting its first sync', async () => {
+        // That sync starts from scratch already, so there is no cursor to delete.
+        await addItem('item-new', 'Capital One', null);
+        const spy = vi.spyOn(syncApi, 'deleteSyncCursor');
+
+        const r = accounts();
+        await tabTo(r, 'links');
+        await waitFor(() => expect(flat(r)).toContain('awaiting first sync'));
+        r.stdin.write('d');
+
+        await new Promise((res) => setTimeout(res, 50));
+        expect(flat(r)).not.toContain('Delete sync cursor and resync');
+        expect(spy).not.toHaveBeenCalled();
       });
     });
   });

--- a/tui/Accounts.tsx
+++ b/tui/Accounts.tsx
@@ -3,7 +3,7 @@ import { Box, Text, useInput } from 'ink';
 import { useSetTyping } from './TypingContext.js';
 import { useRefreshKey } from './RefreshContext.js';
 import { spawn } from 'node:child_process';
-import { syncAll, describeSyncProgress, type SyncItemResult, type SyncProgress } from '../core/sync.js';
+import { syncAll, deleteSyncCursor, describeSyncProgress, type SyncItemResult, type SyncProgress } from '../core/sync.js';
 import { setSyncResult, mergeSyncResult } from '../core/sync-status.js';
 import {
   refreshTransactions, describeRefreshProgress, describeRefreshResult,
@@ -181,7 +181,7 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
   // blocks [s] the way a sync does. Progress is held as a step rather than a
   // string: the waiting step carries a deadline, so re-rendering it on a timer
   // turns it into a live countdown.
-  const [linksMode, setLinksMode] = useState<'list' | 'confirm-refresh'>('list');
+  const [linksMode, setLinksMode] = useState<'list' | 'confirm-refresh' | 'confirm-delete-cursor'>('list');
   const [refreshProgress, setRefreshProgress] = useState<RefreshProgress | null>(null);
   const refreshAbortRef = useRef<AbortController | null>(null);
   const [, setRefreshTick] = useState(0);
@@ -355,7 +355,14 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
   /** Sync just the given items — used right after a link so the new institution
    *  syncs immediately. Mirrors forceSync but merges its outcome so another
    *  institution's failure badge survives a scoped run. */
-  function syncItems(itemIds: string[], startMsg = 'Syncing new institution…') {
+  function syncItems(
+    itemIds: string[],
+    startMsg = 'Syncing new institution…',
+    // A cursor-zero resync reports every transaction Plaid holds as `added`, so
+    // the default "N new transactions" would badly overstate it — the caller
+    // that knows better supplies its own wording.
+    doneMsg: (added: number) => string = (added) => `Done — ${added} new transaction${added !== 1 ? 's' : ''}`,
+  ) {
     syncStatusRef.current = 'syncing';   // visible before the re-render lands
     setSyncStatus('syncing');
     setSyncMsg(startMsg);
@@ -368,7 +375,7 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
         setSyncMsg(`Sync failed: ${describeSyncFailures(failed)}`);
       } else {
         const added = results.reduce((s, r) => s + r.added, 0);
-        setSyncMsg(`Done — ${added} new transaction${added !== 1 ? 's' : ''}`);
+        setSyncMsg(doneMsg(added));
         setSyncStatus('done');
         setTimeout(() => { setSyncStatus('idle'); setSyncMsg(''); }, 4000);
       }
@@ -412,6 +419,28 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
         refreshAbortRef.current = null;
         setRefreshProgress(null);
         setSyncMsg(`Refresh failed — ${plaidErrorMessage(err)}`);
+        setSyncStatus('error');
+      });
+  }
+
+  /** Forget where this connection's change feed left off, then resync it so Plaid
+   *  resends everything it holds. Free, unlike [r] refresh — the cost is the time
+   *  the resync takes. */
+  function startDeleteCursor(item: LinkedItem) {
+    setLinksMode('list');
+    const label = item.institution_name ?? 'this connection';
+    void deleteSyncCursor(item.item_id)
+      .then(() => {
+        syncItems(
+          [item.item_id],
+          `Sync cursor deleted — re-downloading ${label}…`,
+          // Everything Plaid holds arrives as `added` here, existing rows
+          // included, so this counts what was re-downloaded, not what is new.
+          (added) => `Done — re-downloaded ${added.toLocaleString()} transaction${added !== 1 ? 's' : ''}`,
+        );
+      })
+      .catch((err) => {
+        setSyncMsg(`Could not delete sync cursor — ${plaidErrorMessage(err)}`);
         setSyncStatus('error');
       });
   }
@@ -721,6 +750,14 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
       if (linksMode === 'confirm-refresh') {
         if (key.escape || input === 'n') { setLinksMode('list'); return; }
         if (input === 'y' && linkedItems[itemCursor]) { startRefresh(linkedItems[itemCursor]); return; }
+        // The refresh confirmation points at [d] for the restore case, so accept
+        // it here — cancelling first only to press it again is pure friction.
+        if (input === 'd' && linkedItems[itemCursor]) { setLinksMode('confirm-delete-cursor'); return; }
+        return;
+      }
+      if (linksMode === 'confirm-delete-cursor') {
+        if (key.escape || input === 'n') { setLinksMode('list'); return; }
+        if (input === 'y' && linkedItems[itemCursor]) { startDeleteCursor(linkedItems[itemCursor]); return; }
         return;
       }
       // Esc stops an in-flight refresh rather than leaving the tab — the poll
@@ -744,6 +781,14 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
       // — muscle memory lands on a confirmation, not a charge.
       if (input === 'r' && linkedItems[itemCursor] && syncStatus !== 'syncing') {
         setLinksMode('confirm-refresh');
+        return;
+      }
+      // Confirmed because it is destructive in one direction: replaying the feed
+      // resurrects transactions the user deleted on purpose. Costs nothing at
+      // Plaid, so the gate is about the surprise, not the bill. Skipped while a
+      // row awaits its first sync — that sync starts from scratch already.
+      if (input === 'd' && linkedItems[itemCursor] && !linkedItems[itemCursor].awaitingFirstSync && syncStatus !== 'syncing') {
+        setLinksMode('confirm-delete-cursor');
         return;
       }
       if (input === 's' && syncStatus !== 'syncing') { forceSync(); return; }
@@ -1119,8 +1164,8 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
                         ? <Text>synced <Text color={isSelected ? C_POSITIVE : undefined}>{fmtSyncedAt(item.last_synced_at)}</Text></Text>
                         : <Text color={C_WARNING}>never synced</Text>}
                     </Text>
-                    {/* No cursor means the next sync replays the item's whole history. */}
-                    {!item.hasCursor && !item.awaitingFirstSync && <Text dimColor>· full replay pending</Text>}
+                    {/* No cursor means the next sync re-downloads the item's whole history. */}
+                    {!item.hasCursor && !item.awaitingFirstSync && <Text dimColor>· sync cursor cleared</Text>}
                   </SelectableRow>
                 );
               })}
@@ -1142,7 +1187,9 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
                     </Text>
                     <Text dimColor>Asks your bank to go look for new transactions right now.</Text>
                     <Box marginTop={1} flexDirection="column">
-                      <Text dimColor>Only worth it if you're missing <Text bold>recent</Text> transactions and want the bank re-checked.</Text>
+                      {/* Naming the boundary is what makes the steer below land: past
+                          about a day, Plaid already has it, which is the [d] case. */}
+                      <Text dimColor>Only worth it for transactions from the last day or so — Plaid already has anything older.</Text>
                       {/* The window is fixed at item creation and update mode cannot
                           widen it, so name it here rather than leaving the limit abstract. */}
                       <Text dimColor>
@@ -1152,18 +1199,62 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
                         Then checks for new transactions {POLL_DELAYS_MS.length} times over about {Math.round(POLL_DELAYS_MS.reduce((a, b) => a + b, 0) / 60000)} minutes. Esc stops the checks.
                       </Text>
                     </Box>
+                    {/* Redirects the restore case, and says why refresh is the wrong
+                        tool for it — otherwise it reads as an arbitrary preference
+                        between two buttons. Undimmed headline so it separates from
+                        the four dim lines above. */}
+                    <Box marginTop={1} flexDirection="column">
+                      <Text>Trying to get back transactions you deleted, or an account you removed?</Text>
+                      <Text dimColor>Refresh won't do it — it only fetches what your bank hasn't reported yet.</Text>
+                      {/* Its own line: wrapping mid-phrase would split the key from
+                          the label it names. */}
+                      <Text dimColor>
+                        Press <Text color={C_POSITIVE}>[d] delete sync cursor</Text> instead — it re-downloads everything Plaid holds, free.
+                      </Text>
+                    </Box>
                   </Box>
                   <Box marginTop={1} gap={4}>
                     <Text color={C_WARNING}>[y] Yes, refresh</Text>
+                    <Text color={C_POSITIVE}>[d] delete sync cursor</Text>
+                    <Text color={C_POSITIVE}>[n] / Esc cancel</Text>
+                  </Box>
+                </ModalPanel>
+              )}
+
+              {linksMode === 'confirm-delete-cursor' && selectedItem && (
+                <ModalPanel borderColor={C_WARNING}>
+                  <Text bold color={C_WARNING}>Delete sync cursor and resync</Text>
+                  <Box marginTop={1} flexDirection="column">
+                    <Text>
+                      <Text color={C_ACCENT}>{selectedItem.institution_name ?? '(unknown institution)'}</Text>
+                      <Text dimColor>  — all {selectedItem.account_count} account{selectedItem.account_count !== 1 ? 's' : ''} on this connection</Text>
+                    </Text>
+                    <Text dimColor>
+                      Forgets how far we've read Plaid's change feed, so the next sync re-downloads
+                      every transaction Plaid currently holds. Free — it costs only the time to resync.
+                    </Text>
+                    <Box marginTop={1} flexDirection="column">
+                      <Text dimColor>Existing rows are updated in place, not duplicated, and your categories and tags are kept.</Text>
+                      {/* deleteTransaction leaves no tombstone, so the replayed feed
+                          resurrects deliberate deletions. The one destructive thing
+                          this does, hence undimmed. */}
+                      <Text>Transactions you deleted by hand will come back.</Text>
+                      <Text dimColor>Transactions Plaid no longer has will not.</Text>
+                    </Box>
+                  </Box>
+                  <Box marginTop={1} gap={4}>
+                    <Text color={C_WARNING}>[y] Yes, delete cursor and resync</Text>
                     <Text color={C_POSITIVE}>[n] / Esc cancel</Text>
                   </Box>
                 </ModalPanel>
               )}
 
               <Box marginTop={1} flexDirection="column">
-                <Text dimColor>[u] update link  — update creds for link, keeping its accounts and transactions</Text>
-                <Text dimColor>[r] refresh      — ask this bank for new transactions now (Plaid charges)</Text>
-                <Text dimColor>[s] sync         — re-sync every connection now</Text>
+                {/* Padded to the longest label so the em dashes line up. */}
+                <Text dimColor>[u] update link        — update creds for link, keeping its accounts and transactions</Text>
+                <Text dimColor>[d] delete sync cursor — re-download this connection's full history (free)</Text>
+                <Text dimColor>[r] refresh            — ask this bank for new transactions now (Plaid charges)</Text>
+                <Text dimColor>[s] sync               — re-sync every connection now</Text>
               </Box>
             </>
           )}


### PR DESCRIPTION
Adds a **delete sync cursor and resync** action to the Links tab: it forgets how far we have consumed a connection's `/transactions/sync` change feed, so the next sync starts from the beginning and Plaid resends every transaction it currently holds.

>[!IMPORTANT]
> **Stacked on #150**, which is stacked on #149 and #148. Base is `dev` to match those, so the diff below carries their commits until they merge. The commits belonging to this PR are `ad8eb01` and `2e8055d`. Note this branch predates the test commits since added to #148 (`02695ca`) and #149 (`248c8f6`), so those are not included here.

## Why

`[r] refresh` (#150) is billed per call and only reaches transactions the bank has not reported yet — roughly the last day. For anything older, Plaid already has it, and what is missing is on our side. Deleting the cursor fixes that case and costs nothing at Plaid.

## What it does and does not recover

This is the part worth reading carefully, because the obvious reading is wrong.

**It restores rows this app lost while Plaid kept them:** an account removed via `deleteAccount` (which cascades to its transactions), a row removed by `deleteTransaction`, or a database rebuilt against a live item. Every write in `syncTransactions` is an upsert, so the resync is idempotent — manual categories and tag suppressions survive.

**It cannot restore anything Plaid no longer has** — including the rows we deleted *because* Plaid reported them `removed`. Those are absent from the replayed feed for the same reason they were deleted, so cursor-zero changes nothing about them. Only a relink can bring those back, and only if the bank still reports them.

**The corollary is the one destructive thing here:** `deleteTransaction` leaves no tombstone, so a replay resurrects transactions the user meant to be rid of. Both confirmations say so outright rather than burying it.

`tests/sync.test.ts` pins both directions, including the row Plaid dropped staying dropped.

## Changes

- **core** — `deleteSyncCursor(itemId)` deletes the `sync_state` row and nothing else. The resync is a scoped `syncAll(true, [itemId])`, so it inherits per-item error capture, progress reporting, and `mergeSyncResult` — resyncing one institution leaves another's failure badge alone.
- **TUI** — `[d]` on the Links tab, behind a confirmation naming the institution and its account count.
- **GUI** — a `delete sync cursor` row button and matching modal, bridged as `sync.deleteCursorAndResync` (composed in main so the two steps cannot interleave with another sync).
- **Refresh modal** now steers the restore case here, says why refresh is the wrong tool for it, and accepts `[d]` directly so cancelling first is not required. Its "missing recent transactions" line now names the one-day boundary, since the steer is meaningless without it.
- `syncItems` grew an optional done-message callback: the default `N new transactions` would badly overstate a cursor-zero replay, where every row Plaid holds arrives as `added`. The cursor path reports `re-downloaded N` instead.
- Badge for an item with no stored cursor renamed `· full replay pending` → `· sync cursor cleared` on both surfaces.
- **docs/keybindings.md** — documents `[d]`, plus the `[r] refresh` that #150 added to the Links tab without recording, and a paragraph on which one fixes what.

## Testing

901 tests pass, `npm run typecheck` clean on both configs.

- 8 in `tests/sync.test.ts` — the delete, its scoping, the following sync starting from cursor zero, a restored row, and the row Plaid dropped staying dropped.
- 9 in the links tab block of `tests/tui/screens.test.tsx`, per CONTRIBUTING's TUI requirement — the gate, both confirmations' copy, the `[r]`→`[d]` handoff, the re-downloaded wording, and the awaiting-first-sync skip.
- 11 in a new `tests/gui/accounts-links.test.tsx`. The Links tab had no GUI coverage at all. These stub the Plaid client rather than the bridge, so calls run through the real registry against the in-memory DB and the bridged composition is genuinely under test; two assertions read the DB directly rather than trusting the UI.

Both modals were verified by rendering them through the test harness rather than by reading the JSX, which caught two defects the assertions missed: the steer line wrapped mid-phrase, splitting `[d] delete` from `sync cursor`, and the new hint broke the hint block's column alignment.

The GUI tests were verified by mutation rather than by watching them pass — dropping the cursor delete from the registry fails 2, dropping the awaiting-first-sync gate fails 1, and reverting the status wording fails 2.

## Notes for review

- The refresh-modal steer is **TUI-only**, because the GUI has no refresh action — #150 shipped `/transactions/refresh` to the TUI alone. If refresh gets bridged later, the steer copy needs porting alongside it.
- A cursor-zero replay returns what Plaid *currently* holds, so it never re-issues `removed` for transactions Plaid has since retracted. Any such row already in the database stays as a stale row. That is pre-existing behavior, not introduced here, but it is adjacent enough to be worth knowing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
