### PR TITLE
feat: GUI parity for on-demand transaction refresh

### DIFF
--- a/core/sync-progress.ts
+++ b/core/sync-progress.ts
@@ -1,0 +1,32 @@
+/**
+ * Pure sync-progress types and formatting — no node/db/Plaid deps, so the GUI
+ * renderer can import it to display steps pushed over IPC. core/sync.ts owns the
+ * I/O and re-exports these for existing callers.
+ */
+
+/**
+ * A step within one item's sync, reported as it starts so a caller can show the
+ * user what the network is busy with. Every long phase gets an entry; the counts
+ * are what's known at that point, not a total.
+ */
+export type SyncProgress =
+  | { phase: 'transactions'; page: number; fetched: number }
+  | { phase: 'accounts' }
+  | { phase: 'categorize'; count: number }
+  | { phase: 'tag-rules'; count: number }
+  | { phase: 'remove'; count: number }
+  | { phase: 'dedup' };
+
+/** Human-readable form of a progress step, shared by every caller that renders it. */
+export function describeSyncProgress(p: SyncProgress): string {
+  switch (p.phase) {
+    case 'transactions': return `Fetching transactions… ${p.fetched.toLocaleString()} so far`;
+    case 'accounts':     return 'Fetching accounts & balances…';
+    case 'categorize':   return `Categorizing ${p.count.toLocaleString()} transaction${p.count === 1 ? '' : 's'}…`;
+    case 'tag-rules':    return 'Applying tag rules…';
+    case 'remove':       return `Removing ${p.count.toLocaleString()} deleted transaction${p.count === 1 ? '' : 's'}…`;
+    case 'dedup':        return 'Checking for duplicates…';
+  }
+}
+
+export type SyncProgressFn = (p: SyncProgress) => void;

--- a/core/sync.ts
+++ b/core/sync.ts
@@ -6,33 +6,12 @@ import { applyTagRules } from './tag-rules.js';
 import { deduplicateCsvVsPlaid } from './dedup.js';
 import { decryptToken } from './crypto.js';
 import type { Transaction } from 'plaid';
+import { describeSyncProgress, type SyncProgress, type SyncProgressFn } from './sync-progress.js';
 
