### PR TITLE
fix: register Subscriptions so seeded rules' category shows in pickers

### DIFF
--- a/core/db.ts
+++ b/core/db.ts
@@ -203,7 +203,7 @@ export async function initDb() {
     'Income', 'Transfer', 'Food & Drink', 'Shopping', 'Transportation',
     'Travel', 'Bills & Utilities', 'Insurance', 'Medical', 'Personal Care',
     'Childcare', 'Entertainment', 'Home', 'Services', 'Fees',
-    'Government', 'Taxes', 'Loan Payment', 'Uncategorized',
+    'Government', 'Taxes', 'Loan Payment', 'Subscriptions', 'Uncategorized',
   ];
   await db.batch(
     defaultCategories.map((cat) => ({

--- a/core/seed-rules.ts
+++ b/core/seed-rules.ts
@@ -70,6 +70,17 @@ export async function seedRules(): Promise<{ rules: number; recategorized: numbe
     'write',
   );
 
+  // Register every category the seeded rules assign. Without this a rule can
+  // file transactions under a category the pickers never offer, because those
+  // read from the `categories` table.
+  await db.batch(
+    [...new Set(RULES.map((r) => r.category))].map((cat) => ({
+      sql: 'INSERT OR IGNORE INTO categories (name) VALUES (?)',
+      args: [cat],
+    })),
+    'write',
+  );
+
   const uncategorizedResult = await db.execute({
     sql: 'SELECT id, account_id, name, merchant_name, raw_category, amount FROM transactions WHERE category = ? AND manual_category IS NULL',
     args: ['Uncategorized'],

--- a/tests/seed-rules.test.ts
+++ b/tests/seed-rules.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('../core/db.js', async () => {
+  const { makeTestDb } = await import('./helpers/makeTestDb.js');
+  return { db: await makeTestDb() };
+});
+
+import { db } from '../core/db.js';
+import { seedRules } from '../core/seed-rules.js';
+import { getAllCategories } from '../core/queries.js';
+
+beforeEach(async () => {
+  await db.execute('DELETE FROM category_rules');
+  await db.execute('DELETE FROM categories');
+  await db.execute('DELETE FROM transactions');
+});
+
+describe('seedRules', () => {
+  it('registers every category its rules assign, so the pickers offer them', async () => {
+    await seedRules();
+
+    const ruleCats = (await db.execute('SELECT DISTINCT category FROM category_rules'))
+      .rows as unknown as { category: string }[];
+    const categories = await getAllCategories();
+
+    expect(ruleCats.length).toBeGreaterThan(0);
+    for (const { category } of ruleCats) expect(categories).toContain(category);
+  });
+
+  it('offers Subscriptions, the category its streaming rules assign', async () => {
+    await seedRules();
+    expect(await getAllCategories()).toContain('Subscriptions');
+  });
+
+  it('leaves an existing category row untouched', async () => {
+    await db.execute("INSERT INTO categories (name, flexibility) VALUES ('Subscriptions', 'fixed')");
+    await seedRules();
+    const row = (await db.execute("SELECT flexibility FROM categories WHERE name = 'Subscriptions'"))
+      .rows[0] as unknown as { flexibility: string };
+    expect(row.flexibility).toBe('fixed');
+  });
+});


### PR DESCRIPTION
## The bug

Adding a category rule that files a merchant (e.g. TIDAL) under **Subscriptions** is impossible from the UI — `Subscriptions` never appears in the category picker, even though the seeded starter rules already use it.

## Root cause

Two hardcoded lists that were never reconciled:

- Every category picker (TUI `Rules`/`Transactions`, GUI equivalents) reads `getAllCategories()` → `SELECT name FROM categories`.
- `initDb`'s `defaultCategories` (`core/db.ts`) is the only thing that populates that table, and it omits `Subscriptions`.
- `core/seed-rules.ts` seeds six rules (NETFLIX, SPOTIFY, HULU, DISNEY, APPLE.COM/BILL, GOOGLE STORAGE) assigning `category: 'Subscriptions'`, and `seedRules()` writes only to `category_rules` — it never registers the categories those rules reference.

So `Subscriptions` can hold transactions but is invisible to every picker. It is the only category that drifted; the Plaid category map in `core/categorize.ts` targets only registered names.

## The fix

- `core/db.ts` — add `Subscriptions` to `defaultCategories`. That block is `INSERT OR IGNORE` and runs on every `initDb`, so existing databases pick the row up on next launch; no migration needed.
- `core/seed-rules.ts` — `seedRules()` registers the distinct categories its own rules assign, so a future seed rule cannot reintroduce an unpickable category.
- `tests/seed-rules.test.ts` — new: every seeded rule's category is offered by `getAllCategories()`, `Subscriptions` specifically, and an existing category row keeps its flexibility.

## Verification

`npx tsc --noEmit` clean; full suite green (42 files, 764 tests). Both new coverage tests fail without the `seed-rules.ts` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)