### PR TITLE
feat: let transactions be reattributed to the period they belong to

### DIFF
--- a/core/agent-context.ts
+++ b/core/agent-context.ts
@@ -280,8 +280,12 @@ export const APP_CONTEXT = `
 ## Data Model
 - Transactions are synced from Plaid or imported via CSV.
 - **Sign convention**: positive amount = money out (expense); negative amount = money in (income).
-- Transactions have: id, date, name, display_name, amount, category, account_id, pending, ignored, manual_category.
+- Transactions have: id, date, name, display_name, amount, category, account_id, pending, ignored, manual_category, original_date.
 - \`manual_category\`: set when user or agent manually assigns a category. Survives re-syncs.
+- \`original_date\`: set when a transaction has been reattributed to a different period (a paycheck
+  posting on the 1st that was earned the prior month, a check cashed months after it was written).
+  Holds the bank's posting date; \`date\` holds the reattributed one. All totals and trends use
+  \`date\`, so they reflect the reattribution. Survives re-syncs.
 - \`ignored\`: soft-hides a transaction from all totals (transfers, reimbursements, refunds, etc.).
 - \`hidden_categories\`: categories excluded from all totals and charts (e.g. "Transfer").
 - Accounts: type is one of depository, investment, credit, other.

--- a/core/db.ts
+++ b/core/db.ts
@@ -115,6 +115,10 @@ export async function initDb() {
     'ALTER TABLE transactions ADD COLUMN manual_category TEXT',
     'ALTER TABLE transactions ADD COLUMN display_name TEXT',
     'ALTER TABLE transactions ADD COLUMN ignored INTEGER NOT NULL DEFAULT 0',
+    // Set when the user reattributes a transaction to the period it belongs to
+    // (a paycheck posting on the 1st, a check cashed months after it was written).
+    // Holds the original posting date; `date` holds the reattributed one.
+    'ALTER TABLE transactions ADD COLUMN original_date TEXT',
     'ALTER TABLE category_rules ADD COLUMN min_amount REAL',
     'ALTER TABLE category_rules ADD COLUMN max_amount REAL',
     'ALTER TABLE name_rules ADD COLUMN min_amount REAL',

--- a/core/dedup.ts
+++ b/core/dedup.ts
@@ -10,10 +10,16 @@ export type DupePair = {
   accountName: string;
 };
 
+// Match on posting date, not the displayed date: a reattributed transaction
+// (see `original_date`) can sit months from where the bank actually posted it,
+// which would otherwise push a genuine CSV/Plaid duplicate outside the window.
 const MATCH_SQL = `
   csv.account_id = plaid.account_id
   AND csv.amount = plaid.amount