-/**
- * A step within one item's sync, reported as it starts so a caller can show the
- * user what the network is busy with. Every long phase gets an entry; the counts
- * are what's known at that point, not a total.
- */
-export type SyncProgress =
-  | { phase: 'transactions'; page: number; fetched: number }
-  | { phase: 'accounts' }
-  | { phase: 'categorize'; count: number }
-  | { phase: 'tag-rules'; count: number }
-  | { phase: 'remove'; count: number }
-  | { phase: 'dedup' };
-
-/** Human-readable form of a progress step, shared by every caller that renders it. */
-export function describeSyncProgress(p: SyncProgress): string {
-  switch (p.phase) {
-    case 'transactions': return `Fetching transactions… ${p.fetched.toLocaleString()} so far`;
-    case 'accounts':     return 'Fetching accounts & balances…';
-    case 'categorize':   return `Categorizing ${p.count.toLocaleString()} transaction${p.count === 1 ? '' : 's'}…`;
-    case 'tag-rules':    return 'Applying tag rules…';
-    case 'remove':       return `Removing ${p.count.toLocaleString()} deleted transaction${p.count === 1 ? '' : 's'}…`;
-    case 'dedup':        return 'Checking for duplicates…';
-  }
-}
-
-export type SyncProgressFn = (p: SyncProgress) => void;
+// Progress types/formatting live in the node-free core/sync-progress.ts so the
+// GUI renderer can import them; re-exported here for existing callers.
+export { describeSyncProgress };
+export type { SyncProgress, SyncProgressFn };
 
 export async function syncTransactions(accessToken: string, itemId: string, onProgress?: SyncProgressFn) {
   const cursorRes = await db.execute({

--- a/core/transactions-refresh-format.ts
+++ b/core/transactions-refresh-format.ts
@@ -1,0 +1,74 @@
+/**
+ * Pure refresh-progress types, constants, and formatting — no node/db/Plaid
+ * deps, so the GUI renderer can import them to display progress pushed over IPC.
+ * core/transactions-refresh.ts owns the polling and re-exports these.
+ */
+import { describeSyncProgress, type SyncProgress } from './sync-progress.js';
+import type { SyncItemResult } from './sync.js';
+
+/** Waits before each post-refresh sync check. Banks routinely take a minute or
+ *  more to answer an on-demand extraction, so the tail is long and the total
+ *  budget is a little under four minutes. */
+export const POLL_DELAYS_MS = [15_000, 30_000, 60_000, 120_000];
+
+export type RefreshProgress =
+  | { phase: 'requesting' }
+  // `until` is a wall-clock deadline, not a duration, so a caller can re-render
+  // this same step every second and get a live countdown for free.
+  | { phase: 'waiting'; attempt: number; attempts: number; until: number }
+  | { phase: 'checking'; attempt: number; attempts: number }
+  | { phase: 'sync'; attempt: number; attempts: number; step: SyncProgress };
+
+/** Human-readable form of a progress step, shared by every caller that renders it. */
+export function describeRefreshProgress(p: RefreshProgress): string {
+  switch (p.phase) {
+    case 'requesting':
+      return 'Asking your bank for new transactions…';
+    case 'waiting': {
+      const secs = Math.max(0, Math.round((p.until - Date.now()) / 1000));
+      // Deliberately "requested", not "complete" — see core/transactions-refresh.ts.
+      return `Refresh requested — next check in ${secs}s (check ${p.attempt} of ${p.attempts})…`;
+    }
+    case 'checking':
+      return `Checking for new transactions (check ${p.attempt} of ${p.attempts})…`;
+    case 'sync':
+      return describeSyncProgress(p.step);
+  }
+}
+
+export type RefreshResult = {
+  itemId: string;
+  /** Totals across every check that ran, not just the last one. */
+  added: number;
+  modified: number;
+  removed: number;
+  /** How many sync checks actually ran. 0 means the refresh request itself failed. */
+  checks: number;
+  /** The caller aborted mid-poll. Counts still reflect the checks that did run. */
+  cancelled: boolean;
+  /** Set when the refresh request or a sync check failed. */
+  error?: string;
+  /**
+   * The last check's outcome in syncAll's shape, for feeding core/sync-status so
+   * a refresh maintains the ⚠ badge like any other sync: a failed check raises
+   * it, a clean one clears a stale one. Empty when no check ran — passing an
+   * empty list to mergeSyncResult would clear the badge without having earned it.
+   */
+  syncResults: SyncItemResult[];
+};
+
+/** One-line summary of a finished refresh, for the caller's status line. */
+export function describeRefreshResult(r: RefreshResult): string {
+  const found = [
+    r.added > 0 ? `${r.added} new transaction${r.added === 1 ? '' : 's'}` : null,
+    r.modified > 0 ? `${r.modified} updated` : null,
+  ].filter(Boolean).join(', ');
+
+  if (r.cancelled) {
+    return found
+      ? `Stopped checking — found ${found}`
+      : 'Stopped checking. The refresh may still be running at your bank — press [s] to sync later.';
+  }
+  if (found) return `Done — ${found}`;
+  return 'No new transactions yet — the refresh may still be running at your bank. Try [s] sync again in a few minutes.';
+}

--- a/core/transactions-refresh.ts
+++ b/core/transactions-refresh.ts
@@ -1,7 +1,18 @@
 import { getPlaidClient, plaidErrorMessage } from './plaid.js';
 import { db } from './db.js';
 import { decryptToken } from './crypto.js';
-import { syncTransactions, describeSyncProgress, type SyncItemResult, type SyncProgress } from './sync.js';
+import { syncTransactions } from './sync.js';
+import {
+  POLL_DELAYS_MS, type RefreshProgress, type RefreshResult,
+} from './transactions-refresh-format.js';
+
+// Pure progress types, POLL_DELAYS_MS, and the describe* formatters live in the
+// node-free core/transactions-refresh-format.ts so the GUI renderer can import
+// them; re-exported here for existing callers.
+export {
+  POLL_DELAYS_MS, describeRefreshProgress, describeRefreshResult,
+} from './transactions-refresh-format.js';
+export type { RefreshProgress, RefreshResult } from './transactions-refresh-format.js';
 
 /**
  * On-demand transaction refresh for one Plaid item.
@@ -27,73 +38,6 @@ import { syncTransactions, describeSyncProgress, type SyncItemResult, type SyncP
  * inherently one-item work, and syncAll's 15-minute debounce would skip every
  * check after the first.
  */
-
-/** Waits before each post-refresh sync check. Banks routinely take a minute or
- *  more to answer an on-demand extraction, so the tail is long and the total
- *  budget is a little under four minutes. */
-export const POLL_DELAYS_MS = [15_000, 30_000, 60_000, 120_000];
-
-export type RefreshProgress =
-  | { phase: 'requesting' }
-  // `until` is a wall-clock deadline, not a duration, so a caller can re-render
-  // this same step every second and get a live countdown for free.
-  | { phase: 'waiting'; attempt: number; attempts: number; until: number }
-  | { phase: 'checking'; attempt: number; attempts: number }
-  | { phase: 'sync'; attempt: number; attempts: number; step: SyncProgress };
-
-/** Human-readable form of a progress step, shared by every caller that renders it. */
-export function describeRefreshProgress(p: RefreshProgress): string {
-  switch (p.phase) {
-    case 'requesting':
-      return 'Asking your bank for new transactions…';
-    case 'waiting': {
-      const secs = Math.max(0, Math.round((p.until - Date.now()) / 1000));
-      // Deliberately "requested", not "complete" — see the module comment.
-      return `Refresh requested — next check in ${secs}s (check ${p.attempt} of ${p.attempts})…`;
-    }
-    case 'checking':
-      return `Checking for new transactions (check ${p.attempt} of ${p.attempts})…`;
-    case 'sync':
-      return describeSyncProgress(p.step);
-  }
-}
-
-export type RefreshResult = {
-  itemId: string;
-  /** Totals across every check that ran, not just the last one. */
-  added: number;
-  modified: number;
-  removed: number;
-  /** How many sync checks actually ran. 0 means the refresh request itself failed. */
-  checks: number;
-  /** The caller aborted mid-poll. Counts still reflect the checks that did run. */
-  cancelled: boolean;
-  /** Set when the refresh request or a sync check failed. */
-  error?: string;
-  /**
-   * The last check's outcome in syncAll's shape, for feeding core/sync-status so
-   * a refresh maintains the ⚠ badge like any other sync: a failed check raises
-   * it, a clean one clears a stale one. Empty when no check ran — passing an
-   * empty list to mergeSyncResult would clear the badge without having earned it.
-   */
-  syncResults: SyncItemResult[];
-};
-
-/** One-line summary of a finished refresh, for the caller's status line. */
-export function describeRefreshResult(r: RefreshResult): string {
-  const found = [
-    r.added > 0 ? `${r.added} new transaction${r.added === 1 ? '' : 's'}` : null,
-    r.modified > 0 ? `${r.modified} updated` : null,
-  ].filter(Boolean).join(', ');
-
-  if (r.cancelled) {
-    return found
-      ? `Stopped checking — found ${found}`
-      : 'Stopped checking. The refresh may still be running at your bank — press [s] to sync later.';
-  }
-  if (found) return `Done — ${found}`;
-  return 'No new transactions yet — the refresh may still be running at your bank. Try [s] sync again in a few minutes.';
-}
 
 /** Resolves true when the full delay elapsed, false when `signal` aborted first. */
 function sleep(ms: number, signal?: AbortSignal): Promise<boolean> {

--- a/gui/main/app.ts
+++ b/gui/main/app.ts
@@ -12,6 +12,7 @@ import { registerBridge } from './bridge.js';
 import { registerRefreshPush } from './refresh-ipc.js';
 import { registerSyncStatusPush } from './sync-status-ipc.js';
 import { registerAgentIpc, rejectPendingConfirms } from './agent-ipc.js';
+import { registerSyncIpc } from './sync-ipc.js';
 import { cancelActivePlaidLink } from './plaid-link.js';
 import { buildMenu } from './menu.js';
 
@@ -51,6 +52,7 @@ if (!app.requestSingleInstanceLock()) {
     registerRefreshPush();
     registerSyncStatusPush();
     registerAgentIpc();
+    registerSyncIpc();
     buildMenu();
     createWindow();
 

--- a/gui/main/sync-ipc.ts
+++ b/gui/main/sync-ipc.ts
@@ -1,0 +1,38 @@
+import { ipcMain } from 'electron';
+import { refreshTransactions } from '../../core/transactions-refresh.js';
+import { mergeSyncResult } from '../../core/sync-status.js';
+
+// On-demand /transactions/refresh gets its own channel rather than a registry
+// entry: the poll runs for minutes and streams progress, so the renderer needs
+// a progress push and a cancel path, not a single request/response call.
+export function registerSyncIpc() {
+  // itemId → the controller aborting its in-flight poll, so a later cancel or a
+  // window close can stop the timers and the sync it left running.
+  const inflight = new Map<string, AbortController>();
+
+  ipcMain.handle('sync:refresh', async (e, itemId: string) => {
+    inflight.get(itemId)?.abort(); // never run two polls for one item at once
+    const controller = new AbortController();
+    inflight.set(itemId, controller);
+    const send = (...args: unknown[]) => {
+      if (!e.sender.isDestroyed()) e.sender.send('sync:refresh-progress', ...args);
+    };
+    try {
+      const result = await refreshTransactions(itemId, {
+        signal: controller.signal,
+        onProgress: (progress) => send(progress),
+      });
+      // A check that ran is a real sync outcome: scoped to this item so it badges
+      // its ⚠ (or clears a stale one) without touching other connections.
+      if (result.syncResults.length > 0) mergeSyncResult(result.syncResults, [itemId]);
+      return result;
+    } finally {
+      inflight.delete(itemId);
+    }
+  });
+
+  // Esc / navigating away aborts the poll instead of leaving it running.
+  ipcMain.handle('sync:refresh-cancel', (_e, itemId: string) => {
+    inflight.get(itemId)?.abort();
+  });
+}

--- a/gui/renderer/src/screens/Accounts.tsx
+++ b/gui/renderer/src/screens/Accounts.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { api } from '../api.js';
 import { useQuery } from '../hooks/useQuery.js';
 import { useStatus } from '../hooks/useStatus.js';
@@ -9,6 +9,10 @@ import { SUBTYPE_DISPLAY, ACCOUNT_TYPES, SUBTYPES, MONTHS } from '../constants.j
 import { useScreenKeys } from '../hooks/useScreenKeys.js';
 import { KeyHints } from '../components/KeyHints.js';
 import { fmtTimeAgo, fmtSyncedAt } from '../../../../core/fmt.js';
+import {
+  describeRefreshProgress, describeRefreshResult, POLL_DELAYS_MS,
+  type RefreshProgress, type RefreshResult,
+} from '../../../../core/transactions-refresh-format.js';
 import styles from './Accounts.module.css';
 
 type Tab = 'accounts' | 'links' | 'add-data' | 'dupes';
@@ -47,6 +51,16 @@ export function Accounts() {
   const [updateItem, setUpdateItem] = useState<LinkedItem | null>(null);
   // The connection whose sync cursor is about to be deleted, if any.
   const [cursorItem, setCursorItem] = useState<LinkedItem | null>(null);
+  // The connection whose refresh modal is open. Stays set through the poll so its
+  // live progress and Stop button remain on screen — mirroring the TUI, where
+  // refresh reports through the status line and Esc aborts it.
+  const [refreshItem, setRefreshItem] = useState<LinkedItem | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+  const [refreshProgress, setRefreshProgress] = useState<RefreshProgress | null>(null);
+  // A 'waiting' step carries a deadline; a 1s tick re-renders it into a live
+  // countdown, the same trick the TUI uses.
+  const [, setRefreshTick] = useState(0);
+  const refreshTickRef = useRef<ReturnType<typeof setInterval> | undefined>(undefined);
   const [syncing, setSyncing] = useState(false);
   const plaidConfigured = useQuery(() => api.plaid.isConfigured(), []) ?? false;
   // Item ids that failed the most recent sync (from either the startup or the
@@ -104,6 +118,41 @@ export function Accounts() {
       setSyncing(false);
     }
   }
+
+  async function startRefresh(item: LinkedItem) {
+    setRefreshing(true);
+    setRefreshProgress({ phase: 'requesting' });
+    try {
+      const result = await window.__bridge.invoke('sync:refresh', item.item_id) as RefreshResult;
+      reload();
+      if (result.error) showStatus(`Refresh failed: ${result.error}`, 8000);
+      else showStatus(describeRefreshResult(result), 10000);
+    } catch (err) {
+      showStatus(`Refresh failed: ${err instanceof Error ? err.message : String(err)}`, 3000);
+    } finally {
+      setRefreshing(false);
+      setRefreshProgress(null);
+      setRefreshItem(null);
+    }
+  }
+
+  // Abort the poll main-side; the awaited call above then resolves with whatever
+  // the checks that ran turned up (describeRefreshResult names the cancel case).
+  function stopRefresh(item: LinkedItem) {
+    void window.__bridge.invoke('sync:refresh-cancel', item.item_id);
+  }
+
+  // Main pushes a progress step for every phase of the poll.
+  useEffect(() =>
+    window.__bridge.on('sync:refresh-progress', (...args: unknown[]) =>
+      setRefreshProgress(args[0] as RefreshProgress),
+    ), []);
+
+  useEffect(() => {
+    if (refreshProgress?.phase !== 'waiting') return;
+    refreshTickRef.current = setInterval(() => setRefreshTick((n) => n + 1), 1000);
+    return () => clearInterval(refreshTickRef.current);
+  }, [refreshProgress?.phase]);
 
   const TABS: Tab[] = ['accounts', 'links', 'add-data', 'dupes'];
   useScreenKeys({
@@ -268,6 +317,14 @@ export function Accounts() {
                       )}
                     </td>
                     <td className={styles.tdActions}>
+                      <button
+                        className={styles.rowBtn}
+                        title="Ask this bank for new transactions now (Plaid charges per refresh)"
+                        onClick={() => setRefreshItem(item)}
+                        disabled={refreshing || item.awaitingFirstSync}
+                      >
+                        refresh
+                      </button>
                       <button
                         className={styles.rowBtn}
                         title="Update creds for link, keeping its accounts and transactions"
@@ -541,6 +598,48 @@ export function Accounts() {
             void forceSync();
           }}
         />
+      )}
+
+      {refreshItem && (
+        // While refreshing, onClose is a no-op so the poll's progress stays on
+        // screen — Stop is the only way out mid-run, mirroring the TUI's Esc.
+        <Modal
+          title="Refresh transactions — Plaid charges for each refresh"
+          onClose={() => { if (!refreshing) setRefreshItem(null); }}
+          accent="var(--warning)"
+        >
+          <p>
+            <span className="accent">{refreshItem.institution_name ?? '(unknown institution)'}</span>{' '}
+            <span className="dim">— all {refreshItem.account_count} account{refreshItem.account_count !== 1 ? 's' : ''} on this connection</span>
+          </p>
+          <p className="dim">Asks your bank to go look for new transactions right now.</p>
+          <div className="dim">
+            <p>Only worth it if you're missing <strong>recent</strong> transactions and want the bank re-checked.</p>
+            {/* Fixed at item creation; update mode can't widen it — name it so the
+                limit isn't left abstract. */}
+            <p>It can't reach past this connection's {refreshItem.days_requested ? `${refreshItem.days_requested}-day` : '90-day'} history window.</p>
+            <p>Then checks for new transactions {POLL_DELAYS_MS.length} times over about {Math.round(POLL_DELAYS_MS.reduce((a, b) => a + b, 0) / 60000)} minutes.</p>
+          </div>
+          {refreshProgress && (
+            <p className="warn" style={{ marginTop: '1em' }}>{describeRefreshProgress(refreshProgress)}</p>
+          )}
+          <div className={styles.modalActions}>
+            {refreshing ? (
+              <button className={styles.btnSecondary} onClick={() => stopRefresh(refreshItem)}>
+                Stop checking
+              </button>
+            ) : (
+              <>
+                <button className={styles.btnSecondary} onClick={() => setRefreshItem(null)}>
+                  Cancel
+                </button>
+                <button className={styles.btnPrimary} onClick={() => void startRefresh(refreshItem)}>
+                  Yes, refresh
+                </button>
+              </>
+            )}
+          </div>
+        </Modal>
       )}
 
       {statusEl}

--- a/tests/gui-bridge-parity.test.ts
+++ b/tests/gui-bridge-parity.test.ts
@@ -65,13 +65,13 @@ const EXPECTED_UNBRIDGED: Record<string, string> = {
   // interleaved with another sync.
   deleteSyncCursor: 'GUI bridges the composed sync.deleteCursorAndResync instead',
 
-  // On-demand /transactions/refresh (core/transactions-refresh.ts) — TUI-only for
-  // now. Bridging it needs more than a registry entry: the poll runs for minutes
-  // and streams progress, so the GUI needs a progress channel and a cancel path
-  // rather than a single request/response call. Remove these when that lands.
-  refreshTransactions: 'TUI-only; GUI needs a streaming progress + cancel channel, not a plain bridge call',
-  describeRefreshProgress: 'TUI-only; renderer will format its own progress once refresh is bridged',
-  describeRefreshResult: 'TUI-only; renderer will format its own result once refresh is bridged',
+  // On-demand /transactions/refresh (core/transactions-refresh.ts) — bridged, but
+  // not through the registry: the poll runs for minutes and streams progress, so
+  // it has a dedicated channel (gui/main/sync-ipc.ts, 'sync:refresh') with a
+  // progress push and a cancel path rather than a single request/response call.
+  refreshTransactions: 'bridged via sync-ipc streaming channel, not the registry',
+  describeRefreshProgress: 'renderer imports it directly to format pushed progress steps',
+  describeRefreshResult: 'renderer imports it directly to format the final result',
 
   // Generic settings access — GUI uses typed wrappers (settings.getPretaxMonthly /
   // settings.setPretaxMonthly) rather than the raw getSetting/setSetting functions.

--- a/tests/gui/accounts.test.tsx
+++ b/tests/gui/accounts.test.tsx
@@ -330,4 +330,89 @@ describe('GUI Accounts — Links tab', () => {
     await waitFor(() => expect(screen.getByText('Test Checking')).toBeTruthy());
     expect(screen.queryByRole('button', { name: 'repair' })).toBeNull();
   });
+
+  // Refresh drives core/transactions-refresh.ts over the dedicated 'sync:refresh'
+  // IPC channel (not the registry), so these register a handler on the harness's
+  // invoke and assert the confirm gate + reporting, mirroring the TUI's [r] tests.
+  describe('refresh', () => {
+    it('confirms and names the Plaid charge before calling refresh', async () => {
+      const spy = vi.fn();
+      bridge.onInvoke('sync:refresh', spy);
+      await addItem('item-a', 'Chase', Date.now(), 730);
+      await addAccount('acct-1', 'item-a');
+      await links();
+
+      await userEvent.click(await screen.findByRole('button', { name: 'refresh' }));
+
+      await waitFor(() => expect(screen.getByText(/Plaid charges for each refresh/)).toBeTruthy());
+      // The window is named from days_requested so the limit isn't left abstract.
+      expect(screen.getByText(/730-day history window/)).toBeTruthy();
+      // Nothing billed until the user confirms.
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('Cancel backs out without spending a refresh', async () => {
+      const spy = vi.fn();
+      bridge.onInvoke('sync:refresh', spy);
+      await addItem('item-a', 'Chase', Date.now());
+      await addAccount('acct-1', 'item-a');
+      await links();
+
+      await userEvent.click(await screen.findByRole('button', { name: 'refresh' }));
+      await waitFor(() => expect(screen.getByText(/Plaid charges for each refresh/)).toBeTruthy());
+      await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+      await waitFor(() => expect(screen.queryByText(/Plaid charges for each refresh/)).toBeNull());
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('Yes refreshes the selected item and reports the outcome', async () => {
+      bridge.onInvoke('sync:refresh', async (itemId) => ({
+        itemId, added: 0, modified: 0, removed: 0, checks: 4, cancelled: false, syncResults: [],
+      }));
+      await addItem('item-a', 'Chase', Date.now());
+      await addAccount('acct-1', 'item-a');
+      await links();
+
+      await userEvent.click(await screen.findByRole('button', { name: 'refresh' }));
+      await waitFor(() => expect(screen.getByText(/Plaid charges for each refresh/)).toBeTruthy());
+      await userEvent.click(screen.getByRole('button', { name: 'Yes, refresh' }));
+
+      // The no-luck copy never claims completion — the refresh may still be
+      // running at the bank, and this view can't tell.
+      await waitFor(() => expect(screen.getByText(/No new transactions yet/)).toBeTruthy());
+    });
+
+    it('keeps the modal open with a Stop button while the poll runs', async () => {
+      // Never resolves: the poll is still in flight, so the modal must stay up.
+      bridge.onInvoke('sync:refresh', () => new Promise(() => {}));
+      await addItem('item-a', 'Chase', Date.now());
+      await addAccount('acct-1', 'item-a');
+      await links();
+
+      await userEvent.click(await screen.findByRole('button', { name: 'refresh' }));
+      await waitFor(() => expect(screen.getByText(/Plaid charges for each refresh/)).toBeTruthy());
+      await userEvent.click(screen.getByRole('button', { name: 'Yes, refresh' }));
+
+      await waitFor(() => expect(screen.getByRole('button', { name: 'Stop checking' })).toBeTruthy());
+      // The gate's confirm button is gone once the poll owns the modal.
+      expect(screen.queryByRole('button', { name: 'Yes, refresh' })).toBeNull();
+    });
+
+    it('Stop cancels the in-flight poll', async () => {
+      const cancel = vi.fn();
+      bridge.onInvoke('sync:refresh', () => new Promise(() => {}));
+      bridge.onInvoke('sync:refresh-cancel', cancel);
+      await addItem('item-a', 'Chase', Date.now());
+      await addAccount('acct-1', 'item-a');
+      await links();
+
+      await userEvent.click(await screen.findByRole('button', { name: 'refresh' }));
+      await waitFor(() => expect(screen.getByText(/Plaid charges for each refresh/)).toBeTruthy());
+      await userEvent.click(screen.getByRole('button', { name: 'Yes, refresh' }));
+      await userEvent.click(await screen.findByRole('button', { name: 'Stop checking' }));
+
+      expect(cancel).toHaveBeenCalledWith('item-a');
+    });
+  });
 });

--- a/tests/gui/helpers/renderGui.tsx
+++ b/tests/gui/helpers/renderGui.tsx
@@ -21,12 +21,19 @@ const STUBS: Record<string, Record<string, (...args: unknown[]) => unknown>> = {
   files: { pickCsv: async () => null },
 };
 
-export type BridgeHarness = { emit: (channel: string, ...args: unknown[]) => void };
+export type BridgeHarness = {
+  /** Push an event to subscribers of an `on` channel (e.g. a sync-status update). */
+  emit: (channel: string, ...args: unknown[]) => void;
+  /** Register a handler for an `invoke` channel (the dedicated IPC channels that
+   *  bypass the registry, e.g. 'sync:refresh'). */
+  onInvoke: (channel: string, handler: (...args: unknown[]) => unknown) => void;
+};
 
 /** Installs a fake window.__bridge that routes calls into the real registry
  *  (backed by the mocked in-memory DB). Call in beforeEach, before rendering. */
 export function installBridge(): BridgeHarness {
   const listeners = new Map<string, Set<(...args: unknown[]) => void>>();
+  const invokeHandlers = new Map<string, (...args: unknown[]) => unknown>();
   (window as unknown as { __bridge: unknown }).__bridge = {
     call: async (ns: string, fn: string, args: unknown[]) => {
       const f =
@@ -34,7 +41,10 @@ export function installBridge(): BridgeHarness {
       if (typeof f !== 'function') throw new Error(`Unknown bridge call: ${ns}.${fn}`);
       return f(...args);
     },
-    invoke: async (channel: string) => (channel === 'agent:provider' ? null : undefined),
+    invoke: async (channel: string, ...args: unknown[]) => {
+      if (invokeHandlers.has(channel)) return invokeHandlers.get(channel)!(...args);
+      return channel === 'agent:provider' ? null : undefined;
+    },
     on: (channel: string, cb: (...args: unknown[]) => void) => {
       if (!listeners.has(channel)) listeners.set(channel, new Set());
       listeners.get(channel)!.add(cb);
@@ -45,6 +55,7 @@ export function installBridge(): BridgeHarness {
   };
   return {
     emit: (channel, ...args) => listeners.get(channel)?.forEach((cb) => cb(...args)),
+    onInvoke: (channel, handler) => invokeHandlers.set(channel, handler),
   };
 }
 


### PR DESCRIPTION
## What this adds

The GUI counterpart to #150's `[r] refresh`. Refresh acts on a Plaid **item** and polls `/transactions/sync` for close to four minutes, so — exactly as #150's `EXPECTED_UNBRIDGED` note predicted — it can't be a plain registry bridge call. It needs streaming progress and a cancel path.

## How

- **`gui/main/sync-ipc.ts`** — a dedicated `sync:refresh` channel that runs core's `refreshTransactions`, pushes each step over `sync:refresh-progress`, and takes `sync:refresh-cancel` to abort the poll. `mergeSyncResult` is applied main-side, scoped to the one item, so a check badges (or clears) that connection without touching others — same semantics as the TUI.
- **`gui/renderer/src/screens/Accounts.tsx`** — a `refresh` button on each Links row opens a confirm modal that names the Plaid charge and the item's history window (from `days_requested`). The modal stays open through the poll with a live 1s-tick countdown and a **Stop** button — the GUI analogue of the TUI's Esc-aborts.

Reuses core's `describeRefreshProgress` / `describeRefreshResult` rather than restating any copy — no logic duplicated between TUI and GUI.

## Parity bookkeeping

Updates `gui-bridge-parity`'s `EXPECTED_UNBRIDGED` for the three refresh functions from *TUI-only* to *bridged via dedicated channel* (they're intentionally not in the registry).

## Tests

Extends the GUI test harness with `onInvoke` so tests can drive the channel. 5 new Links-tab tests mirror the TUI's `[r]` coverage: the confirm gate, cancel spends nothing, the refresh runs and reports without ever claiming completion, the modal stays open with a Stop button during the poll, and Stop cancels.

All 29 GUI Accounts tests pass; `gui-bridge-parity` + `transactions-refresh` core tests pass; `npm run typecheck` clean (both configs) — on **Node 22** (the project's required version).

🤖 Generated with [Claude Code](https://claude.com/claude-code)