### PR TITLE
fix: pass the setup wizard's start date to the first bank link

### DIFF
--- a/tests/tui/setup.test.tsx
+++ b/tests/tui/setup.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect, afterAll, afterEach, beforeEach, vi } from 'vitest';
+import React from 'react';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { render, cleanup } from 'ink-testing-library';
+
+// Setup lives in its own test file (rather than screens.test.tsx) because it
+// needs two process-level fakes that would leak into every other screen: a
+// DATA_DIR holding a pre-filled .env, and a stubbed child_process.spawn.
+// Async so the temp dir exists before the core/paths mock below is consumed —
+// vi.hoisted runs ahead of this file's imports, so it loads node builtins itself.
+const { DATA_DIR } = await vi.hoisted(async () => {
+  const [fsMod, osMod, pathMod] = await Promise.all([
+    import('node:fs'), import('node:os'), import('node:path'),
+  ]);
+  const dir = fsMod.default.mkdtempSync(pathMod.default.join(osMod.default.tmpdir(), 'fungible-setup-'));
+  fsMod.default.writeFileSync(
+    pathMod.default.join(dir, '.env'),
+    'PLAID_CLIENT_ID=cid\nPLAID_SECRET=sec\nPLAID_ENV=sandbox\n',
+  );
+  return { DATA_DIR: dir };
+});
+
+vi.mock('../../core/paths.js', () => ({ DATA_DIR }));
+
+vi.mock('../../core/db.js', async () => {
+  const { makeTestDb } = await import('../helpers/makeTestDb.js');
+  return { db: await makeTestDb() };
+});
+
+const spawnMock = vi.hoisted(() => vi.fn((..._args: unknown[]) => ({
+  stdout: { on: vi.fn() },
+  stderr: { on: vi.fn() },
+  on: vi.fn(),
+})));
+
+vi.mock('node:child_process', async (importActual) => {
+  const actual = await importActual<typeof import('node:child_process')>();
+  return { ...actual, spawn: spawnMock };
+});
+
+import { db } from '../../core/db.js';
+import { Setup } from '../../tui/Setup.js';
+import { daysFromStartDate, MAX_DAYS_REQUESTED } from '../../core/settings.js';
+
+const ANSI_RE = /\x1b\[[0-9;]*[mGKHFABCDJ]/g;
+const frame = (r: ReturnType<typeof render>) => (r.lastFrame() ?? '').replace(ANSI_RE, '');
+
+async function waitFor(assertion: () => void, timeout = 1000): Promise<void> {
+  const deadline = Date.now() + timeout;
+  let lastErr: unknown;
+  while (Date.now() < deadline) {
+    try { assertion(); return; } catch (e) { lastErr = e; }
+    await new Promise((res) => setTimeout(res, 30));
+  }
+  throw lastErr;
+}
+
+/** YYYY-MM-DD for a date `n` days before today, in local time. */
+function daysAgo(n: number): string {
+  const d = new Date();
+  d.setHours(12, 0, 0, 0);
+  d.setDate(d.getDate() - n);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+}
+
+const spawnEnv = () => (spawnMock.mock.calls[0]?.[2] as { env?: NodeJS.ProcessEnv } | undefined)?.env;
+
+beforeEach(() => db.execute('DELETE FROM settings')); // each test starts with no saved start date
+afterEach(() => { cleanup(); spawnMock.mockClear(); });
+afterAll(() => fs.rmSync(DATA_DIR, { recursive: true, force: true }));
+
+// The wizard saves a default start date and then offers to link the first bank.
+// days_requested is locked when Plaid creates the Item, so if the start date
+// doesn't reach scripts/link.ts on that first link it can never be widened —
+// the link script omits days_requested and Plaid silently backfills 90 days.
+describe('Setup wizard link step', () => {
+  it('passes the days derived from the saved start date to the link script', async () => {
+    const startDate = daysAgo(200);
+    const r = render(<Setup />);
+
+    await waitFor(() => expect(frame(r)).toContain('Welcome to fungible'));
+    r.stdin.write('\r');                            // welcome → start-date (creds already in .env)
+    await waitFor(() => expect(frame(r)).toContain('Default history start date'));
+    r.stdin.write(startDate);
+    await waitFor(() => expect(frame(r)).toContain(startDate));
+    r.stdin.write('\r');                            // save → link-choice
+    await waitFor(() => expect(frame(r)).toContain('Link a bank account'));
+    r.stdin.write('y');                             // link now
+
+    await waitFor(() => expect(spawnMock).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(spawnEnv()?.PLAID_DAYS_REQUESTED).toBe(String(daysFromStartDate(startDate))),
+    );
+    expect(spawnEnv()?.PLAID_DAYS_REQUESTED).toBe('202'); // 200 days + the 2-day buffer
+  });
+
+  it('falls back to the maximum window when the start date is skipped', async () => {
+    const r = render(<Setup />);
+
+    await waitFor(() => expect(frame(r)).toContain('Welcome to fungible'));
+    r.stdin.write('\r');
+    await waitFor(() => expect(frame(r)).toContain('Default history start date'));
+    r.stdin.write('\r');                            // blank → skip to link-choice
+    await waitFor(() => expect(frame(r)).toContain('Link a bank account'));
+    r.stdin.write('y');
+
+    await waitFor(() => expect(spawnMock).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(spawnEnv()?.PLAID_DAYS_REQUESTED).toBe(String(MAX_DAYS_REQUESTED)),
+    );
+  });
+});

--- a/tui/Setup.tsx
+++ b/tui/Setup.tsx
@@ -5,7 +5,7 @@ import path from 'node:path';
 import { spawn } from 'node:child_process';
 import { seedRules } from '../core/seed-rules.js';
 import { DATA_DIR } from '../core/paths.js';
-import { getSetting, setSetting, daysFromStartDate, DEFAULT_START_DATE_KEY, MAX_DAYS_REQUESTED, START_DATE_BUFFER_DAYS } from '../core/settings.js';
+import { getSetting, setSetting, getDefaultDaysRequested, daysFromStartDate, DEFAULT_START_DATE_KEY, MAX_DAYS_REQUESTED, START_DATE_BUFFER_DAYS } from '../core/settings.js';
 import { C_POSITIVE, C_NEGATIVE, C_WARNING, C_ACCENT } from './ui.js';
 import { TextInput } from './components/index.js';
 
@@ -89,16 +89,24 @@ export function Setup() {
     process.env['PLAID_ENV'] = PLAID_ENVS[plaidEnvIdx];
   }
 
-  function startLink() {
+  async function startLink() {
     setLinkStatus('running');
     setLinkMsg('Opening browser…');
+    // The history window is locked when Plaid creates the Item, so the start
+    // date saved above has to reach the link script here — it can't be widened
+    // afterwards. Without PLAID_DAYS_REQUESTED the script omits days_requested
+    // entirely and Plaid falls back to 90 days.
+    const days = await getDefaultDaysRequested().catch(() => MAX_DAYS_REQUESTED);
     const node = process.execPath;
     const script = new URL('../scripts/link.ts', import.meta.url).pathname;
     const child = spawn(node, [
       '--no-warnings',
       '--import', 'tsx/esm',
       script,
-    ], { cwd: new URL('..', import.meta.url).pathname });
+    ], {
+      cwd: new URL('..', import.meta.url).pathname,
+      env: { ...process.env, PLAID_DAYS_REQUESTED: String(days) },
+    });
     child.stdout.on('data', (data: Buffer) => {
       const line = data.toString().trim().split('\n').pop() ?? '';
       if (line) setLinkMsg(line);
@@ -195,7 +203,7 @@ export function Setup() {
     }
 
     if (step === 'link-choice') {
-      if (input === 'y') { setStep('linking'); startLink(); return; }
+      if (input === 'y') { setStep('linking'); void startLink(); return; }
       if (input === 'n') { setStep('seed-choice'); return; }
       return;
     }


### PR DESCRIPTION
## Problem

In the setup wizard, entering a default history start date (say `2025-04-01`) and then linking your first bank gets you **90 days** of history, not the ~505 the wizard's own screen tells you it will request.

`saveStartDate()` writes the date to the `plaid_default_start_date` setting, but `startLink()` spawned `scripts/link.ts` with no `env` option (`tui/Setup.tsx`). The script reads the window from `PLAID_DAYS_REQUESTED`, and with that unset `resolveDaysRequested()` returns `undefined`, so `createLinkToken` omits the `transactions` block entirely and Plaid applies its 90-day default. The row inserted into `plaid_items` also recorded `days_requested` as NULL, so nothing showed what had actually been requested.

Plaid locks the history window when it creates the Item, so this wasn't recoverable — the first account linked through the wizard was stuck at 90 days unless it was re-linked. Only the Accounts screen (`tui/Accounts.tsx:311`) was passing the setting through.

## Fix

`startLink()` resolves `getDefaultDaysRequested()` and passes it as `PLAID_DAYS_REQUESTED` in the child env, the same way the Accounts screen already does. Skipping the start-date step still falls back to the 730-day maximum.

## Tests

New `tests/tui/setup.test.tsx` drives the wizard with a stubbed `spawn` and asserts the env handed to the link script: the days derived from an entered start date (200 days ago → `202`, including the 2-day buffer), and `730` when the date is skipped. Both fail on `dev` and pass with the fix.

It's a separate file rather than an addition to `tests/tui/screens.test.tsx` because it needs two process-level fakes — a temp `DATA_DIR` holding a pre-filled `.env`, and a stubbed `node:child_process` — that would otherwise leak into every other screen test.

`npm test` (763 tests) and `npm run typecheck` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)