### PR TITLE
fix: net category inflows in trends and health totals

### DIFF
--- a/core/agent-context.ts
+++ b/core/agent-context.ts
@@ -6,6 +6,7 @@
 
 import { db } from './db.js';
 import { yearsToFire } from './health.js';
+import { TRAILING_12MO_AVERAGES_SQL } from './queries.js';
 import { getSetting, PRETAX_MONTHLY_KEY } from './settings.js';
 import { isAssetAccount, isLiabilityAccount } from './account-class.js';
 
@@ -156,21 +157,7 @@ export async function getFinancialHealth(
   const balances = await getBalances();
 
   const [expResult, pretaxRaw] = await Promise.all([
-    db.execute(`
-      SELECT
-        COALESCE(SUM(CASE WHEN amount > 0 THEN amount ELSE 0 END), 0) / 12.0 AS avg_expenses,
-        COALESCE(-SUM(CASE WHEN amount < 0 THEN amount ELSE 0 END), 0) / 12.0 AS avg_income,
-        COALESCE(
-          -SUM(CASE WHEN amount < 0 THEN amount ELSE 0 END) -
-           SUM(CASE WHEN amount > 0 THEN amount ELSE 0 END),
-          0
-        ) / 12.0 AS avg_savings
-      FROM transactions
-      WHERE date >= date('now', '-12 months')
-        AND pending = 0 AND ignored = 0
-        AND category NOT IN (SELECT category FROM hidden_categories)
-        AND category != 'Transfer'
-    `),
+    db.execute(TRAILING_12MO_AVERAGES_SQL),
     getSetting(PRETAX_MONTHLY_KEY),
   ]);
   const expRow = expResult.rows[0] as unknown as { avg_expenses: number; avg_income: number; avg_savings: number };

--- a/core/health.ts
+++ b/core/health.ts
@@ -1,5 +1,6 @@
 import { db } from './db.js';
 import { calcN } from './calculator.js';
+import { TRAILING_12MO_AVERAGES_SQL } from './queries.js';
 
 export type HealthData = {
   avgMonthlyExpenses: number;
@@ -16,21 +17,7 @@ export type HealthData = {
 
 export async function loadHealthData(): Promise<HealthData> {
   const [expRes, cashRes, liquidRes, retirementRes, debtRes, loanRes, nwRes] = await Promise.all([
-    db.execute(`
-      SELECT
-        COALESCE(SUM(CASE WHEN amount > 0 THEN amount ELSE 0 END), 0) / 12.0  AS avg_expenses,
-        COALESCE(-SUM(CASE WHEN amount < 0 THEN amount ELSE 0 END), 0) / 12.0 AS avg_income,
-        COALESCE(
-          -SUM(CASE WHEN amount < 0 THEN amount ELSE 0 END) -
-           SUM(CASE WHEN amount > 0 THEN amount ELSE 0 END),
-          0
-        ) / 12.0 AS avg_savings
-      FROM transactions
-      WHERE date >= date('now', '-12 months')
-        AND pending = 0 AND ignored = 0
-        AND category NOT IN (SELECT category FROM hidden_categories)
-        AND category != 'Transfer'
-    `),
+    db.execute(TRAILING_12MO_AVERAGES_SQL),
     db.execute(`
       SELECT COALESCE(SUM(bh.balance), 0) AS cash
       FROM accounts a

--- a/core/queries.ts
+++ b/core/queries.ts
@@ -15,7 +15,7 @@ export type MerchantSummaryRow = {
 // The catch-all category. Unlike a real category, it legitimately mixes income
 // (e.g. an un-ruled paycheck) with spending, so we never net the two together —
 // see summarizeBuckets.
-const UNCATEGORIZED = 'Uncategorized';
+export const UNCATEGORIZED = 'Uncategorized';
 
 /**
  * Turn per-category {outflow, inflow} buckets into an income/expense/byCategory
@@ -40,6 +40,41 @@ function summarizeBuckets(rows: { category: string; outflow: number; inflow: num
   byCategory.sort((a, b) => b.total - a.total);
   return { income, expenses, net: income - expenses, byCategory };
 }
+
+/**
+ * Trailing-12-month income / expense / savings averages, netted per category by
+ * the same rule as summarizeBuckets: a reimbursement sitting inside an expense
+ * category reduces that category's spend instead of inflating expenses AND
+ * income at once. Summing raw outflows here would overstate avg_expenses, which
+ * feeds runway, the FIRE number, and years-to-FIRE.
+ *
+ * Shared by loadHealthData (TUI/GUI Health tab) and getFinancialHealth (agent),
+ * which must not drift apart.
+ */
+export const TRAILING_12MO_AVERAGES_SQL = `
+  SELECT
+    COALESCE(SUM(spend), 0) / 12.0            AS avg_expenses,
+    COALESCE(SUM(inc), 0) / 12.0              AS avg_income,
+    COALESCE(SUM(inc) - SUM(spend), 0) / 12.0 AS avg_savings
+  FROM (
+    SELECT
+      CASE WHEN category = '${UNCATEGORIZED}' THEN outflow
+           WHEN outflow > inflow THEN outflow - inflow ELSE 0 END AS spend,
+      CASE WHEN category = '${UNCATEGORIZED}' THEN inflow
+           WHEN inflow > outflow THEN inflow - outflow ELSE 0 END AS inc
+    FROM (
+      SELECT category,
+        SUM(CASE WHEN amount > 0 THEN amount ELSE 0 END)  AS outflow,
+        SUM(CASE WHEN amount < 0 THEN -amount ELSE 0 END) AS inflow
+      FROM transactions
+      WHERE date >= date('now', '-12 months')
+        AND pending = 0 AND ignored = 0
+        AND category NOT IN (SELECT category FROM hidden_categories)
+        AND category != 'Transfer'
+      GROUP BY category
+    )
+  )
+`;
 
 export async function getHiddenCategories(): Promise<Set<string>> {
   const result = await db.execute('SELECT category FROM hidden_categories');

--- a/core/trends.ts
+++ b/core/trends.ts
@@ -1,6 +1,6 @@
 import { db } from './db.js';
 import { MONTHS, addDays, weekLabel, type TrendsRange } from './dateUtils.js';
-import { buildSearchRe } from './queries.js';
+import { buildSearchRe, UNCATEGORIZED } from './queries.js';
 import { buildFilterClause, type Filter } from './filters.js';
 
 const pad = (n: number) => String(n).padStart(2, '0');
@@ -177,29 +177,46 @@ export async function getPeriodTotals(view: View, range: TrendsRange, filter?: F
     ? `AND EXISTS (SELECT 1 FROM categories c WHERE c.name = t.category AND c.flexibility = '${view.flex}')`
     : 'AND t.category NOT IN (SELECT category FROM hidden_categories)';
 
-  const amtFilter = view.mode === 'income' ? 'AND t.amount < 0' : view.mode === 'net' ? '' : 'AND t.amount > 0';
-  const base = `FROM transactions t WHERE t.pending = 0 AND t.ignored = 0 ${amtFilter} ${catFilter}${f.clause}`;
   const isNet = view.mode === 'net';
-  const totalExpr = isNet
-    ? 'SUM(CASE WHEN t.amount < 0 THEN ABS(t.amount) ELSE 0 END) as income, SUM(CASE WHEN t.amount > 0 THEN t.amount ELSE 0 END) as expenses, SUM(CASE WHEN t.amount < 0 THEN ABS(t.amount) ELSE -t.amount END) as total'
-    : 'SUM(ABS(t.amount)) as total';
+  const isIncome = view.mode === 'income';
+  const base = `FROM transactions t WHERE t.pending = 0 AND t.ignored = 0 ${catFilter}${f.clause}`;
   const zeroRow = (p: { label: string; from: string; to: string }): PeriodRow =>
     ({ ...p, total: 0, ...(isNet ? { income: 0, expenses: 0 } : {}) });
 
-  let sql: string;
-  let toActual: (r: any) => PeriodRow;
+  const PERIODS = {
+    month:   { select: 'CAST(substr(t.date,1,4) AS INTEGER) as y, CAST(substr(t.date,6,2) AS INTEGER) as m', key: 'y, m' },
+    quarter: { select: 'CAST(substr(t.date,1,4) AS INTEGER) as y, (CAST(substr(t.date,6,2) AS INTEGER)-1)/3+1 as q', key: 'y, q' },
+    year:    { select: 'CAST(substr(t.date,1,4) AS INTEGER) as y', key: 'y' },
+    week:    { select: `date(t.date, '-' || ((CAST(strftime('%w', t.date) AS INTEGER)+6)%7) || ' days') as week_start`, key: 'week_start' },
+  } as const;
+  const period = PERIODS[range === 'month' || range === 'quarter' || range === 'year' ? range : 'week'];
 
+  // Every mode resolves each category's flows the same way summarizeBuckets does
+  // (queries.ts), so Expenses, Income and Net all reconcile with each other and
+  // with the spending summary: a real category nets, and whichever side wins
+  // decides whether it counts as spending or income. Uncategorized is split by
+  // flow instead — it legitimately mixes an un-ruled paycheck with real spending.
+  const INC   = `CASE WHEN category = '${UNCATEGORIZED}' THEN inflow  WHEN inflow  > outflow THEN inflow - outflow ELSE 0 END`;
+  const SPEND = `CASE WHEN category = '${UNCATEGORIZED}' THEN outflow WHEN outflow > inflow  THEN outflow - inflow ELSE 0 END`;
+  const totalCol = isNet ? `SUM(${INC}) - SUM(${SPEND})` : isIncome ? `SUM(${INC})` : `SUM(${SPEND})`;
+
+  const sql = `
+    SELECT ${period.key}, ${totalCol} as total${isNet ? `, SUM(${INC}) as income, SUM(${SPEND}) as expenses` : ''}
+    FROM (
+      SELECT ${period.select}, t.category as category,
+        SUM(CASE WHEN t.amount > 0 THEN t.amount ELSE 0 END)  as outflow,
+        SUM(CASE WHEN t.amount < 0 THEN -t.amount ELSE 0 END) as inflow
+      ${base} GROUP BY ${period.key}, t.category
+    ) GROUP BY ${period.key} ORDER BY ${period.key}`;
+
+  let toActual: (r: any) => PeriodRow;
   if (range === 'month') {
-    sql = `SELECT CAST(substr(t.date,1,4) AS INTEGER) as y, CAST(substr(t.date,6,2) AS INTEGER) as m, ${totalExpr} ${base} GROUP BY y, m ORDER BY y, m`;
     toActual = (r) => ({ label: `${MONTHS[r.m - 1]} ${r.y}`, from: `${r.y}-${pad(r.m)}-01`, to: `${r.y}-${pad(r.m)}-31`, total: Number(r.total), ...(isNet ? { income: Number(r.income), expenses: Number(r.expenses) } : {}) });
   } else if (range === 'quarter') {
-    sql = `SELECT CAST(substr(t.date,1,4) AS INTEGER) as y, (CAST(substr(t.date,6,2) AS INTEGER)-1)/3+1 as q, ${totalExpr} ${base} GROUP BY y, q ORDER BY y, q`;
     toActual = (r) => ({ label: `Q${r.q} ${r.y}`, from: `${r.y}-${Q_FROM[r.q - 1]}-01`, to: `${r.y}-${Q_TO[r.q - 1]}-31`, total: Number(r.total), ...(isNet ? { income: Number(r.income), expenses: Number(r.expenses) } : {}) });
   } else if (range === 'year') {
-    sql = `SELECT CAST(substr(t.date,1,4) AS INTEGER) as y, ${totalExpr} ${base} GROUP BY y ORDER BY y`;
     toActual = (r) => ({ label: `${r.y}`, from: `${r.y}-01-01`, to: `${r.y}-12-31`, total: Number(r.total), ...(isNet ? { income: Number(r.income), expenses: Number(r.expenses) } : {}) });
   } else {
-    sql = `SELECT date(t.date, '-' || ((CAST(strftime('%w', t.date) AS INTEGER)+6)%7) || ' days') as week_start, ${totalExpr} ${base} GROUP BY week_start ORDER BY week_start`;
     toActual = (r) => {
       const to = addDays(r.week_start, 6);
       return { label: weekLabel(r.week_start, to), from: r.week_start, to, total: Number(r.total), ...(isNet ? { income: Number(r.income), expenses: Number(r.expenses) } : {}) };

--- a/tests/trends.test.ts
+++ b/tests/trends.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('../core/db.js', async () => {
+  const { makeTestDb } = await import('./helpers/makeTestDb.js');
+  return { db: await makeTestDb() };
+});
+
+import { db } from '../core/db.js';
+import { getPeriodTotals, type View } from '../core/trends.js';
+
+let seq = 0;
+/** Sign convention: positive amount = money out, negative = money in. */
+async function tx(opts: { date: string; amount: number; category: string; name?: string }) {
+  seq++;
+  await db.execute({
+    sql: `INSERT INTO transactions (id, account_id, date, name, amount, category, pending, ignored)
+          VALUES (?, 'acct1', ?, ?, ?, ?, 0, 0)`,
+    args: [`tx${seq}`, opts.date, opts.name ?? 'Test', opts.amount, opts.category],
+  });
+}
+
+const view = (over: Partial<View>): View =>
+  ({ mode: 'expenses', category: null, flex: null, label: '', ...over });
+
+const monthTotal = async (v: View, from: string) =>
+  (await getPeriodTotals(v, 'month')).find((p) => p.from === from)?.total ?? 0;
+
+beforeEach(async () => {
+  seq = 0;
+  for (const t of ['transactions', 'categories', 'hidden_categories']) await db.execute(`DELETE FROM ${t}`);
+});
+
+describe('getPeriodTotals — inflows net against outflows per category', () => {
+  // The real case this guards: a group trip fronted on one card and repaid by
+  // friends. Both legs are categorized Travel, so the month's travel spend is
+  // the difference, not the gross charge.
+  beforeEach(async () => {
+    await tx({ date: '2026-04-03', amount: 4000, category: 'Travel', name: 'Amtrak' });
+    await tx({ date: '2026-04-16', amount: 6387.31, category: 'Travel', name: 'Amtrak' });
+    await tx({ date: '2026-04-17', amount: -1835.10, category: 'Travel', name: 'Venmo' });
+    await tx({ date: '2026-04-20', amount: -2080.52, category: 'Travel', name: 'Venmo' });
+    await tx({ date: '2026-04-29', amount: -4000, category: 'Travel', name: 'Venmo' });
+  });
+
+  it('category mode reports net spend, not gross outflow', async () => {
+    const total = await monthTotal(view({ mode: 'category', category: 'Travel' }), '2026-04-01');
+    expect(total).toBeCloseTo(2471.69, 2); // 10387.31 out − 7915.62 back
+  });
+
+  it('expenses mode nets the same inflows', async () => {
+    const total = await monthTotal(view({ mode: 'expenses' }), '2026-04-01');
+    expect(total).toBeCloseTo(2471.69, 2);
+  });
+
+  it('flex mode nets the same inflows', async () => {
+    await db.execute("INSERT INTO categories (name, flexibility) VALUES ('Travel', 'discretionary')");
+    const total = await monthTotal(view({ mode: 'flex', flex: 'discretionary' }), '2026-04-01');
+    expect(total).toBeCloseTo(2471.69, 2);
+  });
+
+  it('income mode does not count the repayments as income', async () => {
+    // Travel nets out as spending, so the Venmo legs are already consumed there.
+    // Counting them again here would inflate both sides of the same month.
+    const total = await monthTotal(view({ mode: 'income' }), '2026-04-01');
+    expect(total).toBe(0);
+  });
+
+  it('net mode reconciles with the expenses and income views', async () => {
+    const rows = await getPeriodTotals(view({ mode: 'net' }), 'month');
+    const april = rows.find((p) => p.from === '2026-04-01');
+    const expenses = await monthTotal(view({ mode: 'expenses' }), '2026-04-01');
+    const income   = await monthTotal(view({ mode: 'income' }), '2026-04-01');
+
+    expect(april?.expenses).toBeCloseTo(expenses, 2);
+    expect(april?.income).toBeCloseTo(income, 2);
+    expect(april?.total).toBeCloseTo(income - expenses, 2);
+  });
+});
+
+describe('getPeriodTotals — netting edge cases', () => {
+  it('a category that nets negative drops out rather than offsetting other categories', async () => {
+    // A refund larger than the month's spend in that category is income, not a
+    // discount on groceries.
+    await tx({ date: '2026-05-10', amount: 100, category: 'Shopping' });
+    await tx({ date: '2026-05-11', amount: -400, category: 'Shopping' });
+    await tx({ date: '2026-05-12', amount: 250, category: 'Grocery' });
+
+    const total = await monthTotal(view({ mode: 'expenses' }), '2026-05-01');
+    expect(total).toBe(250); // Grocery only; Shopping's −300 does not reduce it
+  });
+
+  it('Uncategorized keeps outflows and inflows separate', async () => {
+    // Uncategorized legitimately mixes an un-ruled paycheck with real spending,
+    // so netting there would erase the spending. Matches summarizeBuckets.
+    await tx({ date: '2026-05-10', amount: 300, category: 'Uncategorized' });
+    await tx({ date: '2026-05-11', amount: -5000, category: 'Uncategorized', name: 'Paycheck' });
+
+    const total = await monthTotal(view({ mode: 'expenses' }), '2026-05-01');
+    expect(total).toBe(300);
+  });
+
+  it('net mode reports the netted category, not both gross sides', async () => {
+    await tx({ date: '2026-06-01', amount: 1000, category: 'Travel' });
+    await tx({ date: '2026-06-02', amount: -400, category: 'Travel' });
+
+    const rows = await getPeriodTotals(view({ mode: 'net' }), 'month');
+    const june = rows.find((p) => p.from === '2026-06-01');
+    expect(june?.expenses).toBeCloseTo(600, 2); // not 1000
+    expect(june?.income).toBe(0);               // not 400
+    expect(june?.total).toBeCloseTo(-600, 2);
+  });
+
+  it('a category that nets negative shows up as income across all three views', async () => {
+    // A tax refund exceeding the year's tax payments is genuinely income; it must
+    // land on the income side rather than discounting other spending.
+    await tx({ date: '2026-07-01', amount: 500, category: 'Taxes' });
+    await tx({ date: '2026-07-02', amount: -2000, category: 'Taxes' });
+    await tx({ date: '2026-07-03', amount: 300, category: 'Grocery' });
+
+    const rows = await getPeriodTotals(view({ mode: 'net' }), 'month');
+    const july = rows.find((p) => p.from === '2026-07-01');
+    expect(july?.income).toBeCloseTo(1500, 2);
+    expect(july?.expenses).toBeCloseTo(300, 2);
+    expect(await monthTotal(view({ mode: 'income' }), '2026-07-01')).toBeCloseTo(1500, 2);
+    expect(await monthTotal(view({ mode: 'expenses' }), '2026-07-01')).toBeCloseTo(300, 2);
+  });
+
+  it('a month with no transactions reports zero, not a missing row', async () => {
+    await tx({ date: '2026-04-10', amount: 50, category: 'Grocery' });
+    await tx({ date: '2026-06-10', amount: 50, category: 'Grocery' });
+
+    expect(await monthTotal(view({ mode: 'expenses' }), '2026-05-01')).toBe(0);
+  });
+});


### PR DESCRIPTION
## Why

Money that flows back **into** an expense category — a friend repaying a group trip, a refund, a card reward credit — was being discarded instead of reducing that category's spend. Two surfaces were inflated, and both disagreed with the spending summary.

Found via a real case: April 2026 travel showed **$10,717** on the trends page. The actual figure is **$1,972** — an Amtrak booking for a group, largely repaid by Venmo. Both legs were correctly categorized `Travel`; only the outflows were counted.

## The rule already existed

`summarizeBuckets` (`core/queries.ts`) had it right: net a real category's outflow against its inflow, and let whichever side wins decide whether it lands in spending or income. `Uncategorized` splits by flow instead, since it legitimately mixes an un-ruled paycheck with real spending.

Trends and health each reimplemented the aggregation and missed that rule.

## Trends

`expenses`, `category` and `flex` filtered to `amount > 0`, discarding inflows; `income` counted them gross. So the same $8,746 inflated April's expenses *and* its income.

All five modes now share one query shape, so **Expenses, Income and Net reconcile with each other and with the summary**. `flexbreakdown` was already correct and is unchanged. This removes a query shape rather than adding one.

Verified through the real code path against a live database:

```
Expenses view total : 14321.03   (was 23066.65)
Income   view total :  3996.60
Net view  .expenses : 14321.03
Net view  .income   :  3996.60
Net view  .total    : -10324.43
Travel category     :  1971.65   (was 10717.27)
```

Those match `spending_summary` for April exactly.

## Health

`avg_expenses` summed raw outflows. It feeds runway, the FIRE number and years-to-FIRE, so the error compounded into the planning numbers:

| Metric | Before | After |
|---|---|---|
| Avg monthly expenses | $13,994.56 | **$13,088.85** |
| Annual spend | $167,935 | **$157,066** |
| FIRE number @ 4% | $4,198,367 | **$3,926,655** |
| Cash runway | 5.60 mo | **5.99 mo** |

Over the trailing 12 months, **$10,868** of reimbursements were counted as spending — 84% of it Travel, the rest Taxes, Childcare, Shopping and small refunds. Because those inflows inflated expenses *and* income simultaneously, savings rate stayed correct while every expense-derived number drifted.

`core/health.ts` and `core/agent-context.ts` held **duplicate copies** of this query. Both now use one shared `TRAILING_12MO_AVERAGES_SQL`, so they can't drift apart again.

## Tests

Trends had **no test coverage at all**. Adds 10 tests covering the netting rule across all modes, the `Uncategorized` split, a category that nets negative landing in income rather than discounting other categories, and — the specific regression caught in review — that `net`'s income/expenses equal what the income and expenses views independently report.

Full suite: 960/961. The one failure (`tests/tui/screens.test.tsx`, Canvas screen marker) is pre-existing and reproduces on a clean `dev` checkout.

## Reviewer note

This is a **visible behavior change**. Expense trend lines drop in reimbursement-heavy months, and the Health tab's spend dial seeds ~$900 lower. Those are the correct numbers, but they will look different.

Not addressed here: `buildTrendViews` (`core/trends.ts:22`) still orders the category menu by gross outflow. It affects menu ordering only, no displayed number, so it's left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)