### PR TITLE
fix(gui): ad-hoc sign the macOS app so Gatekeeper doesn't call it damaged

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ npm run gui
 
 The GUI reads/writes the same `~/.fungible/` database as the TUI — switch freely.
 
-For first-launch caveats on unsigned installers (Gatekeeper, SmartScreen) and packaging details, see [`docs/gui.md`](docs/gui.md).
+For first-launch caveats on the un-notarized installers (Gatekeeper, SmartScreen) and packaging details, see [`docs/gui.md`](docs/gui.md).
 
 ### Storage
 

--- a/docs/gui.md
+++ b/docs/gui.md
@@ -14,11 +14,13 @@ Download an installer from the [latest GitHub Release](https://github.com/tomfun
 - **Windows (x64)** — `fungible-<version>-win-x64.exe`
 - **Linux (x64)** — `fungible-<version>-linux-x86_64.AppImage` or `.deb`
 
-The installers aren't code-signed. On first launch:
+The installers are ad-hoc signed, not notarized (no paid Apple Developer ID). On first launch:
 
-- **macOS** — Gatekeeper will block it. Open System Settings → Privacy & Security → "Open Anyway", or run `xattr -d com.apple.quarantine /Applications/Fungible.app` once.
+- **macOS** — Gatekeeper blocks it with "Apple could not verify 'Fungible' is free of malware". Open it once from System Settings → Privacy & Security → "Open Anyway", or run `xattr -dr com.apple.quarantine /Applications/Fungible.app`.
 - **Windows** — SmartScreen may warn; click "More info" → "Run anyway".
 - **Linux AppImage** — `chmod +x` the file, then run it.
+
+On releases up to v1.8.0 the macOS app shipped unsigned, so Gatekeeper rejected it outright with "Fungible is damaged and can't be opened" and offered no "Open Anyway" (issue [#144](https://github.com/tomfunk/fungible/issues/144)). The `xattr -dr` command above clears that too; upgrading is the better fix.
 
 ### From source
 

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -27,6 +27,15 @@ asarUnpack:
 npmRebuild: false
 
 mac:
+  # Without this, electron-builder finds no Developer ID cert in CI, skips
+  # signing entirely, and ships the .app carrying only the linker-signed ad-hoc
+  # signature Electron's prebuilt binary came with. That signature no longer
+  # matches the repacked bundle, so Gatekeeper rejects a quarantined download
+  # outright with "damaged and can't be opened" — a dead end with no "Open
+  # Anyway" escape hatch (issue #144). '-' re-signs the finished bundle ad-hoc,
+  # which verifies cleanly; the download still warns (unnotarized), but the
+  # warning is the dismissable kind. Real fix is a Developer ID + notarization.
+  identity: '-'
   target:
     - target: dmg
       arch: [arm64, x64]


### PR DESCRIPTION
Fixes #144.

## Root cause

Downloaded `fungible-1.8.0-mac-arm64.dmg` and inspected the shipped bundle:

```
Identifier=Electron
flags=0x20002(adhoc,linker-signed)

$ codesign --verify --deep --strict Fungible.app
Fungible.app: code has no resources but signature indicates they must be present
```

electron-builder v26 finds no Developer ID cert on the CI runner and **skips signing entirely** — there is no automatic ad-hoc fallback (`app-builder-lib/out/mac/MacTargetHelper.js:44`). So the release shipped the `.app` carrying only the linker-signed stub that Electron's prebuilt binary came with, identifier still `Electron`. That signature no longer matches the repacked bundle.

On Apple Silicon a *broken* signature plus the quarantine flag is a hard reject — "Fungible is damaged and can't be opened" — and macOS offers no "Open Anyway", so the workaround in `docs/gui.md` didn't help the reporter.

## Fix

`identity: '-'` opts into explicit ad-hoc signing, so electron-builder re-signs the finished bundle.

Verified on a local `--dir` build:

- signs as `Identifier=com.tomfunk.fungible`, `flags=0x10002(adhoc,runtime)`
- `codesign --verify --deep --strict` → *valid on disk, satisfies its Designated Requirement*
- entitlements include `com.apple.security.cs.disable-library-validation` (electron-builder's default template), so hardened runtime doesn't block the libsql native binding — confirmed by launching the packaged app with `--demo`, which comes up and stays up
- `syspolicy_check distribution` now flags ad-hoc as a *Warning* instead of the app being unlaunchable

Downloads still warn ("Apple could not verify Fungible is free of malware") because the app isn't notarized, but that dialog has the Open Anyway escape hatch.

## Not fixed here

Real notarization needs an Apple Developer Program membership ($99/yr) plus `CSC_LINK` / `CSC_KEY_PASSWORD` / `APPLE_ID` / `APPLE_APP_SPECIFIC_PASSWORD` / `APPLE_TEAM_ID` secrets wired into `release.yml`. Ad-hoc is the ceiling without that.

Docs updated to describe the dialog users actually see, to use `xattr -dr` (recursive — plain `-d` can leave nested attributes), and to note that ≤ v1.8.0 shows "damaged".

🤖 Generated with [Claude Code](https://claude.com/claude-code)