### PR TITLE
fix: pair each Plaid transaction with at most one CSV duplicate

### DIFF
--- a/core/dedup.ts
+++ b/core/dedup.ts
@@ -30,29 +30,118 @@ const MATCH_SQL = `
   )
 `;
 
+/**
+ * One CSV row that *could* be the same transaction as one Plaid row. The join is
+ * many-to-many by nature — a merchant you visit twice in a week produces rows
+ * that all match each other on amount, name and the ±3 day window — so this is a
+ * candidate, not a verdict. `pairCandidates` reduces it to a decision.
+ *
+ * Carries the two rowids so pairing can break ties by insertion order rather
+ * than by whatever order SQLite happened to return.
+ */
+type Candidate = DupePair & { plaidId: string; csvRowid: number; plaidRowid: number };
+
+// LEFT JOIN, not INNER: a CSV row whose account was deleted out from under it
+// still deduplicates against Plaid the way it always has. An INNER JOIN here
+// would quietly make orphaned rows undeletable.
+const CANDIDATE_SQL = `
+  SELECT csv.id as csvId, csv.date as csvDate, csv.name as csvName, csv.amount as csvAmount,
+         plaid.id as plaidId, plaid.date as plaidDate, plaid.name as plaidName,
+         csv.rowid as csvRowid, plaid.rowid as plaidRowid,
+         COALESCE(a.name, '') as accountName
+  FROM transactions csv
+  JOIN transactions plaid ON ${MATCH_SQL}
+  LEFT JOIN accounts a ON a.id = csv.account_id
+`;
+
+const normalize = (s: string) => s.trim().toLowerCase().replace(/\s+/g, ' ');
+
+/**
+ * How strong the name evidence is, lower being stronger. Mirrors the tiers in
+ * MATCH_SQL: an exact string, the same string modulo case and whitespace, one
+ * name contained in the other, and finally the loose masked-prefix and
+ * first-word rules that exist to catch `AMAZON*XYZ123` style Plaid names.
+ */
+function nameRank(csvName: string, plaidName: string): number {
+  if (csvName === plaidName) return 0;
+  const c = normalize(csvName);
+  const p = normalize(plaidName);
+  if (c === p) return 1;
+  if (c.includes(p) || p.includes(c)) return 2;
+  return 3;
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const dayGap = (a: string, b: string) =>
+  Math.abs(Date.parse(`${a}T00:00:00Z`) - Date.parse(`${b}T00:00:00Z`)) / DAY_MS;
+
+/**
+ * Reduces the many-to-many candidate set to a set of one-to-one pairs: every
+ * CSV row is matched to at most one Plaid row, and every Plaid row absorbs at
+ * most one CSV row.
+ *
+ * This is the whole point of the module. Two real $5 coffees in the same week
+ * match each other's rows on every criterion MATCH_SQL tests, so a naive "delete
+ * every CSV row that matched something" deletes both when Plaid only reported
+ * one of them — silently losing a genuine transaction. Pairing means a Plaid row
+ * can only ever cancel out the single CSV row it most likely *is*, and any
+ * surplus CSV rows survive as the separate purchases they are.
+ *
+ * Greedy assignment over candidates sorted best-first. Ranking, in order:
+ *
+ *   1. Name evidence, because CSV and Plaid routinely disagree about the posting
+ *      date — that disagreement is the reason for the ±3 day window in the first
+ *      place — but rarely about the merchant string. A same-name match three days
+ *      out is better evidence than a different-name match on the same day.
+ *   2. Date proximity, to settle same-strength names.
+ *   3. Insertion order, so the outcome is deterministic when a file contains
+ *      literally identical rows. The earliest CSV row is the one consumed.
+ */
+export function pairCandidates(candidates: Candidate[]): Candidate[] {
+  const ranked = [...candidates].sort((x, y) =>
+    nameRank(x.csvName, x.plaidName) - nameRank(y.csvName, y.plaidName) ||
+    dayGap(x.csvDate, x.plaidDate) - dayGap(y.csvDate, y.plaidDate) ||
+    x.csvRowid - y.csvRowid ||
+    x.plaidRowid - y.plaidRowid,
+  );
+
+  const takenCsv = new Set<string>();
+  const takenPlaid = new Set<string>();
+  const paired: Candidate[] = [];
+  for (const c of ranked) {
+    if (takenCsv.has(c.csvId) || takenPlaid.has(c.plaidId)) continue;
+    takenCsv.add(c.csvId);
+    takenPlaid.add(c.plaidId);
+    paired.push(c);
+  }
+  return paired;
+}
+
+async function loadPairs(): Promise<Candidate[]> {
+  const result = await db.execute(CANDIDATE_SQL);
+  const rows = (result.rows as unknown as Candidate[]).map((r) => ({
+    ...r,
+    csvAmount: Number(r.csvAmount),
+    csvRowid: Number(r.csvRowid),
+    plaidRowid: Number(r.plaidRowid),
+  }));
+  return pairCandidates(rows);
+}
+
 export async function getCsvPlaidDupeCandidates(): Promise<DupePair[]> {
-  const result = await db.execute(`
-    SELECT csv.id as csvId, csv.date as csvDate, csv.name as csvName, csv.amount as csvAmount,
-           plaid.date as plaidDate, plaid.name as plaidName,
-           a.name as accountName
-    FROM transactions csv
-    JOIN transactions plaid ON ${MATCH_SQL}
-    JOIN accounts a ON a.id = csv.account_id
-    ORDER BY csv.date DESC
-  `);
-  return result.rows as unknown as DupePair[];
+  const paired = await loadPairs();
+  // Newest first, insertion order within a date so the list doesn't reshuffle
+  // between reads.
+  paired.sort((x, y) => (x.csvDate < y.csvDate ? 1 : x.csvDate > y.csvDate ? -1 : x.csvRowid - y.csvRowid));
+  return paired.map(({ csvId, csvDate, csvName, csvAmount, plaidDate, plaidName, accountName }) =>
+    ({ csvId, csvDate, csvName, csvAmount, plaidDate, plaidName, accountName }));
 }
 
 export async function deduplicateCsvVsPlaid(): Promise<number> {
-  const result = await db.execute(`
-    SELECT csv.id as csv_id
-    FROM transactions csv
-    JOIN transactions plaid ON ${MATCH_SQL}
-  `);
-  const csvDupes = result.rows as unknown as { csv_id: string }[];
-  if (csvDupes.length === 0) return 0;
+  const paired = await loadPairs();
+  if (paired.length === 0) return 0;
 
-  const ids = csvDupes.map((r) => r.csv_id);
+  const ids = paired.map((p) => p.csvId);
   const placeholders = ids.map(() => '?').join(',');
   const del = await db.execute({
     sql: `DELETE FROM transactions WHERE id IN (${placeholders})`,

--- a/tests/dedup.test.ts
+++ b/tests/dedup.test.ts
@@ -6,7 +6,7 @@ vi.mock('../core/db.js', async () => {
 });
 
 import { db } from '../core/db.js';
-import { deduplicateCsvVsPlaid } from '../core/dedup.js';
+import { deduplicateCsvVsPlaid, getCsvPlaidDupeCandidates } from '../core/dedup.js';
 
 let seq = 0;
 async function csvTx(opts: { name: string; amount: number; date?: string; accountId?: string }) {
@@ -34,6 +34,7 @@ async function exists(id: string) {
 beforeEach(async () => {
   seq = 0;
   await db.execute('DELETE FROM transactions');
+  await db.execute('DELETE FROM accounts');
 });
 
 describe('deduplicateCsvVsPlaid', () => {
@@ -155,14 +156,100 @@ describe('deduplicateCsvVsPlaid', () => {
       expect(await exists(plaid)).toBe(true);
     });
 
-    it('handles multiple CSV duplicates of the same Plaid transaction', async () => {
+  });
+
+  // Every criterion in MATCH_SQL is satisfied by two genuinely separate visits to
+  // the same merchant in the same week, so the join is many-to-many and matching
+  // "everything that matched" throws away real transactions.
+  describe('one-to-one pairing', () => {
+    it('lets one Plaid row absorb only one of two identical CSV rows', async () => {
       const csv1 = await csvTx({ name: 'STARBUCKS', amount: 5 });
       const csv2 = await csvTx({ name: 'STARBUCKS', amount: 5 });
       await plaidTx({ name: 'STARBUCKS', amount: 5 });
-      const removed = await deduplicateCsvVsPlaid();
-      expect(removed).toBe(2);
+      expect(await deduplicateCsvVsPlaid()).toBe(1);
+      // Earliest CSV row is the one consumed, so the outcome is deterministic
+      // when a file contains literally identical rows.
+      expect(await exists(csv1)).toBe(false);
+      expect(await exists(csv2)).toBe(true);
+    });
+
+    it('absorbs both CSV rows when Plaid reported both purchases', async () => {
+      const csv1 = await csvTx({ name: 'STARBUCKS', amount: 5 });
+      const csv2 = await csvTx({ name: 'STARBUCKS', amount: 5 });
+      await plaidTx({ name: 'STARBUCKS', amount: 5 });
+      await plaidTx({ name: 'STARBUCKS', amount: 5 });
+      expect(await deduplicateCsvVsPlaid()).toBe(2);
       expect(await exists(csv1)).toBe(false);
       expect(await exists(csv2)).toBe(false);
+    });
+
+    it('leaves surplus Plaid rows alone when the CSV has fewer', async () => {
+      const csv = await csvTx({ name: 'STARBUCKS', amount: 5 });
+      const plaid1 = await plaidTx({ name: 'STARBUCKS', amount: 5 });
+      const plaid2 = await plaidTx({ name: 'STARBUCKS', amount: 5 });
+      expect(await deduplicateCsvVsPlaid()).toBe(1);
+      expect(await exists(csv)).toBe(false);
+      expect(await exists(plaid1)).toBe(true);
+      expect(await exists(plaid2)).toBe(true);
+    });
+
+    it('pairs the stronger name match ahead of the closer date', async () => {
+      const fuzzy = await csvTx({ name: 'STARBUCKS STORE 4471', amount: 5, date: '2025-01-15' });
+      const exact = await csvTx({ name: 'STARBUCKS', amount: 5, date: '2025-01-17' });
+      await plaidTx({ name: 'STARBUCKS', amount: 5, date: '2025-01-15' });
+      expect(await deduplicateCsvVsPlaid()).toBe(1);
+      expect(await exists(exact)).toBe(false);
+      expect(await exists(fuzzy)).toBe(true);
+    });
+
+    it('pairs the closer date when the names are equally strong', async () => {
+      const far  = await csvTx({ name: 'AMAZON', amount: 50, date: '2025-01-18' });
+      const near = await csvTx({ name: 'AMAZON', amount: 50, date: '2025-01-16' });
+      await plaidTx({ name: 'AMAZON', amount: 50, date: '2025-01-15' });
+      expect(await deduplicateCsvVsPlaid()).toBe(1);
+      expect(await exists(near)).toBe(false);
+      expect(await exists(far)).toBe(true);
+    });
+
+    it('reports the same pairing to the review list that it would delete', async () => {
+      const csv1 = await csvTx({ name: 'STARBUCKS', amount: 5 });
+      await csvTx({ name: 'STARBUCKS', amount: 5 });
+      await plaidTx({ name: 'STARBUCKS', amount: 5 });
+      const pairs = await getCsvPlaidDupeCandidates();
+      expect(pairs.map((p) => p.csvId)).toEqual([csv1]);
+    });
+  });
+
+  describe('candidate list', () => {
+    it('carries the account name', async () => {
+      await db.execute({
+        sql: "INSERT INTO accounts (id, name, type) VALUES ('acct1', 'Chase Sapphire', 'credit')",
+      });
+      await csvTx({ name: 'AMAZON', amount: 50 });
+      await plaidTx({ name: 'AMAZON', amount: 50 });
+      const pairs = await getCsvPlaidDupeCandidates();
+      expect(pairs).toHaveLength(1);
+      expect(pairs[0].accountName).toBe('Chase Sapphire');
+    });
+
+    // The account row can go missing — deleteAccount cascades to transactions,
+    // but a half-finished delete or a restored backup can leave orphans behind.
+    // Those still deduplicate; they just have no name to show.
+    it('still reports rows whose account is missing', async () => {
+      await csvTx({ name: 'AMAZON', amount: 50 });
+      await plaidTx({ name: 'AMAZON', amount: 50 });
+      const pairs = await getCsvPlaidDupeCandidates();
+      expect(pairs).toHaveLength(1);
+      expect(pairs[0].accountName).toBe('');
+    });
+
+    it('lists newest first', async () => {
+      const older = await csvTx({ name: 'AMAZON', amount: 50, date: '2025-01-10' });
+      const newer = await csvTx({ name: 'NETFLIX', amount: 15, date: '2025-02-10' });
+      await plaidTx({ name: 'AMAZON', amount: 50, date: '2025-01-10' });
+      await plaidTx({ name: 'NETFLIX', amount: 15, date: '2025-02-10' });
+      const pairs = await getCsvPlaidDupeCandidates();
+      expect(pairs.map((p) => p.csvId)).toEqual([newer, older]);
     });
   });
 


### PR DESCRIPTION
`deduplicateCsvVsPlaid` deletes **every** CSV row that matched a Plaid row, not one per. The join behind it is many-to-many by nature: two separate visits to the same merchant in the same week satisfy every criterion `MATCH_SQL` tests — same account, same amount, names that match, dates inside the ±3 day window — so both CSV rows match the single Plaid row and both get deleted, losing a genuine transaction.

`tests/dedup.test.ts` asserted the lossy behavior, so this inverts that test:

```js
// before
const csv1 = await csvTx({ name: 'STARBUCKS', amount: 5 });
const csv2 = await csvTx({ name: 'STARBUCKS', amount: 5 });
await plaidTx({ name: 'STARBUCKS', amount: 5 });
expect(removed).toBe(2);   // ← both deleted, only one was a duplicate
```

The ±3 day window exists precisely because CSV and Plaid disagree about posting dates, so overlap is normal rather than exceptional. And the loss is invisible: the row is gone, nothing reports it, and the sync that did it reports a duplicate count that looks like success.

## The fix

Candidates are reduced to one-to-one pairs before anything is deleted — each CSV row matches at most one Plaid row, each Plaid row absorbs at most one CSV row. Greedy assignment over candidates sorted best-first, ranked by:

1. **Name evidence.** The two sources rarely disagree about the merchant string but routinely disagree about the date, so a same-name match three days out is stronger evidence than a different-name match on the same day. The tiers mirror the ones already in `MATCH_SQL`.
2. **Date proximity**, to settle equally strong names.
3. **Insertion order**, so a file containing literally identical rows still produces a deterministic winner. The earliest CSV row is the one consumed.

`getCsvPlaidDupeCandidates` and `deduplicateCsvVsPlaid` now share the candidate query and the pairing pass, so the Dupes review list shows exactly what an automatic dedup would remove. They previously shared only the SQL fragment and could disagree.

## Two things worth a look in review

**`MATCH_SQL` is untouched.** Same candidates as before; all that changed is what happens to them afterwards. Likewise `DupePair` and `deduplicateCsvVsPlaid`'s signature, so no caller needed touching — including `core/sync.ts` and both Accounts screens.

**The shared query uses `LEFT JOIN accounts`.** The review list used an inner join; the delete path joined `accounts` not at all. Unifying on an inner join would have quietly made CSV rows whose account went missing undeletable, so the left join preserves the delete path's behavior exactly. Those rows keep deduplicating, they just have no name to show. There's a test pinning it.

## Testing

`tests/dedup.test.ts` goes from 19 to 27 tests: one Plaid row absorbing one of two identical CSV rows, both absorbed when Plaid reported both purchases, surplus Plaid rows left alone, name-strength preference, date preference, review-list/delete agreement, and the account-name join in both directions.

Full suite passes (769 tests, 41 files); `npm run typecheck` clean.

## Context

This came out of looking at #19 — backfilling years of CSV history into a Plaid-linked account makes wide overlap the normal case rather than the exception, which turns this from a rare annoyance into routine data loss. It stands on its own though, and doesn't depend on anything else I've proposed there.

Branched off `dev` and touches only `core/dedup.ts` and `tests/dedup.test.ts`, so it doesn't collide with #148/#149/#150/#151 — merge it in any order relative to those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
