### PR TITLE
fix: tighten the on-demand refresh guards on both surfaces

### DIFF
--- a/gui/main/sync-ipc.ts
+++ b/gui/main/sync-ipc.ts
@@ -27,7 +27,10 @@ export function registerSyncIpc() {
       if (result.syncResults.length > 0) mergeSyncResult(result.syncResults, [itemId]);
       return result;
     } finally {
-      inflight.delete(itemId);
+      // Only if it is still ours: an abort resolves this poll a tick after the
+      // replacing call has already stored its own controller, and deleting that
+      // one would leave the new poll with no cancel path.
+      if (inflight.get(itemId) === controller) inflight.delete(itemId);
     }
   });
 

--- a/gui/renderer/src/screens/Accounts.tsx
+++ b/gui/renderer/src/screens/Accounts.tsx
@@ -61,6 +61,9 @@ export function Accounts() {
   // countdown, the same trick the TUI uses.
   const [, setRefreshTick] = useState(0);
   const refreshTickRef = useRef<ReturnType<typeof setInterval> | undefined>(undefined);
+  // The item whose poll is in flight, held in a ref so the unmount cleanup can
+  // read it without re-subscribing on every refresh.
+  const refreshingItemIdRef = useRef<string | null>(null);
   const [syncing, setSyncing] = useState(false);
   const plaidConfigured = useQuery(() => api.plaid.isConfigured(), []) ?? false;
   // Item ids that failed the most recent sync (from either the startup or the
@@ -148,6 +151,7 @@ export function Accounts() {
   }
 
   async function startRefresh(item: LinkedItem) {
+    refreshingItemIdRef.current = item.item_id;
     setRefreshing(true);
     setRefreshProgress({ phase: 'requesting' });
     try {
@@ -158,6 +162,7 @@ export function Accounts() {
     } catch (err) {
       showStatus(`Refresh failed: ${err instanceof Error ? err.message : String(err)}`, 3000);
     } finally {
+      refreshingItemIdRef.current = null;
       setRefreshing(false);
       setRefreshProgress(null);
       setRefreshItem(null);
@@ -169,6 +174,13 @@ export function Accounts() {
   function stopRefresh(item: LinkedItem) {
     void window.__bridge.invoke('sync:refresh-cancel', item.item_id);
   }
+
+  // Navigating away aborts the poll rather than leaving it to run its full
+  // budget main-side, the same cleanup the TUI does on unmount.
+  useEffect(() => () => {
+    const itemId = refreshingItemIdRef.current;
+    if (itemId) void window.__bridge.invoke('sync:refresh-cancel', itemId);
+  }, []);
 
   // Main pushes a progress step for every phase of the poll.
   useEffect(() =>

--- a/tui/Accounts.tsx
+++ b/tui/Accounts.tsx
@@ -805,8 +805,9 @@ export function Accounts({ onNavigate, isActive, showHints }: { onNavigate: (s: 
       }
       // Confirmed rather than immediate: Plaid bills per /transactions/refresh
       // call. Also worth the gate because [r] was "repair link" one release ago
-      // — muscle memory lands on a confirmation, not a charge.
-      if (input === 'r' && linkedItems[itemCursor] && syncStatus !== 'syncing') {
+      // — muscle memory lands on a confirmation, not a charge. Skipped while a
+      // row awaits its first sync: that sync fetches the same window for free.
+      if (input === 'r' && linkedItems[itemCursor] && !linkedItems[itemCursor].awaitingFirstSync && syncStatus !== 'syncing') {
         setLinksMode('confirm-refresh');
         return;
       }


### PR DESCRIPTION
Three findings from an ultrareview of the current dev → main diff, all on the on-demand `/transactions/refresh` path. All were rated nits; none are merge-blocking on their own, but they cluster around the same poll lifecycle so they travel together.

### `[r]` was ungated on placeholder rows — `tui/Accounts.tsx:809`

The guard checked only `linkedItems[itemCursor] && syncStatus !== 'syncing'`, missing the `!awaitingFirstSync` check that the sibling `[d]` guard four lines down and the GUI's `disabled={refreshing || item.awaitingFirstSync}` both apply. On a row whose first sync hasn't landed, the confirm modal reads "all 0 accounts on this connection" and cites an N-day history window that hasn't been established — and confirming spends a billed refresh on an item where the free first sync fetches the same window.

### The inflight map deleted by key, not by identity — `gui/main/sync-ipc.ts:30`

`inflight.delete(itemId)` in the `finally` ran unconditionally. When two `sync:refresh` calls for one item overlap, the abort resolves the losing poll on a microtask — *after* the replacing call has already done `inflight.set(itemId, controller2)` — so the loser's teardown deleted the winner's controller. The live poll then has no cancel path: `sync:refresh-cancel` is a silent no-op and the Stop button does nothing while the poll runs its full ~4-minute budget. Now gated on `inflight.get(itemId) === controller`.

No Plaid billing implication here — `transactionsRefresh` fires once per invocation and the poll only hits the free `/transactions/sync`. The cost is the dead Stop button.

### No unmount cleanup in the GUI — `gui/renderer/src/screens/Accounts.tsx`

Navigating away from Accounts mid-refresh left the poll running main-side and reset the local `refreshing` flag, which is what made a second refresh (and so the overlap above) reachable in the first place. Added a `refreshingItemIdRef` set on start and cleared in the `finally`, plus an unmount effect that fires `sync:refresh-cancel` for it — mirroring the TUI's `useEffect(() => () => refreshAbortRef.current?.abort(), [])`. A ref rather than the `refreshItem` state so the cleanup doesn't re-subscribe on every refresh.

## Testing

- `tsc --noEmit` clean.
- Full suite: 937/942. The `App > digit-nav sweep` failure in `tests/tui/screens.test.tsx` reproduces identically on a stashed tree, so it is pre-existing and unrelated (missing "Canvas" marker). The `accounts-update-link` failures in the full run were load flakiness — all 6 pass in isolation with these changes applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)