-  AND ABS(JULIANDAY(csv.date) - JULIANDAY(plaid.date)) <= 3
+  AND ABS(
+    JULIANDAY(COALESCE(csv.original_date, csv.date))
+    - JULIANDAY(COALESCE(plaid.original_date, plaid.date))
+  ) <= 3
   AND csv.id   LIKE 'csv-%'
   AND plaid.id NOT LIKE 'csv-%'
   AND (

--- a/core/sync.ts
+++ b/core/sync.ts
@@ -83,7 +83,8 @@ export async function syncTransactions(accessToken: string, itemId: string, onPr
           sql: `INSERT INTO transactions (id, account_id, date, name, merchant_name, amount, category, raw_category, pending, display_name)
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(id) DO UPDATE SET
-                  date=excluded.date, name=excluded.name, merchant_name=excluded.merchant_name,
+                  date=CASE WHEN original_date IS NOT NULL THEN date ELSE excluded.date END,
+                  name=excluded.name, merchant_name=excluded.merchant_name,
                   amount=excluded.amount,
                   category=COALESCE(manual_category, excluded.category),
                   raw_category=excluded.raw_category,

--- a/core/tools.ts
+++ b/core/tools.ts
@@ -20,7 +20,7 @@ import { getFinanceGuide, getFinanceTopicList, formatGuideSection, type GuideTop
 import { applyCategoriesToAll } from './categorize.js';
 import { deleteCategoryRule } from './rules.js';
 import { rebuildDisplayNames } from './rename.js';
-import { setTransactionCategory, clearTransactionOverride, setTransactionIgnored } from './transactions.js';
+import { setTransactionCategory, clearTransactionOverride, setTransactionIgnored, setTransactionDate, clearTransactionDate } from './transactions.js';
 import { addTagToTransaction, removeTagFromTransaction, getOrCreateTag } from './tags.js';
 import { fmt, fmtSigned, fmtSpan } from './fmt.js';
 import { syncAll } from './sync.js';
@@ -36,6 +36,7 @@ import { CANVAS_SPEC_PATH, appendHistory, searchHistory, getHistoryEntry, delete
 // or TUI refresh and afterWrite callbacks will be silently skipped for that tool.
 export const WRITE_TOOLS = new Set([
   'edit_transaction', 'clear_edit', 'ignore_transaction',
+  'set_transaction_date', 'clear_transaction_date',
   'add_rule', 'delete_rule', 'add_name_rule', 'delete_name_rule',
   'tag_transaction', 'toggle_hidden_category', 'sync',
   'show_canvas', 'load_canvas', 'delete_canvas',
@@ -235,6 +236,29 @@ export const TOOL_DEFS: ToolDef[] = [
     },
   },
   {
+    name: 'set_transaction_date',
+    description: 'Reattribute a transaction to the period it belongs to (e.g. a paycheck that posted on the 1st but was earned the prior month, or a check cashed months after it was written). The bank\'s posting date is preserved and the change survives re-syncs.',
+    parameters: {
+      type: 'object',
+      properties: {
+        id:   { type: 'string', description: 'Transaction ID' },
+        date: { type: 'string', description: 'Date to attribute the transaction to, YYYY-MM-DD' },
+      },
+      required: ['id', 'date'],
+    },
+  },
+  {
+    name: 'clear_transaction_date',
+    description: 'Undo a date reattribution, restoring the bank\'s original posting date.',
+    parameters: {
+      type: 'object',
+      properties: {
+        id: { type: 'string', description: 'Transaction ID' },
+      },
+      required: ['id'],
+    },
+  },
+  {
     name: 'clear_edit',
     description: 'Remove a manual category override from a transaction, reverting to rule-based categorization.',
     parameters: {
@@ -401,6 +425,8 @@ export function describeToolCall(name: string, input: Record<string, unknown>): 
   switch (name) {
     case 'edit_transaction':       return `Set transaction category to "${s('category')}" [id: ${s('id')}]`;
     case 'clear_edit':             return `Remove manual category override [id: ${s('id')}]`;
+    case 'set_transaction_date':   return `Reattribute transaction to ${s('date')} [id: ${s('id')}]`;
+    case 'clear_transaction_date': return `Restore original posting date [id: ${s('id')}]`;
     case 'ignore_transaction':     return `${input['ignore'] ? 'Ignore' : 'Un-ignore'} transaction [id: ${s('id')}]`;
     case 'add_rule':               return `Add category rule: "${s('pattern')}" → ${s('category')}`;
     case 'delete_rule':            return `Delete category rule #${n('id')}`;
@@ -788,6 +814,29 @@ async function executeToolImpl(
       if (!tx) return `No transaction with id ${str('id')}.`;
       await setTransactionCategory(str('id'), str('category'));
       return `Set "${tx.name}" → ${str('category')} (pinned)`;
+    }
+
+    case 'set_transaction_date': {
+      const txResult = await db.execute({ sql: 'SELECT name, date FROM transactions WHERE id = ?', args: [str('id')] });
+      const tx = txResult.rows[0] as unknown as { name: string; date: string } | undefined;
+      if (!tx) return `No transaction with id ${str('id')}.`;
+      const date = str('date');
+      // Reject anything SQLite's date functions would silently treat as NULL —
+      // a bad date here would quietly drop the row out of every range query.
+      if (!/^\d{4}-\d{2}-\d{2}$/.test(date) || Number.isNaN(Date.parse(date))) {
+        return `"${date}" is not a valid date. Use YYYY-MM-DD.`;
+      }
+      await setTransactionDate(str('id'), date);
+      return `Reattributed "${tx.name}" from ${tx.date} → ${date} (posting date preserved)`;
+    }
+
+    case 'clear_transaction_date': {
+      const txResult = await db.execute({ sql: 'SELECT name, original_date FROM transactions WHERE id = ?', args: [str('id')] });
+      const tx = txResult.rows[0] as unknown as { name: string; original_date: string | null } | undefined;
+      if (!tx) return `No transaction with id ${str('id')}.`;
+      if (!tx.original_date) return `"${tx.name}" has no date override.`;
+      await clearTransactionDate(str('id'));
+      return `Restored "${tx.name}" to its posting date ${tx.original_date}`;
     }
 
     case 'clear_edit': {

--- a/core/transactions.ts
+++ b/core/transactions.ts
@@ -30,6 +30,25 @@ export async function clearTransactionOverride(id: string): Promise<void> {
   });
 }
 
+/**
+ * Reattribute a transaction to the period it belongs to. Preserves the bank's
+ * posting date in `original_date` on the first edit, so repeated edits never
+ * lose it and `clearTransactionDate` can always get back to the truth.
+ */
+export async function setTransactionDate(id: string, date: string): Promise<void> {
+  await db.execute({
+    sql: 'UPDATE transactions SET original_date = COALESCE(original_date, date), date = ? WHERE id = ?',
+    args: [date, id],
+  });
+}
+
+export async function clearTransactionDate(id: string): Promise<void> {
+  await db.execute({
+    sql: 'UPDATE transactions SET date = COALESCE(original_date, date), original_date = NULL WHERE id = ?',
+    args: [id],
+  });
+}
+
 export async function setTransactionIgnored(id: string, ignored: boolean): Promise<void> {
   await db.execute({
     sql: 'UPDATE transactions SET ignored = ? WHERE id = ?',

--- a/mcp/create-server.ts
+++ b/mcp/create-server.ts
@@ -72,6 +72,29 @@ export function createMcpServer(opts: { afterWrite?: () => void } = {}): McpServ
     (input) => run('edit_transaction', input),
   );
 
+  // ── set_transaction_date ────────────────────────────────────────────────────
+
+  server.tool(
+    'set_transaction_date',
+    'Reattribute a transaction to the period it belongs to (e.g. a paycheck that posted on the 1st but was earned the prior month, or a check cashed months after it was written). The bank\'s posting date is preserved and the change survives re-syncs.',
+    {
+      id:   z.string().describe('Transaction ID from list_transactions'),
+      date: z.string().describe('Date to attribute the transaction to, YYYY-MM-DD'),
+    },
+    (input) => run('set_transaction_date', input),
+  );
+
+  // ── clear_transaction_date ──────────────────────────────────────────────────
+
+  server.tool(
+    'clear_transaction_date',
+    'Undo a date reattribution, restoring the bank\'s original posting date.',
+    {
+      id: z.string().describe('Transaction ID from list_transactions'),
+    },
+    (input) => run('clear_transaction_date', input),
+  );
+
   // ── clear_edit ──────────────────────────────────────────────────────────────
 
   server.tool(

--- a/tests/dedup.test.ts
+++ b/tests/dedup.test.ts
@@ -175,3 +175,33 @@ describe('deduplicateCsvVsPlaid', () => {
     expect(await deduplicateCsvVsPlaid()).toBe(2);
   });
 });
+
+describe('deduplicateCsvVsPlaid with reattributed dates', () => {
+  it('still matches a duplicate whose displayed date was moved months away', async () => {
+    // Same transaction from both sources, posted a day apart. The CSV copy has
+    // been reattributed to a prior period; matching must use the posting date.
+    const csvId = await csvTx({ name: 'BRAINCO TECHNOLO', amount: -5531.2, date: '2025-01-01' });
+    await db.execute({
+      sql: "UPDATE transactions SET date = '2024-11-30', original_date = '2025-01-01' WHERE id = ?",
+      args: [csvId],
+    });
+    await plaidTx({ name: 'BRAINCO TECHNOLO', amount: -5531.2, date: '2025-01-02' });
+
+    expect(await deduplicateCsvVsPlaid()).toBe(1);
+    expect(await exists(csvId)).toBe(false);
+  });
+
+  it('does not match when the posting dates are genuinely far apart', async () => {
+    // Reattributing must not manufacture a match either: these are two real,
+    // distinct payments that happen to share an amount.
+    const csvId = await csvTx({ name: 'Albany Children\'s Center', amount: 2914, date: '2024-11-25' });
+    await db.execute({
+      sql: "UPDATE transactions SET date = '2025-01-02', original_date = '2024-11-25' WHERE id = ?",
+      args: [csvId],
+    });
+    await plaidTx({ name: 'Albany Children\'s Center', amount: 2914, date: '2025-01-02' });
+
+    expect(await deduplicateCsvVsPlaid()).toBe(0);
+    expect(await exists(csvId)).toBe(true);
+  });
+});

--- a/tests/helpers/makeTestDb.ts
+++ b/tests/helpers/makeTestDb.ts
@@ -27,7 +27,8 @@ const SCHEMA = `
     pending INTEGER NOT NULL DEFAULT 0,
     manual_category TEXT,
     display_name TEXT,
-    ignored INTEGER NOT NULL DEFAULT 0
+    ignored INTEGER NOT NULL DEFAULT 0,
+    original_date TEXT
   );
 
   CREATE TABLE category_rules (

--- a/tests/sync.test.ts
+++ b/tests/sync.test.ts
@@ -355,3 +355,45 @@ describe('describeSyncProgress', () => {
     expect(describeSyncProgress({ phase: 'dedup' })).toBe('Checking for duplicates…');
   });
 });
+
+describe('syncTransactions — reattributed dates survive re-sync', () => {
+  const plaidTx = (id: string, date: string) => ({
+    transaction_id: id,
+    account_id: 'acct-1',
+    date,
+    name: 'BRAINCO TECHNOLO',
+    merchant_name: null,
+    amount: -5531.2,
+    pending: false,
+    personal_finance_category: { primary: 'INCOME' },
+  });
+
+  async function dateOf(id: string) {
+    const r = await db.execute({ sql: 'SELECT date, original_date FROM transactions WHERE id = ?', args: [id] });
+    return r.rows[0] as unknown as { date: string; original_date: string | null };
+  }
+
+  it('keeps a reattributed date when Plaid re-sends the transaction', async () => {
+    mockPlaid([], [plaidTx('tx-pay', '2025-07-01')]);
+    await syncTransactions('token', 'item-1');
+    await db.execute("UPDATE transactions SET date = '2025-06-30', original_date = '2025-07-01' WHERE id = 'tx-pay'");
+
+    // Plaid re-sends the same row on a later sync with its own posting date.
+    await deleteSyncCursor('item-1');
+    mockPlaid([], [plaidTx('tx-pay', '2025-07-01')]);
+    await syncTransactions('token', 'item-1');
+
+    expect(await dateOf('tx-pay')).toEqual({ date: '2025-06-30', original_date: '2025-07-01' });
+  });
+
+  it('still accepts Plaid date changes on transactions with no override', async () => {
+    mockPlaid([], [plaidTx('tx-pay', '2025-07-01')]);
+    await syncTransactions('token', 'item-1');
+
+    await deleteSyncCursor('item-1');
+    mockPlaid([], [plaidTx('tx-pay', '2025-07-03')]);
+    await syncTransactions('token', 'item-1');
+
+    expect(await dateOf('tx-pay')).toEqual({ date: '2025-07-03', original_date: null });
+  });
+});

--- a/tests/transactions.test.ts
+++ b/tests/transactions.test.ts
@@ -11,6 +11,8 @@ import {
   clearTransactionOverride,
   setTransactionIgnored,
   setTransactionDisplayName,
+  setTransactionDate,
+  clearTransactionDate,
   deleteTransaction,
   upsertCategoryRule,
   upsertNameRule,
@@ -210,5 +212,49 @@ describe('setIgnoredBulk', () => {
     await setIgnoredBulk([id], false);
     const row = (await db.execute({ sql: 'SELECT ignored FROM transactions WHERE id = ?', args: [id] })).rows[0] as unknown as { ignored: number };
     expect(row.ignored).toBe(0);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────
+describe('setTransactionDate', () => {
+  async function dateOf(id: string) {
+    const r = await db.execute({ sql: 'SELECT date, original_date FROM transactions WHERE id = ?', args: [id] });
+    return r.rows[0] as unknown as { date: string; original_date: string | null };
+  }
+
+  it('moves the date and preserves the posting date', async () => {
+    const id = await insertTx({ name: 'BRAINCO TECHNOLO' }); // posts 2025-01-15
+    await setTransactionDate(id, '2024-12-31');
+    expect(await dateOf(id)).toEqual({ date: '2024-12-31', original_date: '2025-01-15' });
+  });
+
+  it('keeps the first posting date across repeated edits', async () => {
+    const id = await insertTx({ name: 'BRAINCO TECHNOLO' });
+    await setTransactionDate(id, '2024-12-31');
+    await setTransactionDate(id, '2024-12-01');
+    // original_date must still be the bank's date, not the intermediate edit
+    expect(await dateOf(id)).toEqual({ date: '2024-12-01', original_date: '2025-01-15' });
+  });
+
+  it('clearTransactionDate restores the posting date', async () => {
+    const id = await insertTx({ name: 'Check #311 Cashed' });
+    await setTransactionDate(id, '2024-06-01');
+    await clearTransactionDate(id);
+    expect(await dateOf(id)).toEqual({ date: '2025-01-15', original_date: null });
+  });
+
+  it('clearTransactionDate is a no-op on an unedited transaction', async () => {
+    const id = await insertTx({ name: 'Target' });
+    await clearTransactionDate(id);
+    expect(await dateOf(id)).toEqual({ date: '2025-01-15', original_date: null });
+  });
+
+  it('reattributed transactions land in the new period for range queries', async () => {
+    const id = await insertTx({ name: 'BRAINCO TECHNOLO', amount: -5531.2 });
+    await setTransactionDate(id, '2024-12-31');
+    const inDec = await db.execute("SELECT id FROM transactions WHERE date BETWEEN '2024-12-01' AND '2024-12-31'");
+    const inJan = await db.execute("SELECT id FROM transactions WHERE date BETWEEN '2025-01-01' AND '2025-01-31'");
+    expect(inDec.rows.map((r) => r.id)).toEqual([id]);
+    expect(inJan.rows).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Why

Bank posting dates routinely sit in a different month than the period the money belongs to, which distorts every month-over-month comparison:

- A BrainCo paycheck earned in June posted **July 1** — moving $5,531 out of June and into July. June looks like a 1-paycheck month and July like a 3-paycheck month.
- Childcare check #311, written **5/25** for June tuition, was still uncashed on **9/2** — so June showed $0 childcare despite care being delivered and paid.

## Approach

Add an `original_date` column holding the bank's posting date, while `date` holds the reattributed one. The ~40 existing date-filtering queries already read `date`, so they pick up the correction **with no changes** — no view, no `COALESCE` threading through call sites.

This follows the `manual_category` precedent, but resolves at read time rather than write time (`core/sync.ts`), since the true posting date has to be preserved rather than overwritten.

## Changes

| File | Change |
|---|---|
| `core/db.ts` | `original_date TEXT` migration, using the existing idempotent `ALTER TABLE` list |
| `core/transactions.ts` | `setTransactionDate` / `clearTransactionDate` |
| `core/sync.ts` | Upsert keeps a reattributed date instead of clobbering with `excluded.date` |
| `core/dedup.ts` | Match on `COALESCE(original_date, date)` |
| `core/tools.ts`, `mcp/create-server.ts` | `set_transaction_date`, `clear_transaction_date` |
| `core/agent-context.ts` | Document the column for the agent |

## Details worth reviewing

- **Repeated edits keep the bank's date.** `COALESCE(original_date, date)` on write means a second edit can't overwrite the posting date with the first edit's guess.
- **Dedup is guarded both directions.** A row moved months away is still caught as a CSV/Plaid duplicate, and two genuinely distinct same-amount payments still aren't matched. Both tested — the second matters because the recurring Albany childcare payments are all identical amounts.
- **Date input is validated.** SQLite's date functions return NULL on malformed input, which would silently drop a transaction out of every range query rather than erroring.
- **Balance history is untouched**, so net worth still reconciles against the bank regardless of what gets reattributed.

## Tests

65 passing across `tests/transactions.test.ts`, `tests/dedup.test.ts`, `tests/sync.test.ts`, covering repeated edits, clearing, re-sync survival, range-query movement, and both dedup directions.

Full suite: 950/951. The one failure (`tests/tui/screens.test.tsx`, Canvas screen marker) is pre-existing and reproduces on a clean `dev` checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)