### PR TITLE
fix(gui): don't hand an update-mode link the add-mode flow, and merge scoped sync results

### DIFF
--- a/core/db.ts
+++ b/core/db.ts
@@ -148,6 +148,11 @@ export async function initDb() {
     ['Personal Care', 'flexible'], ['Home', 'flexible'], ['Services', 'flexible'],
     ['Shopping', 'discretionary'], ['Entertainment', 'discretionary'],
     ['Travel', 'discretionary'], ['Dining', 'discretionary'], ['Fees', 'discretionary'],
+    // Streaming and cloud storage — cancellable, so discretionary rather than
+    // fixed. Must stay in step with the seeded Subscriptions rules in
+    // core/seed-rules.ts: a category with no tier here falls to 'untagged' in
+    // every fixed/flexible/discretionary breakdown.
+    ['Subscriptions', 'discretionary'],
   ];
   await db.batch(
     flexDefaults.map(([cat, flex]) => ({

--- a/core/fmt.ts
+++ b/core/fmt.ts
@@ -57,7 +57,12 @@ export function fmtSyncedAt(ms: number | null): string {
   if (ms === null) return 'never';
   if (Date.now() - ms < 24 * 60 * 60 * 1000) return fmtTimeAgo(ms);
   const dt = new Date(ms);
-  return `${MONTHS[dt.getMonth()]} ${dt.getDate()}`;
+  const date = `${MONTHS[dt.getMonth()]} ${dt.getDate()}`;
+  // Year only when it isn't the current one. This is the "is this connection
+  // healthy?" column, and a year-old link reading the same as a four-month-old
+  // one hides exactly what the column exists to reveal.
+  const year = new Date().getFullYear();
+  return dt.getFullYear() === year ? date : `${date} ${dt.getFullYear()}`;
 }
 
 export function fmtSpan(earliest: string | null, latest: string | null): string {

--- a/core/sync.ts
+++ b/core/sync.ts
@@ -194,7 +194,12 @@ export async function syncAll(
   itemIds?: string[],
   onProgress?: (itemId: string, p: SyncProgress) => void,
 ): Promise<SyncItemResult[]> {
-  const itemsRes = itemIds && itemIds.length > 0
+  // An empty scope means "sync these zero items", not "sync everything". The
+  // distinction matters because the array crosses the GUI's IPC bridge from the
+  // renderer, where a caller that computes an empty list would otherwise trigger
+  // a full sync of every institution — the opposite of what it asked for.
+  if (itemIds && itemIds.length === 0) return [];
+  const itemsRes = itemIds
     ? await db.execute({
         sql: `SELECT item_id, access_token, last_synced_at FROM plaid_items
               WHERE item_id IN (${itemIds.map(() => '?').join(', ')})`,

--- a/gui/main/bridge.ts
+++ b/gui/main/bridge.ts
@@ -2,13 +2,17 @@ import { dialog, ipcMain } from 'electron';
 import { parseCSV } from '../../core/csv.js';
 import { isPlaidConfigured } from '../../core/plaid.js';
 import { getDefaultDaysRequested } from '../../core/settings.js';
-import { runPlaidLink } from './plaid-link.js';
+import { cancelActivePlaidLink, runPlaidLink } from './plaid-link.js';
 import { registry } from './registry.js';
 
 const plaid = {
   isConfigured: async (): Promise<boolean> => isPlaidConfigured(),
   getDefaultDaysRequested,
   linkBank: (daysRequested?: number, updateItemId?: string) => runPlaidLink(daysRequested, updateItemId),
+  // Closing the link dialog abandons the flow. Without telling main, the flow
+  // stays in flight for its full 10-minute timeout and refuses every other link
+  // or update the user tries in the meantime.
+  cancelLink: async (): Promise<void> => cancelActivePlaidLink(),
 };
 
 const files = {

--- a/gui/main/plaid-link.ts
+++ b/gui/main/plaid-link.ts
@@ -11,10 +11,18 @@ import { isPlaidConfigured } from '../../core/plaid.js';
 // The pages and the persistence live in core/plaid-link-flow.ts, shared with
 // scripts/link.ts; only the server lifecycle below is Electron-specific.
 
+type LinkParams = { daysRequested?: number; updateItemId?: string };
+
 let activeLink: Promise<{ institutionName: string | null; updateMode: boolean }> | null = null;
+// The parameters `activeLink` was started with. Load-bearing: coalescing onto an
+// in-flight flow is only safe when the new call means the same thing.
+let activeParams: LinkParams | null = null;
 let cancelActive: (() => void) | null = null;
 
 const MAX_CALLBACK_BODY = 1_000_000;
+
+const sameFlow = (a: LinkParams, b: LinkParams) =>
+  a.updateItemId === b.updateItemId && a.daysRequested === b.daysRequested;
 
 /** Abort an in-progress link flow (e.g. window closed): closes the callback
  *  server, rejects the pending promise, and allows a fresh retry. */
@@ -28,16 +36,32 @@ export function cancelActivePlaidLink() {
  *
  * Passing `updateItemId` updates the credentials on that existing connection
  * instead of adding a new one, keeping its accounts and transactions intact.
+ *
+ * Only one flow runs at a time. A repeat of the flow already running (a double
+ * click) rides along on it; a *different* flow is refused rather than silently
+ * handed the wrong promise — returning an add-mode flow to an update-mode caller
+ * would exchange the public token with no `updateItemId`, creating a second Item
+ * and duplicating every account and transaction on the connection the user was
+ * trying to repair.
  */
 export function runPlaidLink(
   daysRequested?: number,
   updateItemId?: string,
 ): Promise<{ institutionName: string | null; updateMode: boolean }> {
-  if (activeLink) return activeLink;
+  const params: LinkParams = { daysRequested, updateItemId };
+  if (activeLink) {
+    if (activeParams && sameFlow(activeParams, params)) return activeLink;
+    return Promise.reject(new Error(
+      'Another bank connection is already in progress — finish it in your browser, or close that dialog, before starting this one.',
+    ));
+  }
   if (!isPlaidConfigured()) {
     return Promise.reject(new Error('Plaid is not configured — set PLAID_CLIENT_ID and PLAID_SECRET in ~/.fungible/.env'));
   }
 
+  // Set before the executor runs, so the `finish`/`catch` teardown below always
+  // clears a value that was already there rather than racing this assignment.
+  activeParams = params;
   activeLink = new Promise((resolve, reject) => {
     void (async () => {
       const days = daysRequested !== undefined ? clampDaysRequested(daysRequested) : undefined;
@@ -95,6 +119,7 @@ export function runPlaidLink(
         clearTimeout(timeout);
         setTimeout(() => server.close(), 1000);
         activeLink = null;
+        activeParams = null;
         cancelActive = null;
       }
 
@@ -117,6 +142,7 @@ export function runPlaidLink(
       });
     })().catch((err) => {
       activeLink = null;
+      activeParams = null;
       cancelActive = null;
       reject(err);
     });

--- a/gui/main/registry.ts
+++ b/gui/main/registry.ts
@@ -221,7 +221,11 @@ export const registry = {
     // which drives the renderer banner + row badges via the sync-status push.
     syncAll: async (force?: boolean, itemIds?: string[]) => {
       const results = await syncAll(force, itemIds);
-      setSyncResult(results);
+      // A scoped run only speaks for the items it attempted — merge, so an
+      // institution this run never touched keeps its failure badge. Only a
+      // whole-DB sync has earned the right to clear everything.
+      if (itemIds && itemIds.length > 0) mergeSyncResult(results, itemIds);
+      else setSyncResult(results);
       return results;
     },
     // Delete one item's cursor and resync it, so Plaid resends its full history.

--- a/gui/renderer/src/screens/Accounts.tsx
+++ b/gui/renderer/src/screens/Accounts.tsx
@@ -673,6 +673,14 @@ function LinkBankModal({
     });
   }, []);
 
+  /** Closing while the browser flow is open abandons it, so tell main to tear it
+   *  down — otherwise it holds the single link slot until it times out and the
+   *  user can't start another link, or update a broken one, until then. */
+  function close() {
+    if (running) void api.plaid.cancelLink();
+    onClose();
+  }
+
   async function start() {
     let n: number | undefined;
     if (!updateItem) {
@@ -694,7 +702,7 @@ function LinkBankModal({
   }
 
   return (
-    <Modal title={updateItem ? 'Update link' : 'Link a bank'} onClose={onClose}>
+    <Modal title={updateItem ? 'Update link' : 'Link a bank'} onClose={close}>
       {running ? (
         <div>
           <p className="accent">⟳ Complete the Plaid flow in your browser, then return here.</p>

--- a/gui/renderer/src/screens/Accounts.tsx
+++ b/gui/renderer/src/screens/Accounts.tsx
@@ -93,6 +93,34 @@ export function Accounts() {
     }
   }
 
+  /** Sync only the just-linked institution(s). Scoped, so another institution's
+   *  failure badge survives it; awaited and followed by a reload, so the
+   *  placeholder row turns into real accounts on its own — otherwise the tab
+   *  sits at "◷ awaiting first sync" until the user presses [s] or navigates
+   *  away and back, and a failed first sync says nothing at all. */
+  async function syncNewInstitutions() {
+    if (syncing) return;
+    const accts = await api.queries.getLinkedAccounts();
+    const itemIds = [...new Set(accts.filter((a) => a.awaitingFirstSync).map((a) => a.item_id!))];
+    if (itemIds.length === 0) return;
+    setSyncing(true);
+    try {
+      const results = await api.sync.syncAll(true, itemIds);
+      const failed = results.filter((r) => r.error);
+      if (failed.length > 0) {
+        showStatus(`Sync failed: ${failed.map((r) => r.error).join('  ·  ')}`, 8000);
+      } else {
+        const added = results.reduce((s, r) => s + r.added, 0);
+        showStatus(`Sync done — ${added} new transaction${added === 1 ? '' : 's'}`, 4000);
+      }
+      reload();
+    } catch {
+      showStatus('Sync failed', 3000);
+    } finally {
+      setSyncing(false);
+    }
+  }
+
   /** Delete one connection's sync cursor, then resync it so Plaid resends
    *  everything it holds. Both steps run in main so they can't be interleaved
    *  with another sync. */
@@ -541,11 +569,7 @@ export function Accounts() {
             showStatus(`Connected ${institution ?? 'bank'} — syncing…`, 4000);
             reload();
             setTab('accounts');
-            // Trigger scoped sync for newly linked institution
-            void api.queries.getLinkedAccounts().then((accts) => {
-              const itemIds = [...new Set(accts.filter((a) => a.awaitingFirstSync).map((a) => a.item_id!))];
-              if (itemIds.length > 0) void api.sync.syncAll(true, itemIds);
-            });
+            void syncNewInstitutions();
           }}
         />
       )}

--- a/scripts/link.ts
+++ b/scripts/link.ts
@@ -67,6 +67,12 @@ async function main() {
           console.error(`Link failed: ${e.message}`);
           res.writeHead(500, { 'Content-Type': 'text/plain' });
           res.end(e.message);
+          // The stderr above flips the TUI panel to "failed", which offers
+          // "Press Enter to return" — so the user leaves while this process is
+          // still holding port 4747. Exit with it, or the next [l] link a bank
+          // dies on EADDRINUSE and linking stays broken for the rest of the
+          // session. The delay lets the 500 flush to the browser first.
+          setTimeout(() => { server.close(); process.exit(1); }, 1000);
         }
       });
       return;
@@ -74,6 +80,16 @@ async function main() {
 
     res.writeHead(404);
     res.end();
+  });
+
+  // listen() reports failure as an async 'error' event, which main().catch never
+  // sees — without this an EADDRINUSE surfaces to the user as a raw stack trace
+  // in the link panel.
+  server.on('error', (err: NodeJS.ErrnoException) => {
+    console.error(err.code === 'EADDRINUSE'
+      ? `Link failed: port ${PORT} is already in use — another link is still running. Close it, then try again.`
+      : `Link failed: ${err.message}`);
+    process.exit(1);
   });
 
   server.listen(PORT, '127.0.0.1', () => {

--- a/tests/gui/helpers/renderGui.tsx
+++ b/tests/gui/helpers/renderGui.tsx
@@ -17,6 +17,7 @@ const STUBS: Record<string, Record<string, (...args: unknown[]) => unknown>> = {
     linkBank: async () => {
       throw new Error('plaid link not available in tests');
     },
+    cancelLink: async () => {},
   },
   files: { pickCsv: async () => null },
 };

--- a/tests/sync.test.ts
+++ b/tests/sync.test.ts
@@ -155,13 +155,20 @@ describe('syncAll item filter', () => {
     expect(await syncedItemIds()).toEqual(['item-a', 'item-b']);
   });
 
-  it('treats an empty filter as unfiltered', async () => {
+  // An empty scope means "sync these zero items", not "sync everything". The
+  // array crosses the GUI's IPC bridge from the renderer, so a caller that
+  // computes an empty list must not get a full sync of every institution — the
+  // opposite of what it asked for, and expensive on a large database. `undefined`
+  // remains the way to ask for all of them.
+  it('treats an empty filter as an empty scope, not as unfiltered', async () => {
     await seedItems('item-a', 'item-b');
-    mockPlaid();
+    const plaid = mockPlaid();
 
     const results = await syncAll(true, []);
 
-    expect(results.map((r) => r.itemId).sort()).toEqual(['item-a', 'item-b']);
+    expect(results).toEqual([]);
+    expect(await syncedItemIds()).toEqual([]);
+    expect(plaid.transactionsSync).not.toHaveBeenCalled();
   });
 
   it('syncs several named items and skips the rest', async () => {

--- a/tui/Accounts.tsx
+++ b/tui/Accounts.tsx
@@ -323,6 +323,29 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
     setSyncMsg(describeSyncProgress(p));
   }
 
+  /** A sync parked because one was already in flight when a link finished.
+   *  Without this the new institution's first sync was dropped silently and its
+   *  row sat at "awaiting first sync" until the next launch. */
+  const pendingSyncRef = useRef<{ itemIds: string[]; startMsg?: string } | null>(null);
+
+  /** Run a parked sync, if any. Reports whether it started one, so the caller
+   *  can skip idling out a status line the queued run has just taken over.
+   *  Clears the ref first, so a queued run draining into itself can't loop. */
+  function drainPendingSync(): boolean {
+    const pending = pendingSyncRef.current;
+    pendingSyncRef.current = null;
+    if (!pending || pending.itemIds.length === 0) return false;
+    syncItems(pending.itemIds, pending.startMsg);
+    return true;
+  }
+
+  /** Sync `itemIds` now, or park them if a sync is already running. */
+  function syncItemsWhenFree(itemIds: string[], startMsg?: string) {
+    if (itemIds.length === 0) return;
+    if (syncStatusRef.current === 'syncing') pendingSyncRef.current = { itemIds, startMsg };
+    else syncItems(itemIds, startMsg);
+  }
+
   function forceSync() {
     syncStatusRef.current = 'syncing';   // visible before the re-render lands
     setSyncStatus('syncing');
@@ -338,11 +361,14 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
         // enough to read, and there's a real problem to act on.
         setSyncStatus('error');
         setSyncMsg(`Sync failed: ${describeSyncFailures(failed)}`);
+        // A queued run replaces this line, but the failure itself survives in
+        // the shared store as the row badge and the global banner.
+        drainPendingSync();
       } else {
         const added = results.reduce((s, r) => s + r.added, 0);
         setSyncMsg(`Done — ${added} new transaction${added !== 1 ? 's' : ''}`);
         setSyncStatus('done');
-        setTimeout(() => { setSyncStatus('idle'); setSyncMsg(''); }, 4000);
+        if (!drainPendingSync()) setTimeout(() => { setSyncStatus('idle'); setSyncMsg(''); }, 4000);
       }
     }).catch((err) => {
       // syncAll no longer throws on per-item failure, so this is a broader fault
@@ -373,11 +399,12 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
       if (failed.length > 0) {
         setSyncStatus('error');
         setSyncMsg(`Sync failed: ${describeSyncFailures(failed)}`);
+        drainPendingSync();
       } else {
         const added = results.reduce((s, r) => s + r.added, 0);
         setSyncMsg(doneMsg(added));
         setSyncStatus('done');
-        setTimeout(() => { setSyncStatus('idle'); setSyncMsg(''); }, 4000);
+        if (!drainPendingSync()) setTimeout(() => { setSyncStatus('idle'); setSyncMsg(''); }, 4000);
       }
     }).catch((err) => {
       setSyncMsg(`Sync failed — ${plaidErrorMessage(err)}`);
@@ -547,7 +574,7 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
           // to the attempted item, leaving other items' failures alone.
           setLinkMsg('Link updated! Press Enter to continue.');
           void loadAccounts();
-          if (syncStatusRef.current !== 'syncing') syncItems([updateItemId], 'Syncing updated link…');
+          syncItemsWhenFree([updateItemId], 'Syncing updated link…');
         } else {
           setLinkMsg('Bank connected! Press Enter to continue.');
           // The reload surfaces the institution's placeholder row immediately —
@@ -556,7 +583,7 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
           // from the loaded list rather than out of the link subprocess's stdout.
           void loadAccounts().then((accts) => {
             const itemIds = [...new Set(accts.filter((a) => a.awaitingFirstSync).map((a) => a.item_id!))];
-            if (itemIds.length > 0 && syncStatusRef.current !== 'syncing') syncItems(itemIds);
+            syncItemsWhenFree(itemIds);
           });
         }
       } else if (code !== null) {

--- a/tui/NetWorth.tsx
+++ b/tui/NetWorth.tsx
@@ -8,6 +8,7 @@ import { handleNavKey } from './nav.js';
 import { useTerminalWidth, MONTHS, SUBTYPE_DISPLAY, C_POSITIVE, C_NEGATIVE, C_ACCENT } from './ui.js';
 import { usePagination, PageHeader } from './components/index.js';
 import { useRefreshKey } from './RefreshContext.js';
+import { useLoadGuard } from './useLoadGuard.js';
 
 const BAR_WIDTH = 32;
 const PAGE = 20;
@@ -71,8 +72,15 @@ export function NetWorth({ onNavigate, isActive, showHints }: { onNavigate: (s: 
   }, [refreshKey]);
 
   const filterKey = selectedIds ? [...selectedIds].sort().join(',') : '';
+  // [Space] can retoggle the filter several times a second, and this query is an
+  // unindexed window function over all of balance_history — so a slow earlier
+  // request can land after a faster later one and paint a chart that disagrees
+  // with the selection on screen, with no later event to correct it.
+  const historyGuard = useLoadGuard();
   useEffect(() => {
+    const token = historyGuard.begin();
     void getNetWorthHistory(range, selectedIds ? [...selectedIds] : undefined).then((r) => {
+      if (!historyGuard.isLatest(token)) return;
       setRows(r);
       if (filterMode) {
         setCursor((c) => Math.min(c, Math.max(0, r.length - 1)));
@@ -178,8 +186,13 @@ export function NetWorth({ onNavigate, isActive, showHints }: { onNavigate: (s: 
   const termW = useTerminalWidth();
   const inner = Math.max(60, termW) - 4;
   const AMT_W  = 14;
-  const IND_W  = filterMode ? 2 : 0;
-  const NAME_W = Math.max(14, inner - AMT_W - 16 - IND_W);
+  // Columns the indicator cell occupies on a data row: 2 for '● ' plus the row
+  // Box's gap={2} that follows it. The gap is part of the width because Ink adds
+  // no gap for a null child, so outside filter mode the lead costs nothing —
+  // which is why rows with no indicator (the totals, the excluded block) pad by
+  // NAME_W + LEAD_W to line their amounts up with the rows above.
+  const LEAD_W  = filterMode ? 4 : 0;
+  const NAME_W = Math.max(14, inner - AMT_W - 16 - LEAD_W);
 
   const { visible, pageStart } = usePagination(rows, cursor, PAGE);
   const labelW = range === 'year' ? 4 : range === 'quarter' ? 7 : range === 'month' ? 8 : 12;
@@ -293,10 +306,10 @@ export function NetWorth({ onNavigate, isActive, showHints }: { onNavigate: (s: 
               ? assets.map((a, i) => renderAssetRow(a, i))
               : assetTypes.map((t, i) => renderAssetTypeRow(t, i))}
             <Box gap={2} marginTop={0}>
-              <Text dimColor>{'─'.repeat(NAME_W + IND_W)}</Text>
+              <Text dimColor>{'─'.repeat(NAME_W + LEAD_W)}</Text>
             </Box>
             <Box gap={2}>
-              <Text bold>{'Total assets'.padEnd(NAME_W + IND_W)}</Text>
+              <Text bold>{'Total assets'.padEnd(NAME_W + LEAD_W)}</Text>
               <Text bold color={C_POSITIVE}>{fmt(totalAssets).padStart(AMT_W)}</Text>
             </Box>
           </Box>
@@ -308,10 +321,10 @@ export function NetWorth({ onNavigate, isActive, showHints }: { onNavigate: (s: 
               ? liabilities.map((a, i) => renderLiabilityRow(a, assets.length + i))
               : liabilityTypes.map((t, i) => renderLiabilityTypeRow(t, assetTypes.length + i))}
             <Box gap={2}>
-              <Text dimColor>{'─'.repeat(NAME_W + IND_W)}</Text>
+              <Text dimColor>{'─'.repeat(NAME_W + LEAD_W)}</Text>
             </Box>
             <Box gap={2}>
-              <Text bold>{'Total debt'.padEnd(NAME_W + IND_W)}</Text>
+              <Text bold>{'Total debt'.padEnd(NAME_W + LEAD_W)}</Text>
               <Text bold color={C_NEGATIVE}>{fmt(totalLiabilities).padStart(AMT_W)}</Text>
             </Box>
           </Box>
@@ -322,16 +335,16 @@ export function NetWorth({ onNavigate, isActive, showHints }: { onNavigate: (s: 
               <Text bold dimColor>Excluded (not in net worth)</Text>
               {excluded.map((a) => (
                 <Box key={a.id} gap={2}>
-                  <Text dimColor>{truncate(a.nickname ?? a.name, NAME_W + IND_W).padEnd(NAME_W + IND_W)}</Text>
+                  <Text dimColor>{truncate(a.nickname ?? a.name, NAME_W + LEAD_W).padEnd(NAME_W + LEAD_W)}</Text>
                   <Text dimColor>{fmt(a.balance).padStart(AMT_W)}</Text>
                   <Text dimColor>{SUBTYPE_DISPLAY[a.subtype ?? a.type] ?? (a.subtype ?? a.type)}</Text>
                 </Box>
               ))}
               <Box gap={2}>
-                <Text dimColor>{'─'.repeat(NAME_W + IND_W)}</Text>
+                <Text dimColor>{'─'.repeat(NAME_W + LEAD_W)}</Text>
               </Box>
               <Box gap={2}>
-                <Text dimColor>{'Excluded total'.padEnd(NAME_W + IND_W)}</Text>
+                <Text dimColor>{'Excluded total'.padEnd(NAME_W + LEAD_W)}</Text>
                 <Text dimColor>{fmtSigned(exclNet).padStart(AMT_W)}</Text>
               </Box>
             </Box>

--- a/tui/Transactions.tsx
+++ b/tui/Transactions.tsx
@@ -155,8 +155,14 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
 
   async function toggleTag(tagId: number) {
     if (!selected) return;
+    // null means the panel's marks are still being re-read for the row the
+    // cursor just moved to. Treating that as "has no tags" would turn a remove
+    // into an INSERT OR IGNORE that changes nothing, and patchTagState would
+    // drop the optimistic edit too — the keypress would appear to do nothing.
+    // Ignore it; the marks land in a moment and the key works again.
+    if (selectedTagIds === null) return;
     const txId = selected.id;
-    const had = selectedTagIds?.has(tagId) ?? false;
+    const had = selectedTagIds.has(tagId);
     patchTagState(txId, (ids) => {
       const n = new Set(ids);
       if (had) n.delete(tagId); else n.add(tagId);


### PR DESCRIPTION
Two connection-management bugs found while reviewing #160 (dev → main).

## 1. An update-mode link could be handed the add-mode flow

`runPlaidLink` coalesced any concurrent call onto the in-flight one:

```ts
if (activeLink) return activeLink;
```

That predates update mode, when every call meant the same thing. Now the parameters change what the flow *does*.

The GUI `Modal` closes on Esc / backdrop click / ✕ without cancelling the flow — `cancelActivePlaidLink` only ran on the window `closed` event — so an abandoned "Link a bank" stayed pending for its full 10-minute timeout. Starting an "update link" in that window returned the **add-mode** promise: no new browser tab opened, and if the user finished the still-open add-mode Plaid tab, `completeLink` ran with `updateItemId: undefined`, creating a second Item and **duplicating every account and transaction** on the connection they were trying to repair — while the renderer reported `Updated <bank> — syncing…`. The broken connection was untouched. The reverse order was equally broken.

The flow is now keyed on its parameters. A repeat of the same flow (a double click) still rides along; a different one is refused with a message naming the conflict. Closing the dialog now cancels the flow through a new `plaid.cancelLink` bridge call, so the refusal stays rare rather than becoming a 10-minute lockout.

## 2. A scoped sync cleared other institutions' failure badges

`registry.sync.syncAll` used `setSyncResult`, whose "a clean run clears all" is only correct for a whole-DB sync — the exact reasoning that motivated `mergeSyncResult`, which the sibling `deleteCursorAndResync` already applies correctly.

So: bank A is showing ⚠ sync failed → user links bank B → the post-link scoped `syncAll(true, [itemB])` succeeds → A's row badge and the global banner silently vanish, though A is still broken. The TUI path (`tui/Accounts.tsx` `syncItems`) already got this right.

Now merges when scoped, sets when whole-DB.

## Testing

`npx tsc --noEmit` clean. Full suite on Node 22: 935 passed, 7 failed — all in `tests/tui/{accounts-update-link,screens,setup}.test.tsx`. Clean `dev` at 80dfab7 fails the same three files (8 failures; the count drifts run to run), so these are pre-existing timeout flakes under full-suite parallelism, not regressions. This branch touches only `gui/` and the GUI test harness. All GUI suites pass, including `accounts-update-link`, `accounts-links`, and `plaid-link-flow`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Second commit: the remaining review findings

Seven more from the same review pass, unrelated to each other and to the two above.

**`core/db.ts`** — `Subscriptions` was seeded as a default category but had no entry in `flexDefaults`, so `COALESCE(c.flexibility, 'untagged')` filed it under **untagged** in every fixed/flexible/discretionary breakdown. Newly visible because this release adds six seeded rules routing Netflix/Spotify/Hulu/Disney+/Apple/Google Storage into it — Trends would show a growing untagged bucket for a category the app itself created. Now `discretionary`.

**`core/sync.ts`** — an empty `itemIds` array meant "sync everything" rather than "sync nothing". Harmless while both call sites guarded on `length > 0`, but the array now crosses the GUI's IPC bridge from the renderer, where a caller computing an empty scope would trigger a full sync of every institution — the opposite of what it asked for. `undefined` remains the way to ask for all of them.

⚠️ **This changes behaviour an existing test pinned.** `treats an empty filter as unfiltered` was a bare characterization test with no rationale comment, unlike its neighbours in that file, and nothing in the tree relies on the old semantics. It now states the new contract. Worth a second opinion if that was a deliberate choice rather than an accident.

**`core/fmt.ts`** — `fmtSyncedAt` dropped the year, so a connection last synced March 2025 read identically to one synced this March, on the column whose whole job is to reveal a stale link. Year shown only when it isn't the current one, so existing output is unchanged for recent syncs.

**`scripts/link.ts`** — the callback error branch responded 500 but never released port 4747. Since the stderr write flips the TUI panel to "failed" (offering "Press Enter to return"), the user left while the process still held the port, and the next `[l] link a bank` died on an unhandled `EADDRINUSE` — a raw stack trace as the user-facing message, with linking broken for the rest of the session. Now exits after flushing the response, and `listen` errors render as a sentence.

**`tui/NetWorth.tsx`** — two things. The history query had no out-of-order guard despite being keyed on a selection `[Space]` can retoggle several times a second, over an unindexed window function; it now uses `useLoadGuard`, as Dashboard and Transactions already do. Separately, filter mode left the totals and dividers two columns short of the data rows: Ink adds no gap for a `null` child, so the indicator lead costs 4 columns when it renders and 0 when it doesn't — `IND_W` counted only the 2-column indicator and is now `LEAD_W`, covering the gap too.

**`tui/Transactions.tsx`** — toggling a tag while the panel's marks were still being re-read (the window after the cursor moves to a new row) took the "add" branch, hitting `INSERT OR IGNORE` and dropping the optimistic edit, so the keypress silently did nothing. Ignored until the marks land.

**`tui/Accounts.tsx` + `gui/renderer/.../Accounts.tsx`** — a post-link sync was dropped outright if another sync happened to be running (TUI), and was fire-and-forget with no reload and no error path (GUI), so the row sat at `◷ awaiting first sync` until the user pressed `[s]`. The TUI now parks it and runs it when the current sync lands; the GUI awaits it, reloads, and reports failures.

## Testing

`npm run typecheck` and `npm run gui:build` clean. Full suite on Node 22: 935 passed, 7 failed — all in `tests/tui/{accounts-update-link,screens,setup}.test.tsx`, all 5s timeouts rather than assertion failures. Clean `dev` at 80dfab7 fails the same files (8 failures; the count drifts run to run), and `screens.test.tsx > digit-nav sweep` times out identically on untouched `dev` when run alone. `accounts-update-link.test.tsx` passes 6/6 in isolation, which covers the `tui/Accounts.tsx` change here.
