### PR TITLE
fix: let update link repair a connection that lost its accounts

### DIFF
--- a/core/plaid.ts
+++ b/core/plaid.ts
@@ -50,6 +50,17 @@ export function getPlaidClient(): PlaidApi {
  * includes `transactions.days_requested` — so `daysRequested` is ignored when
  * updating. That window is fixed when the Item is created and cannot be
  * widened later. See https://plaid.com/docs/link/update-mode/
+ *
+ * `update.account_selection_enabled` is what makes the update actually able to
+ * *repair* a connection rather than only re-type its password. Plain update mode
+ * re-authorizes credentials and nothing else, so an Item whose accounts have gone
+ * away — Plaid reports `NO_ACCOUNTS`, typically after the institution renumbers
+ * an account or the user's earlier Account Select choice stops matching anything
+ * — fails the same way after every "update link" press. Enabling Account Select
+ * re-presents the account picker, which is the only in-app path back. OAuth
+ * institutions in the US always show their own picker regardless of this flag;
+ * the ones that need it are the non-OAuth institutions, where without it the
+ * button is a no-op for exactly the failure it looks like it should fix.
  */
 export async function createLinkToken(userId: string, daysRequested?: number, accessToken?: string) {
   const response = await getPlaidClient().linkTokenCreate({
@@ -58,7 +69,7 @@ export async function createLinkToken(userId: string, daysRequested?: number, ac
     country_codes: [CountryCode.Us],
     language: 'en',
     ...(accessToken
-      ? { access_token: accessToken }
+      ? { access_token: accessToken, update: { account_selection_enabled: true } }
       : {
           products: [Products.Transactions],
           // Omitting transactions lets Plaid apply its 90-day default

--- a/tests/plaid-link-token.test.ts
+++ b/tests/plaid-link-token.test.ts
@@ -54,4 +54,18 @@ describe('createLinkToken', () => {
     expect(req.transactions).toBeUndefined();
     expect(req.access_token).toBe('access-abc');
   });
+
+  // Without this, "update link" can only re-type a password. An Item that has
+  // lost its accounts (Plaid's NO_ACCOUNTS) then fails identically after every
+  // press, because nothing in the flow ever re-opens the account picker — and at
+  // a non-OAuth institution the picker only appears when we ask for it.
+  it('enables Account Select in update mode so a link with no accounts can be repaired', async () => {
+    await createLinkToken('local-user', undefined, 'access-abc');
+    expect(lastRequest().update).toEqual({ account_selection_enabled: true });
+  });
+
+  it('does not send update options when adding a new bank', async () => {
+    await createLinkToken('local-user');
+    expect(lastRequest().update).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## The bug

"Update link" could only ever re-type a password. `createLinkToken` built the update-mode token with `access_token` alone, and plain update mode re-authorizes credentials without ever re-opening the account picker.

So an Item that has *lost* its accounts — Plaid's `NO_ACCOUNTS`, typically after the institution renumbers an account or an earlier Account Select choice stops matching anything — fails identically after every press. The button is a no-op for precisely the failure it looks like it should fix.

## How it surfaced

A live Betterment link (`ins_115605`) stopped syncing. The tell is that the Item itself looks perfectly healthy:

```
/item/get          error: null,  update_type: background
/accounts/get      NO_ACCOUNTS — no valid accounts were found for this item
/transactions/sync NO_ACCOUNTS — same
```

Betterment is `oauth: false`, so there was no institution-side account picker to fall back on either. Pressing update link re-authenticated fine and changed nothing.

## The fix

Pass `update: { account_selection_enabled: true }` on the update-mode token so Link re-presents the account picker. US OAuth institutions always show their own picker regardless of the flag — the non-OAuth ones are the ones this rescues.

Both surfaces pick it up: the TUI's `[u]` (`scripts/link.ts`) and the GUI's update link (`gui/main/plaid-link.ts`) share `createFlowLinkToken`.

## Verification

- Confirmed against Plaid **production** for the affected item — the request is accepted and mints a token, so the flag isn't rejected for this institution.
- Then verified end-to-end in the real app: update link now shows the account picker, re-selecting the account repairs the connection, and it syncs.
- Two tests added in `tests/plaid-link-token.test.ts` — Account Select is on in update mode, and no `update` block is sent when adding a new bank.
- `tsc --noEmit` clean. Full suite passes except a pre-existing Canvas render failure in `tests/tui/screens.test.tsx` that fails identically on `dev` without these changes.

## Known follow-on

If the institution hands back a *new* `account_id`, `core/sync.ts:52` inserts it as a new account row and the old row stays behind with its history. The user has to re-nickname the new row and exclude the old one. Out of scope here, but worth a look separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KNFbGkZPsz3VXe8U1DBMQk