### PR TITLE
fix: point PLAID_ENV=development users at production in the error message

### DIFF
--- a/core/plaid.ts
+++ b/core/plaid.ts
@@ -13,8 +13,15 @@ export function getPlaidClient(): PlaidApi {
   const env = process.env.PLAID_ENV ?? 'sandbox';
   const basePath = PlaidEnvironments[env as keyof typeof PlaidEnvironments];
   if (!basePath) {
+    // Plaid retired the "development" tier. Anyone whose linking appeared to work on
+    // that value was silently reaching production (the SDK's default basePath), so
+    // point them at production rather than letting them downgrade to sandbox data.
+    const hint =
+      env === 'development'
+        ? ' Plaid retired the "development" tier. If your bank connection was working before, you were reaching Plaid production — set PLAID_ENV=production to keep that access. Use "sandbox" only for test data.'
+        : '';
     throw new Error(
-      `PLAID_ENV="${env}" is not a valid Plaid environment. Valid values: ${Object.keys(PlaidEnvironments).join(', ')}.`
+      `PLAID_ENV="${env}" is not a valid Plaid environment. Valid values: ${Object.keys(PlaidEnvironments).join(', ')}.${hint}`
     );
   }
   const config = new Configuration({


### PR DESCRIPTION
Follow-up to #129.

## What was already done

The substance of #129 shipped in c5e5332 (Jul 29): `.env.example` defaults to `sandbox`, `getPlaidClient()` throws on an unresolvable `PLAID_ENV`, and `'development'` is gone from the pickers in `tui/Setup.tsx` and the GUI `Settings.tsx`. That commit went straight to `dev`/`main` with no PR, which is why #129 stayed open.

## What was still missing

The migration guidance called out in the issue thread never reached users — no PR description, no changelog. Today an existing `development` user upgrades, hits the new hard error, and reads:

```
PLAID_ENV="development" is not a valid Plaid environment. Valid values: production, sandbox.
```

That's a coin flip, and the wrong side is costly. Before c5e5332, `PLAID_ENV=development` left `basePath` undefined and the generated Plaid `Configuration` fell back to `production.plaid.com` — so anyone whose linking *appeared to work* was hitting production all along. They need `production`; choosing `sandbox` silently swaps their real bank data for test data with no error.

## Change

Special-case `development` in the error so the guidance lands where the user actually is:

```
PLAID_ENV="development" is not a valid Plaid environment. Valid values: production, sandbox.
Plaid retired the "development" tier. If your bank connection was working before, you were
reaching Plaid production — set PLAID_ENV=production to keep that access. Use "sandbox" only
for test data.
```

Any other invalid value keeps the plain message.

## Verification

- `tsc --noEmit` clean.
- Exercised `getPlaidClient()` with `development` (hinted error), `bogus` (plain error), and `sandbox` (builds a client).
- Full suite: 683/684. The one failure, `tests/tui/screens.test.tsx` "digit-nav sweep", is pre-existing — reproduced identically on clean HEAD with this change reverted. It's an `ERR_REQUIRE_ESM` from `html-encoding-sniffer` in `node_modules`, unrelated to this diff, but worth a separate look.

Reported and diagnosed by @scaljei in #129.