### PR TITLE
feat: merge category and name rules into one unified rule form

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,10 @@ out/
 release/
 test-results/
 playwright-report/
+
+# Fiefdom (local-only, per-machine)
+.fiefdom/fiefs.json
+.fiefdom/fiefs/
+.fiefdom/worktrees/
+.fiefdom/bin/
+.fiefdom/cross-fief-requests.log

--- a/core/rules-merge.ts
+++ b/core/rules-merge.ts
@@ -1,0 +1,114 @@
+import type { Rule, NameRule } from './queries.js';
+
+/**
+ * One row of the unified rule list: a category rule, a name rule, or both when
+ * the two describe the same match (see `ruleKey`).
+ */
+export type MergedRule = {
+  /**
+   * Stable row identity, unique within a merged list: the ids of the rules
+   * behind the row, `categoryRuleId:nameRuleId` with a missing side left empty.
+   * Not the pairing key (see `ruleKey`) -- two category rules can share that
+   * one. Rule ids survive a reload, so this key survives a refresh too.
+   */
+  key: string;
+  pattern: string;
+  matchType: string;
+  minAmount: number | null;
+  maxAmount: number | null;
+  accountId: string | null;
+  /** null when this row has no category rule. */
+  category: string | null;
+  categoryRuleId: number | null;
+  priority: number | null;
+  /** null when this row has no name rule. */
+  replacement: string | null;
+  nameRuleId: number | null;
+};
+
+/** ASCII unit separator: cannot occur in a pattern or an account id. */
+const SEP = '\u001f';
+
+/**
+ * A category rule and a name rule describe the same row when their match type,
+ * pattern, account and amount bounds all agree. A null account/bound normalizes
+ * to the empty string, which keeps null distinct from 0 (empty vs "0").
+ */
+export function ruleKey(r: {
+  match_type: string;
+  pattern: string;
+  account_id: string | null;
+  min_amount: number | null;
+  max_amount: number | null;
+}): string {
+  return [
+    r.match_type,
+    r.pattern,
+    r.account_id ?? '',
+    r.min_amount === null ? '' : String(r.min_amount),
+    r.max_amount === null ? '' : String(r.max_amount),
+  ].join(SEP);
+}
+
+/**
+ * Merges category rules and name rules into one list, pairing rows that share a
+ * `ruleKey`. Every input appears exactly once: pairing consumes a name rule, so
+ * two category rules with the same key and a single name rule available yield
+ * one paired row and one category-only row.
+ *
+ * Ordering is stable, because a TUI cursor rides on it: rows derived from
+ * `rules` come first in `rules` order, then the leftover name-only rows in
+ * `nameRules` order.
+ */
+export function mergeRules(rules: Rule[], nameRules: NameRule[]): MergedRule[] {
+  // A queue of name-rule indices per key, so each name rule is consumed by at
+  // most one category rule.
+  const pending = new Map<string, number[]>();
+  nameRules.forEach((n, i) => {
+    const key = ruleKey(n);
+    const queue = pending.get(key);
+    if (queue) queue.push(i);
+    else pending.set(key, [i]);
+  });
+
+  const merged: MergedRule[] = [];
+  const paired = new Array<boolean>(nameRules.length).fill(false);
+
+  for (const r of rules) {
+    const idx = pending.get(ruleKey(r))?.shift();
+    const name = idx === undefined ? undefined : nameRules[idx];
+    if (idx !== undefined) paired[idx] = true;
+    merged.push({
+      key: `${r.id}:${name ? name.id : ''}`,
+      pattern: r.pattern,
+      matchType: r.match_type,
+      minAmount: r.min_amount,
+      maxAmount: r.max_amount,
+      accountId: r.account_id,
+      category: r.category,
+      categoryRuleId: r.id,
+      priority: r.priority,
+      replacement: name ? name.replacement : null,
+      nameRuleId: name ? name.id : null,
+    });
+  }
+
+  nameRules.forEach((n, i) => {
+    if (paired[i]) return;
+    merged.push({
+      key: `:${n.id}`,
+      pattern: n.pattern,
+      matchType: n.match_type,
+      minAmount: n.min_amount,
+      maxAmount: n.max_amount,
+      accountId: n.account_id,
+      category: null,
+      categoryRuleId: null,
+      priority: null,
+      replacement: n.replacement,
+      nameRuleId: n.id,
+    });
+  });
+
+  return merged;
+}

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -153,14 +153,17 @@ Three sections, cycle with `Tab`: **Rules**, **Tag Rules**, **Categories**.
 
 | Key | Action |
 |-----|--------|
+| `↑ ↓` | Navigate |
 | `/` | Search rules |
 | `a` | Add rule |
 | `Enter` | Edit selected rule |
 | `x` | Delete selected rule |
 
-The **Rules** list shows category rules and name rules in one table — `TYPE | PATTERN | AMOUNT | CATEGORY | NAME` — and a rule that sets both a category and a display name is one row.
+The **Rules** list shows category rules and name rules in one table — `TYPE | PATTERN | AMOUNT | CATEGORY | NAME` — and a rule that sets both a category and a display name is one row. A rule scoped to one account shows `@account` at the end of its row.
 
-The **rule form** is a single panel with fields navigated by `↑ ↓`: Pattern, Match type, Min $, Max $, Category, Display name, Account. `← →` cycles/toggles the active field. A new rule opens with Category on `— none —`, so a pattern on its own is not yet saveable: `Enter` saves once there is a pattern plus a category, a display name, or both; with a pattern but neither, it moves the field cursor to Category to point at what is missing; with no pattern it does nothing. One save writes a category rule, a name rule, or both, and clearing a field on an existing rule deletes that side — set Category to `— none —` (labelled `— none (removes rule) —` while editing a rule that has a category) to drop the category rule, empty Display name to drop the name rule. `x` on a row deletes both underlying records. Matching is substring or regex with optional min/max amount filters, and applies to both halves of the rule at once.
+The **rule form** is a single panel with fields navigated by `↑ ↓`: Pattern, Match type, Min $, Max $, Category, Display name, Account. `← →` cycles/toggles the active field; **Account** scopes the rule to a single account and defaults to all of them.
+
+A new rule opens with Category on `— none —`, so a pattern on its own is not yet saveable: `Enter` saves once there is a pattern plus a category, a display name, or both; with a pattern but neither, it moves the field cursor to Category to point at what is missing; with no pattern it does nothing. One save writes a category rule, a name rule, or both, and clearing a field on an existing rule deletes that side — set Category to `— none —` (labelled `— none (removes rule) —` while editing a rule that has a category) to drop the category rule, empty Display name to drop the name rule. `x` on a row deletes both underlying records. Matching is substring or regex with optional min/max amount filters, and applies to both halves of the rule at once.
 
 The **tag rule form** has: Match type (`all` / `name` / `regex`), Pattern (hidden for `all`), Min $, Max $, Tag, Account. It shows a live count of the transactions that match; saving tags them, and tags you removed by hand stay removed. Deleting a tag rule leaves existing tags in place.
 
@@ -168,6 +171,7 @@ The **tag rule form** has: Match type (`all` / `name` / `regex`), Pattern (hidde
 
 | Key | Action |
 |-----|--------|
+| `↑ ↓` | Select category |
 | `a` | Add new category |
 | `Enter` | Edit selected category (Name, Flexibility, Hidden — navigated with `↑ ↓`) |
 | `x` | Delete category (resets affected transactions to Uncategorized) |

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -147,9 +147,9 @@ Liquid assets = cash + brokerage (excludes 401k, IRA, pension).
 
 ## Rules `[7]`
 
-Three sections, cycle with `Tab`: **Category Rules**, **Name Rules**, **Categories**.
+Three sections, cycle with `Tab`: **Rules**, **Tag Rules**, **Categories**.
 
-**Category Rules / Name Rules:**
+**Rules / Tag Rules:**
 
 | Key | Action |
 |-----|--------|
@@ -158,7 +158,11 @@ Three sections, cycle with `Tab`: **Category Rules**, **Name Rules**, **Categori
 | `Enter` | Edit selected rule |
 | `x` | Delete selected rule |
 
-The **rule form** is a single panel with fields navigated by `↑ ↓`: Pattern, Match type, Min $, Max $, Category (rules) or Replacement (name rules). `← →` cycles/toggles the active field. Category rules support substring and regex matching with optional min/max amount filters. Name rules support the same matching plus a replacement display name.
+The **Rules** list shows category rules and name rules in one table — `TYPE | PATTERN | AMOUNT | CATEGORY | NAME` — and a rule that sets both a category and a display name is one row.
+
+The **rule form** is a single panel with fields navigated by `↑ ↓`: Pattern, Match type, Min $, Max $, Category, Display name, Account. `← →` cycles/toggles the active field. A new rule opens with Category on `— none —`, so a pattern on its own is not yet saveable: `Enter` saves once there is a pattern plus a category, a display name, or both; with a pattern but neither, it moves the field cursor to Category to point at what is missing; with no pattern it does nothing. One save writes a category rule, a name rule, or both, and clearing a field on an existing rule deletes that side — set Category to `— none —` (labelled `— none (removes rule) —` while editing a rule that has a category) to drop the category rule, empty Display name to drop the name rule. `x` on a row deletes both underlying records. Matching is substring or regex with optional min/max amount filters, and applies to both halves of the rule at once.
+
+The **tag rule form** has: Match type (`all` / `name` / `regex`), Pattern (hidden for `all`), Min $, Max $, Tag, Account. It shows a live count of the transactions that match; saving tags them, and tags you removed by hand stay removed. Deleting a tag rule leaves existing tags in place.
 
 **Categories:**
 

--- a/gui/renderer/src/screens/Rules.module.css
+++ b/gui/renderer/src/screens/Rules.module.css
@@ -194,6 +194,12 @@
   font-size: 13px;
 }
 
+.saveHint {
+  margin: 10px 0 0;
+  font-size: 12.5px;
+  color: var(--text-dim);
+}
+
 .modalInput {
   width: 100%;
 }

--- a/gui/renderer/src/screens/Rules.tsx
+++ b/gui/renderer/src/screens/Rules.tsx
@@ -6,12 +6,13 @@ import { Modal } from '../components/Modal.js';
 import { useScreenKeys } from '../hooks/useScreenKeys.js';
 import { KeyHints } from '../components/KeyHints.js';
 import { fmt } from '../../../../core/fmt.js';
-import type { Rule, NameRule, TagRuleRow, LinkedAccount } from '../../../../core/queries.js';
+import { mergeRules, type MergedRule } from '../../../../core/rules-merge.js';
+import type { TagRuleRow, LinkedAccount } from '../../../../core/queries.js';
 import type { TagOption } from '../../../../core/tags.js';
 import type { TagMatchType } from '../../../../core/tag-rules.js';
 import styles from './Rules.module.css';
 
-type Tab = 'rules' | 'names' | 'tags' | 'categories';
+type Tab = 'rules' | 'tags' | 'categories';
 
 const FLEX_OPTIONS = ['', 'fixed', 'flexible', 'discretionary'] as const;
 
@@ -47,14 +48,13 @@ export function Rules() {
     return a ? (a.nickname ?? a.name) : id;
   };
 
-  const [ruleForm, setRuleForm] = useState<{ editing: Rule | null } | null>(null);
-  const [nameRuleForm, setNameRuleForm] = useState<{ editing: NameRule | null } | null>(null);
+  const [ruleForm, setRuleForm] = useState<{ editing: MergedRule | null } | null>(null);
   const [tagRuleForm, setTagRuleForm] = useState<{ editing: TagRuleRow | null } | null>(null);
   const [addCatOpen, setAddCatOpen] = useState(false);
   const [renameCat, setRenameCat] = useState<string | null>(null);
 
   const searchRef = useRef<HTMLInputElement>(null);
-  const TABS: Tab[] = ['rules', 'names', 'tags', 'categories'];
+  const TABS: Tab[] = ['rules', 'tags', 'categories'];
   useScreenKeys({
     Tab: () => {
       setSearch('');
@@ -63,20 +63,25 @@ export function Rules() {
     '/': () => searchRef.current?.focus(),
     a: () => {
       if (tab === 'rules') setRuleForm({ editing: null });
-      else if (tab === 'names') setNameRuleForm({ editing: null });
       else if (tab === 'tags') setTagRuleForm({ editing: null });
       else setAddCatOpen(true);
     },
     Escape: () => setSearch(''),
   });
 
+  // Category rules and name rules live in separate tables, but a row that both
+  // renames and categorizes a merchant is one rule to a person — merge them.
+  const merged = mergeRules(rules, nameRules);
+
   const q = search.toLowerCase();
-  const filteredRules = q
-    ? rules.filter((r) => r.pattern.toLowerCase().includes(q) || r.category.toLowerCase().includes(q))
-    : rules;
-  const filteredNameRules = q
-    ? nameRules.filter((r) => r.pattern.toLowerCase().includes(q) || r.replacement.toLowerCase().includes(q))
-    : nameRules;
+  const filteredMerged = q
+    ? merged.filter(
+        (r) =>
+          r.pattern.toLowerCase().includes(q) ||
+          (r.category?.toLowerCase().includes(q) ?? false) ||
+          (r.replacement?.toLowerCase().includes(q) ?? false),
+      )
+    : merged;
   const filteredTagRules = q
     ? tagRules.filter((r) => r.pattern.toLowerCase().includes(q) || r.tag_name.toLowerCase().includes(q))
     : tagRules;
@@ -88,10 +93,7 @@ export function Rules() {
         <h1 className={styles.title}>Rules</h1>
         <div className={styles.tabs}>
           <button className={tab === 'rules' ? styles.tabActive : styles.tab} onClick={() => setTab('rules')}>
-            Category rules ({rules.length})
-          </button>
-          <button className={tab === 'names' ? styles.tabActive : styles.tab} onClick={() => setTab('names')}>
-            Name rules ({nameRules.length})
+            Rules ({merged.length})
           </button>
           <button className={tab === 'tags' ? styles.tabActive : styles.tab} onClick={() => setTab('tags')}>
             Tag rules ({tagRules.length})
@@ -120,7 +122,6 @@ export function Rules() {
           className={styles.addBtn}
           onClick={() => {
             if (tab === 'rules') setRuleForm({ editing: null });
-            else if (tab === 'names') setNameRuleForm({ editing: null });
             else if (tab === 'tags') setTagRuleForm({ editing: null });
             else setAddCatOpen(true);
           }}
@@ -131,8 +132,8 @@ export function Rules() {
 
       {tab === 'rules' && (
         <section className={styles.panel}>
-          {filteredRules.length === 0 ? (
-            <p className="dim">{search ? 'No rules match.' : 'No category rules yet.'}</p>
+          {filteredMerged.length === 0 ? (
+            <p className="dim">{search ? 'No rules match.' : 'No rules yet.'}</p>
           ) : (
             <table className={styles.table}>
               <thead>
@@ -141,72 +142,39 @@ export function Rules() {
                   <th className={styles.th}>Pattern</th>
                   <th className={styles.th}>Amount</th>
                   <th className={styles.th}>Category</th>
+                  <th className={styles.th}>Display name</th>
                   <th className={styles.th}>Priority</th>
                   <th className={styles.th}>Scope</th>
                   <th className={styles.th} />
                 </tr>
               </thead>
               <tbody>
-                {filteredRules.map((r) => (
-                  <tr key={r.id} className={styles.row} onClick={() => setRuleForm({ editing: r })}>
-                    <td className="dim">{r.match_type}</td>
+                {filteredMerged.map((r) => (
+                  <tr key={r.key} className={styles.row} onClick={() => setRuleForm({ editing: r })}>
+                    <td className="dim">{r.matchType}</td>
                     <td className={styles.tdPattern}>{r.pattern}</td>
-                    <td className="num dim">{amountLabel(r.min_amount, r.max_amount)}</td>
-                    <td className="accent">{r.category}</td>
-                    <td className="num dim">{r.priority}</td>
-                    <td className="dim">{r.account_id ? accountLabel(r.account_id) : 'All'}</td>
+                    <td className="num dim">{amountLabel(r.minAmount, r.maxAmount)}</td>
+                    <td className="accent">{r.category ?? ''}</td>
+                    <td className="warn">{r.replacement ?? ''}</td>
+                    <td className="num dim">{r.priority ?? ''}</td>
+                    <td className="dim">{r.accountId ? accountLabel(r.accountId) : 'All'}</td>
                     <td className={styles.tdActions}>
                       <button
                         className={`${styles.rowBtn} ${styles.rowBtnDanger}`}
                         onClick={async (e) => {
                           e.stopPropagation();
-                          const count = await api.rules.deleteCategoryRule(r.id);
-                          showStatus(`Rule deleted · recategorized ${count} transaction${count === 1 ? '' : 's'}`, 3000);
-                          reload();
-                        }}
-                      >
-                        delete
-                      </button>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          )}
-        </section>
-      )}
-
-      {tab === 'names' && (
-        <section className={styles.panel}>
-          {filteredNameRules.length === 0 ? (
-            <p className="dim">{search ? 'No name rules match.' : 'No name rules yet.'}</p>
-          ) : (
-            <table className={styles.table}>
-              <thead>
-                <tr>
-                  <th className={styles.th}>Type</th>
-                  <th className={styles.th}>Pattern</th>
-                  <th className={styles.th}>Amount</th>
-                  <th className={styles.th}>Display name</th>
-                  <th className={styles.th}>Scope</th>
-                  <th className={styles.th} />
-                </tr>
-              </thead>
-              <tbody>
-                {filteredNameRules.map((r) => (
-                  <tr key={r.id} className={styles.row} onClick={() => setNameRuleForm({ editing: r })}>
-                    <td className="dim">{r.match_type}</td>
-                    <td className={styles.tdPattern}>{r.pattern}</td>
-                    <td className="num dim">{amountLabel(r.min_amount, r.max_amount)}</td>
-                    <td className="warn">{r.replacement}</td>
-                    <td className="dim">{r.account_id ? accountLabel(r.account_id) : 'All'}</td>
-                    <td className={styles.tdActions}>
-                      <button
-                        className={`${styles.rowBtn} ${styles.rowBtnDanger}`}
-                        onClick={async (e) => {
-                          e.stopPropagation();
-                          await api.rules.deleteNameRule(r.id);
-                          showStatus('Name rule deleted');
+                          // One row, both underlying records.
+                          let recategorized: number | null = null;
+                          if (r.categoryRuleId !== null) {
+                            recategorized = await api.rules.deleteCategoryRule(r.categoryRuleId);
+                          }
+                          if (r.nameRuleId !== null) await api.rules.deleteNameRule(r.nameRuleId);
+                          showStatus(
+                            recategorized === null
+                              ? 'Rule deleted'
+                              : `Rule deleted · recategorized ${recategorized} transaction${recategorized === 1 ? '' : 's'}`,
+                            3000,
+                          );
                           reload();
                         }}
                       >
@@ -354,22 +322,9 @@ export function Rules() {
           categories={categories}
           accounts={accounts}
           onClose={() => setRuleForm(null)}
-          onSaved={(count) => {
+          onSaved={(message) => {
             setRuleForm(null);
-            showStatus(`Rule saved · recategorized ${count} transaction${count === 1 ? '' : 's'}`, 3000);
-            reload();
-          }}
-        />
-      )}
-
-      {nameRuleForm && (
-        <NameRuleFormModal
-          editing={nameRuleForm.editing}
-          accounts={accounts}
-          onClose={() => setNameRuleForm(null)}
-          onSaved={() => {
-            setNameRuleForm(null);
-            showStatus('Name rule saved');
+            showStatus(message, 3000);
             reload();
           }}
         />
@@ -422,7 +377,7 @@ export function Rules() {
   );
 }
 
-// ── Rule form (add/edit category rule) ──────────────────────────────────────
+// ── Rule form (add/edit — one rule writes a category rule, a name rule, or both) ─
 
 function RuleFormModal({
   editing,
@@ -431,18 +386,19 @@ function RuleFormModal({
   onClose,
   onSaved,
 }: {
-  editing: Rule | null;
+  editing: MergedRule | null;
   categories: string[];
   accounts: LinkedAccount[];
   onClose: () => void;
-  onSaved: (count: number) => void;
+  onSaved: (message: string) => void;
 }) {
   const [pattern, setPattern] = useState(editing?.pattern ?? '');
-  const [matchType, setMatchType] = useState<'name' | 'regex'>((editing?.match_type as 'name' | 'regex') ?? 'name');
-  const [minAmount, setMinAmount] = useState(editing?.min_amount !== null && editing ? String(editing.min_amount) : '');
-  const [maxAmount, setMaxAmount] = useState(editing?.max_amount !== null && editing ? String(editing.max_amount) : '');
-  const [category, setCategory] = useState(editing?.category ?? categories[0] ?? '');
-  const [accountId, setAccountId] = useState<string | null>(editing?.account_id ?? null);
+  const [matchType, setMatchType] = useState<'name' | 'regex'>((editing?.matchType as 'name' | 'regex') ?? 'name');
+  const [minAmount, setMinAmount] = useState(editing?.minAmount != null ? String(editing.minAmount) : '');
+  const [maxAmount, setMaxAmount] = useState(editing?.maxAmount != null ? String(editing.maxAmount) : '');
+  const [category, setCategory] = useState(editing?.category ?? '');
+  const [replacement, setReplacement] = useState(editing?.replacement ?? '');
+  const [accountId, setAccountId] = useState<string | null>(editing?.accountId ?? null);
   const [matchCount, setMatchCount] = useState(0);
   const [error, setError] = useState('');
 
@@ -457,26 +413,59 @@ function RuleFormModal({
     }
   }, [pattern, matchType]);
 
+  const displayName = replacement.trim();
+  // A rule that neither categorizes nor renames does nothing — don't let it save.
+  const canSave = pattern.trim().length > 0 && (category !== '' || displayName.length > 0);
+
   async function save() {
-    if (!pattern.trim() || !category) return;
+    if (!canSave) return;
+    const min = minAmount.trim() ? parseFloat(minAmount) : null;
+    const max = maxAmount.trim() ? parseFloat(maxAmount) : null;
     try {
-      const count = await api.rules.saveCategoryRule({
-        pattern,
-        matchType,
-        category,
-        minAmount: minAmount.trim() ? parseFloat(minAmount) : null,
-        maxAmount: maxAmount.trim() ? parseFloat(maxAmount) : null,
-        accountId,
-        editingId: editing?.id ?? null,
-      });
-      onSaved(count);
+      // Category first: both writes share the pattern, so a bad regex is
+      // rejected by the first one and cannot half-apply.
+      let recategorized: number | null = null;
+      if (category) {
+        recategorized = await api.rules.saveCategoryRule({
+          pattern,
+          matchType,
+          category,
+          minAmount: min,
+          maxAmount: max,
+          accountId,
+          editingId: editing?.categoryRuleId ?? null,
+        });
+      } else if (editing?.categoryRuleId != null) {
+        recategorized = await api.rules.deleteCategoryRule(editing.categoryRuleId);
+      }
+
+      if (displayName) {
+        await api.rules.saveNameRule({
+          pattern,
+          matchType,
+          replacement: displayName,
+          minAmount: min,
+          maxAmount: max,
+          accountId,
+          editingId: editing?.nameRuleId ?? null,
+        });
+      } else if (editing?.nameRuleId != null) {
+        await api.rules.deleteNameRule(editing.nameRuleId);
+      }
+
+      const parts = ['Rule saved'];
+      if (recategorized !== null) {
+        parts.push(`recategorized ${recategorized} transaction${recategorized === 1 ? '' : 's'}`);
+      }
+      if (displayName) parts.push(`shown as "${displayName}"`);
+      onSaved(parts.join(' · '));
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to save rule');
     }
   }
 
   return (
-    <Modal title={editing ? 'Edit category rule' : 'New category rule'} onClose={onClose} accent="var(--manual)">
+    <Modal title={editing ? 'Edit rule' : 'New rule'} onClose={onClose} accent="var(--manual)">
       <div className={styles.formGrid}>
         <label>Pattern</label>
         <input value={pattern} onChange={(e) => setPattern(e.target.value)} autoFocus placeholder="e.g. UBER or ^AMZN" />
@@ -491,106 +480,13 @@ function RuleFormModal({
         <input value={maxAmount} onChange={(e) => setMaxAmount(e.target.value.replace(/[^\d.\-]/g, ''))} />
         <label>Category</label>
         <select value={category} onChange={(e) => setCategory(e.target.value)}>
+          <option value="">{editing?.categoryRuleId != null ? '— none (removes rule) —' : '— none —'}</option>
           {categories.map((c) => (
             <option key={c} value={c}>
               {c}
             </option>
           ))}
         </select>
-        <label>Account</label>
-        <select value={accountId ?? ''} onChange={(e) => setAccountId(e.target.value || null)}>
-          <option value="">All accounts</option>
-          {accounts.map((a) => (
-            <option key={a.id} value={a.id}>
-              {a.nickname ?? a.name}
-            </option>
-          ))}
-        </select>
-      </div>
-      {pattern.trim() && (
-        <p className={styles.matchHint}>
-          <span className="warn">{matchCount} transactions match</span>
-          <span className="dim"> · saving recategorizes them</span>
-        </p>
-      )}
-      {error && <p className="neg">{error}</p>}
-      <div className={styles.modalActions}>
-        <button className={styles.btnSecondary} onClick={onClose}>
-          Cancel
-        </button>
-        <button className={styles.btnPrimary} onClick={() => void save()} disabled={!pattern.trim() || !category}>
-          Save
-        </button>
-      </div>
-    </Modal>
-  );
-}
-
-// ── Name rule form ──────────────────────────────────────────────────────────
-
-function NameRuleFormModal({
-  editing,
-  accounts,
-  onClose,
-  onSaved,
-}: {
-  editing: NameRule | null;
-  accounts: LinkedAccount[];
-  onClose: () => void;
-  onSaved: () => void;
-}) {
-  const [pattern, setPattern] = useState(editing?.pattern ?? '');
-  const [matchType, setMatchType] = useState<'name' | 'regex'>((editing?.match_type as 'name' | 'regex') ?? 'name');
-  const [minAmount, setMinAmount] = useState(editing?.min_amount !== null && editing ? String(editing.min_amount) : '');
-  const [maxAmount, setMaxAmount] = useState(editing?.max_amount !== null && editing ? String(editing.max_amount) : '');
-  const [replacement, setReplacement] = useState(editing?.replacement ?? '');
-  const [accountId, setAccountId] = useState<string | null>(editing?.account_id ?? null);
-  const [matchCount, setMatchCount] = useState(0);
-  const [error, setError] = useState('');
-
-  useEffect(() => {
-    if (pattern.trim()) {
-      api.rules
-        .countPatternMatches(pattern, matchType)
-        .then(setMatchCount)
-        .catch(() => setMatchCount(0));
-    } else {
-      setMatchCount(0);
-    }
-  }, [pattern, matchType]);
-
-  async function save() {
-    if (!pattern.trim() || !replacement.trim()) return;
-    try {
-      await api.rules.saveNameRule({
-        pattern,
-        matchType,
-        replacement: replacement.trim(),
-        minAmount: minAmount.trim() ? parseFloat(minAmount) : null,
-        maxAmount: maxAmount.trim() ? parseFloat(maxAmount) : null,
-        accountId,
-        editingId: editing?.id ?? null,
-      });
-      onSaved();
-    } catch (e) {
-      setError(e instanceof Error ? e.message : 'Failed to save name rule');
-    }
-  }
-
-  return (
-    <Modal title={editing ? 'Edit name rule' : 'New name rule'} onClose={onClose} accent="var(--warning)">
-      <div className={styles.formGrid}>
-        <label>Pattern</label>
-        <input value={pattern} onChange={(e) => setPattern(e.target.value)} autoFocus placeholder="e.g. AMZN Mktp" />
-        <label>Match type</label>
-        <select value={matchType} onChange={(e) => setMatchType(e.target.value as 'name' | 'regex')}>
-          <option value="name">name (substring)</option>
-          <option value="regex">regex</option>
-        </select>
-        <label>Min $ (optional)</label>
-        <input value={minAmount} onChange={(e) => setMinAmount(e.target.value.replace(/[^\d.\-]/g, ''))} />
-        <label>Max $ (optional)</label>
-        <input value={maxAmount} onChange={(e) => setMaxAmount(e.target.value.replace(/[^\d.\-]/g, ''))} />
         <label>Display name</label>
         <input value={replacement} onChange={(e) => setReplacement(e.target.value)} placeholder="e.g. Amazon" />
         <label>Account</label>
@@ -606,18 +502,18 @@ function NameRuleFormModal({
       {pattern.trim() && (
         <p className={styles.matchHint}>
           <span className="warn">{matchCount} transactions match</span>
+          {category && <span className="dim"> · saving recategorizes them</span>}
         </p>
       )}
       {error && <p className="neg">{error}</p>}
+      {pattern.trim() && !canSave && (
+        <p className={styles.saveHint}>Pick a category or enter a display name to save.</p>
+      )}
       <div className={styles.modalActions}>
         <button className={styles.btnSecondary} onClick={onClose}>
           Cancel
         </button>
-        <button
-          className={styles.btnPrimary}
-          onClick={() => void save()}
-          disabled={!pattern.trim() || !replacement.trim()}
-        >
+        <button className={styles.btnPrimary} onClick={() => void save()} disabled={!canSave}>
           Save
         </button>
       </div>

--- a/tests/gui-bridge-parity.test.ts
+++ b/tests/gui-bridge-parity.test.ts
@@ -42,6 +42,9 @@ const EXPECTED_UNBRIDGED: Record<string, string> = {
   isSignificantDelta: 'renderer imports pure core/scorecard.ts directly',
   ratioLabel: 'renderer imports pure core/scorecard.ts directly',
 
+  // Pure rule-merge helper -- renderer imports core/rules-merge.ts directly
+  mergeRules: 'renderer imports pure core/rules-merge.ts directly',
+
   // Electron-side bridge namespaces live in gui/main/bridge.ts (not registry.ts)
   getDefaultDaysRequested: 'bridge plaid namespace (gui/main/bridge.ts)',
 

--- a/tests/gui/rules.test.tsx
+++ b/tests/gui/rules.test.tsx
@@ -26,12 +26,38 @@ beforeEach(async () => {
 
 afterEach(() => cleanup());
 
+/** Row count in a table, so a test can prove both underlying records changed. */
+async function tableCount(table: string): Promise<number> {
+  const res = await db.execute(`SELECT COUNT(*) AS c FROM ${table}`);
+  return Number((res.rows[0] as unknown as { c: number }).c);
+}
+
+/** A name rule whose match (type/pattern/account/amounts) equals the seeded
+ *  'Whole Foods' category rule, so the two merge into one row. */
+async function seedPairedNameRule() {
+  await db.execute(
+    `INSERT INTO name_rules (match_type, pattern, replacement, min_amount, max_amount, account_id)
+     VALUES ('name', 'Whole Foods', 'WF Market', NULL, NULL, NULL)`,
+  );
+}
+
 describe('GUI Rules', () => {
   it('lists the seeded category rule', async () => {
     renderScreen(<Rules />);
     await waitFor(() => expect(screen.getByText('Whole Foods')).toBeTruthy());
-    expect(screen.getByRole('button', { name: 'Category rules (1)' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Rules (1)' })).toBeTruthy();
     expect(screen.getByText('Grocery')).toBeTruthy();
+  });
+
+  it('shows a category rule and its matching name rule as one row', async () => {
+    await seedPairedNameRule();
+    renderScreen(<Rules />);
+    await waitFor(() => expect(screen.getByText('Whole Foods')).toBeTruthy());
+    // Two records, one row.
+    expect(screen.getByRole('button', { name: 'Rules (1)' })).toBeTruthy();
+    const row = screen.getByText('Whole Foods').closest('tr')!;
+    expect(row.textContent).toContain('Grocery');
+    expect(row.textContent).toContain('WF Market');
   });
 
   it('creates a category rule with live match count and recategorizes', async () => {
@@ -44,7 +70,113 @@ describe('GUI Rules', () => {
     await userEvent.selectOptions(selects[1], 'Dining'); // [0] = match type, [1] = category
     await userEvent.click(screen.getByRole('button', { name: 'Save' }));
     await waitFor(() => expect(screen.getByText(/recategorized \d+ transactions?/)).toBeTruthy());
-    expect(screen.getByRole('button', { name: 'Category rules (2)' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Rules (2)' })).toBeTruthy();
+    expect(await tableCount('name_rules')).toBe(0);
+  });
+
+  it('creates a category rule and a name rule in one save', async () => {
+    renderScreen(<Rules />);
+    await waitFor(() => expect(screen.getByText('Whole Foods')).toBeTruthy());
+    await userEvent.click(screen.getByRole('button', { name: '+ Add' }));
+    await userEvent.type(screen.getByPlaceholderText('e.g. UBER or ^AMZN'), 'Trader');
+    await userEvent.selectOptions(screen.getAllByRole('combobox')[1], 'Dining');
+    await userEvent.type(screen.getByPlaceholderText('e.g. Amazon'), 'TJs');
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(screen.getByText(/Rule saved/)).toBeTruthy());
+    expect(await tableCount('category_rules')).toBe(2);
+    expect(await tableCount('name_rules')).toBe(1);
+    // Both records land on one row.
+    expect(screen.getByRole('button', { name: 'Rules (2)' })).toBeTruthy();
+    const row = screen.getByText('Trader').closest('tr')!;
+    expect(row.textContent).toContain('Dining');
+    expect(row.textContent).toContain('TJs');
+  });
+
+  it('creates a name-only rule when the category is "— none —"', async () => {
+    renderScreen(<Rules />);
+    await waitFor(() => expect(screen.getByText('Whole Foods')).toBeTruthy());
+    await userEvent.click(screen.getByRole('button', { name: '+ Add' }));
+    await userEvent.type(screen.getByPlaceholderText('e.g. UBER or ^AMZN'), 'AMZN');
+    await userEvent.selectOptions(screen.getAllByRole('combobox')[1], '');
+    await userEvent.type(screen.getByPlaceholderText('e.g. Amazon'), 'Amazon');
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(screen.getByText(/Rule saved/)).toBeTruthy());
+    expect(await tableCount('name_rules')).toBe(1);
+    expect(await tableCount('category_rules')).toBe(1); // only the seeded one
+    expect(screen.getByRole('button', { name: 'Rules (2)' })).toBeTruthy();
+    const row = screen.getByText('AMZN').closest('tr')!;
+    expect(row.textContent).toContain('Amazon');
+  });
+
+  it('starts a new rule with no category, so a rename-only rule cannot categorize by accident', async () => {
+    renderScreen(<Rules />);
+    await waitFor(() => expect(screen.getByText('Whole Foods')).toBeTruthy());
+    await userEvent.click(screen.getByRole('button', { name: '+ Add' }));
+    const categorySelect = screen.getAllByRole('combobox')[1] as HTMLSelectElement;
+    expect(categorySelect.value).toBe('');
+    expect(screen.getByRole('option', { name: '— none —' })).toBeTruthy();
+  });
+
+  it('disables Save until a category or a display name is set, and says why', async () => {
+    renderScreen(<Rules />);
+    await waitFor(() => expect(screen.getByText('Whole Foods')).toBeTruthy());
+    await userEvent.click(screen.getByRole('button', { name: '+ Add' }));
+    const save = screen.getByRole('button', { name: 'Save' }) as HTMLButtonElement;
+    expect(save.disabled).toBe(true); // no pattern yet
+    // Nothing typed yet: the form isn't asking for anything, so stay quiet.
+    expect(screen.queryByText('Pick a category or enter a display name to save.')).toBeNull();
+
+    await userEvent.type(screen.getByPlaceholderText('e.g. UBER or ^AMZN'), 'AMZN');
+    expect(save.disabled).toBe(true); // a rule that neither categorizes nor renames
+    expect(screen.getByText('Pick a category or enter a display name to save.')).toBeTruthy();
+
+    await userEvent.type(screen.getByPlaceholderText('e.g. Amazon'), 'Amazon');
+    expect(save.disabled).toBe(false);
+    expect(screen.queryByText('Pick a category or enter a display name to save.')).toBeNull();
+  });
+
+  it('hides the hint once a category alone is picked', async () => {
+    renderScreen(<Rules />);
+    await waitFor(() => expect(screen.getByText('Whole Foods')).toBeTruthy());
+    await userEvent.click(screen.getByRole('button', { name: '+ Add' }));
+    await userEvent.type(screen.getByPlaceholderText('e.g. UBER or ^AMZN'), 'AMZN');
+    expect(screen.getByText('Pick a category or enter a display name to save.')).toBeTruthy();
+    await userEvent.selectOptions(screen.getAllByRole('combobox')[1], 'Shopping');
+    expect(screen.queryByText('Pick a category or enter a display name to save.')).toBeNull();
+    expect((screen.getByRole('button', { name: 'Save' }) as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it('spells out that "none" removes an existing category rule', async () => {
+    await seedPairedNameRule();
+    renderScreen(<Rules />);
+    await waitFor(() => expect(screen.getByText('Whole Foods')).toBeTruthy());
+    await userEvent.click(screen.getByText('Whole Foods'));
+    expect(screen.getByRole('option', { name: '— none (removes rule) —' })).toBeTruthy();
+    expect(screen.queryByRole('option', { name: '— none —' })).toBeNull();
+  });
+
+  it('keeps the plain "none" label on a row with no category rule', async () => {
+    await db.execute(
+      `INSERT INTO name_rules (match_type, pattern, replacement, min_amount, max_amount, account_id)
+       VALUES ('name', 'AMZN', 'Amazon', NULL, NULL, NULL)`,
+    );
+    renderScreen(<Rules />);
+    await waitFor(() => expect(screen.getByText('AMZN')).toBeTruthy());
+    await userEvent.click(screen.getByText('AMZN'));
+    expect(screen.getByRole('option', { name: '— none —' })).toBeTruthy();
+    expect(screen.queryByRole('option', { name: '— none (removes rule) —' })).toBeNull();
+  });
+
+  it('removes the category rule when an edited row is set to "none"', async () => {
+    await seedPairedNameRule();
+    renderScreen(<Rules />);
+    await waitFor(() => expect(screen.getByText('Whole Foods')).toBeTruthy());
+    await userEvent.click(screen.getByText('Whole Foods'));
+    await userEvent.selectOptions(screen.getAllByRole('combobox')[1], '');
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(screen.getByText(/Rule saved/)).toBeTruthy());
+    expect(await tableCount('category_rules')).toBe(0);
+    expect(await tableCount('name_rules')).toBe(1);
   });
 
   it('deletes a rule', async () => {
@@ -53,20 +185,31 @@ describe('GUI Rules', () => {
     const row = screen.getByText('Whole Foods').closest('tr')!;
     await userEvent.click(Array.from(row.querySelectorAll('button')).find((b) => b.textContent === 'delete')!);
     await waitFor(() => expect(screen.getByText(/Rule deleted · recategorized \d+ transactions?/)).toBeTruthy());
-    expect(screen.getByRole('button', { name: 'Category rules (0)' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Rules (0)' })).toBeTruthy();
   });
 
-  it('creates a name rule', async () => {
+  it('deleting a merged row removes both underlying records', async () => {
+    await seedPairedNameRule();
     renderScreen(<Rules />);
     await waitFor(() => expect(screen.getByText('Whole Foods')).toBeTruthy());
-    await userEvent.click(screen.getByRole('button', { name: 'Name rules (0)' }));
-    await waitFor(() => expect(screen.getByText('No name rules yet.')).toBeTruthy());
-    await userEvent.click(screen.getByRole('button', { name: '+ Add' }));
-    await userEvent.type(screen.getByPlaceholderText('e.g. AMZN Mktp'), 'AMZN');
-    await userEvent.type(screen.getByPlaceholderText('e.g. Amazon'), 'Amazon');
+    const row = screen.getByText('Whole Foods').closest('tr')!;
+    await userEvent.click(Array.from(row.querySelectorAll('button')).find((b) => b.textContent === 'delete')!);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Rules (0)' })).toBeTruthy());
+    expect(await tableCount('category_rules')).toBe(0);
+    expect(await tableCount('name_rules')).toBe(0);
+  });
+
+  it('drops the name rule when the display name is cleared on an existing row', async () => {
+    await seedPairedNameRule();
+    renderScreen(<Rules />);
+    await waitFor(() => expect(screen.getByText('WF Market')).toBeTruthy());
+    await userEvent.click(screen.getByText('Whole Foods'));
+    const displayName = screen.getByPlaceholderText('e.g. Amazon');
+    await userEvent.clear(displayName);
     await userEvent.click(screen.getByRole('button', { name: 'Save' }));
-    await waitFor(() => expect(screen.getByText('Name rule saved')).toBeTruthy());
-    expect(screen.getByRole('button', { name: 'Name rules (1)' })).toBeTruthy();
+    await waitFor(() => expect(screen.getByText(/Rule saved/)).toBeTruthy());
+    expect(await tableCount('name_rules')).toBe(0);
+    expect(await tableCount('category_rules')).toBe(1);
   });
 
   it('categories tab lists categories with flexibility and visibility controls', async () => {

--- a/tests/rules-merge.test.ts
+++ b/tests/rules-merge.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect } from 'vitest';
+
+import type { Rule, NameRule } from '../core/queries.js';
+import { mergeRules, ruleKey } from '../core/rules-merge.js';
+
+function rule(over: Partial<Rule> & { id: number }): Rule {
+  return {
+    priority: 0,
+    match_type: 'contains',
+    pattern: 'amazon',
+    category: 'Shopping',
+    min_amount: null,
+    max_amount: null,
+    account_id: null,
+    ...over,
+  };
+}
+
+function nameRule(over: Partial<NameRule> & { id: number }): NameRule {
+  return {
+    match_type: 'contains',
+    pattern: 'amazon',
+    replacement: 'Amazon',
+    min_amount: null,
+    max_amount: null,
+    account_id: null,
+    ...over,
+  };
+}
+
+/** Merges and asserts the invariants: rows == inputs - pairs, and keys unique. */
+function expectInvariant(rules: Rule[], nameRules: NameRule[]) {
+  const merged = mergeRules(rules, nameRules);
+  const pairs = merged.filter((m) => m.categoryRuleId !== null && m.nameRuleId !== null).length;
+  expect(merged.length).toBe(rules.length + nameRules.length - pairs);
+  expect(new Set(merged.map((m) => m.key)).size).toBe(merged.length);
+  return merged;
+}
+
+describe('ruleKey', () => {
+  it('agrees across the two rule kinds when the five match fields match', () => {
+    expect(ruleKey(rule({ id: 1 }))).toBe(ruleKey(nameRule({ id: 9 })));
+  });
+
+  it('separates the fields so a pattern cannot spill into the account', () => {
+    const a = ruleKey(rule({ id: 1, pattern: 'a', account_id: 'b' }));
+    const b = ruleKey(rule({ id: 2, pattern: 'ab', account_id: null }));
+    expect(a).not.toBe(b);
+  });
+
+  it('keeps a null amount bound distinct from a zero bound', () => {
+    expect(ruleKey(rule({ id: 1, min_amount: null }))).not.toBe(
+      ruleKey(rule({ id: 2, min_amount: 0 })),
+    );
+  });
+});
+
+describe('mergeRules', () => {
+  it('pairs a category rule and a name rule that describe the same row', () => {
+    const merged = expectInvariant(
+      [rule({ id: 1, priority: 5, category: 'Shopping' })],
+      [nameRule({ id: 7, replacement: 'Amazon' })],
+    );
+    expect(merged).toHaveLength(1);
+    expect(merged[0]).toMatchObject({
+      pattern: 'amazon',
+      matchType: 'contains',
+      minAmount: null,
+      maxAmount: null,
+      accountId: null,
+      category: 'Shopping',
+      categoryRuleId: 1,
+      priority: 5,
+      replacement: 'Amazon',
+      nameRuleId: 7,
+    });
+  });
+
+  it('pairs on account and amount bounds, not just the pattern', () => {
+    const merged = expectInvariant(
+      [rule({ id: 1, account_id: 'acc1', min_amount: 10, max_amount: 20 })],
+      [nameRule({ id: 7, account_id: 'acc1', min_amount: 10, max_amount: 20 })],
+    );
+    expect(merged).toHaveLength(1);
+    expect(merged[0]).toMatchObject({
+      accountId: 'acc1',
+      minAmount: 10,
+      maxAmount: 20,
+      categoryRuleId: 1,
+      nameRuleId: 7,
+    });
+  });
+
+  it('leaves a category rule with no partner without a name side', () => {
+    const merged = expectInvariant([rule({ id: 1, priority: 3 })], []);
+    expect(merged).toHaveLength(1);
+    expect(merged[0]).toMatchObject({
+      category: 'Shopping',
+      categoryRuleId: 1,
+      priority: 3,
+      replacement: null,
+      nameRuleId: null,
+    });
+  });
+
+  it('leaves a name rule with no partner without a category side', () => {
+    const merged = expectInvariant([], [nameRule({ id: 7 })]);
+    expect(merged).toHaveLength(1);
+    expect(merged[0]).toMatchObject({
+      replacement: 'Amazon',
+      nameRuleId: 7,
+      category: null,
+      categoryRuleId: null,
+      priority: null,
+    });
+  });
+
+  it('does not pair a null amount bound with a zero bound', () => {
+    const merged = expectInvariant(
+      [rule({ id: 1, min_amount: null })],
+      [nameRule({ id: 7, min_amount: 0 })],
+    );
+    expect(merged).toHaveLength(2);
+    expect(merged[0]).toMatchObject({ categoryRuleId: 1, nameRuleId: null, minAmount: null });
+    expect(merged[1]).toMatchObject({ categoryRuleId: null, nameRuleId: 7, minAmount: 0 });
+  });
+
+  it('does not pair rules that differ only by account', () => {
+    const merged = expectInvariant(
+      [rule({ id: 1, account_id: null })],
+      [nameRule({ id: 7, account_id: 'acc1' })],
+    );
+    expect(merged).toHaveLength(2);
+    expect(merged.map((m) => [m.categoryRuleId, m.nameRuleId])).toEqual([
+      [1, null],
+      [null, 7],
+    ]);
+  });
+
+  it('gives a shared name rule to only the first of two duplicate category rules', () => {
+    const merged = expectInvariant(
+      [rule({ id: 1, category: 'Shopping' }), rule({ id: 2, category: 'Household' })],
+      [nameRule({ id: 7 })],
+    );
+    expect(merged).toHaveLength(2);
+    expect(merged[0]).toMatchObject({ categoryRuleId: 1, nameRuleId: 7, replacement: 'Amazon' });
+    expect(merged[1]).toMatchObject({ categoryRuleId: 2, nameRuleId: null, replacement: null });
+  });
+
+  it('pairs duplicate keys one-for-one when both sides have duplicates', () => {
+    const merged = expectInvariant(
+      [rule({ id: 1 }), rule({ id: 2 }), rule({ id: 3 })],
+      [nameRule({ id: 7 }), nameRule({ id: 8 })],
+    );
+    expect(merged.map((m) => [m.categoryRuleId, m.nameRuleId])).toEqual([
+      [1, 7],
+      [2, 8],
+      [3, null],
+    ]);
+  });
+
+  it('keeps category-rule order, then appends leftover name rules in order', () => {
+    const rules = [
+      rule({ id: 1, pattern: 'a', priority: 9 }),
+      rule({ id: 2, pattern: 'b', priority: 5 }),
+      rule({ id: 3, pattern: 'c', priority: 1 }),
+    ];
+    const nameRules = [
+      nameRule({ id: 7, pattern: 'z' }),
+      nameRule({ id: 8, pattern: 'b' }),
+      nameRule({ id: 9, pattern: 'y' }),
+    ];
+    const merged = expectInvariant(rules, nameRules);
+    expect(merged.map((m) => m.pattern)).toEqual(['a', 'b', 'c', 'z', 'y']);
+    expect(merged.map((m) => [m.categoryRuleId, m.nameRuleId])).toEqual([
+      [1, null],
+      [2, 8],
+      [3, null],
+      [null, 7],
+      [null, 9],
+    ]);
+  });
+
+  it('emits a unique, id-derived key per row', () => {
+    const merged = expectInvariant(
+      [rule({ id: 1 }), rule({ id: 2 })],
+      [nameRule({ id: 7 }), nameRule({ id: 8, pattern: 'other' })],
+    );
+    expect(merged.map((m) => m.key)).toEqual(['1:7', '2:', ':8']);
+  });
+
+  it('returns an empty list when there are no rules at all', () => {
+    expect(mergeRules([], [])).toEqual([]);
+  });
+
+  it('does not mutate its inputs', () => {
+    const rules = [rule({ id: 1 })];
+    const nameRules = [nameRule({ id: 7 })];
+    mergeRules(rules, nameRules);
+    expect(rules).toHaveLength(1);
+    expect(nameRules).toHaveLength(1);
+  });
+});

--- a/tests/tui/screens.test.tsx
+++ b/tests/tui/screens.test.tsx
@@ -1384,8 +1384,8 @@ describe('Rules', () => {
     const r = rules();
     const f = frame(r);
     expect(f).toContain('fungible');
-    expect(f).toContain('Category Rules');
-    expect(f).toContain('Name Rules');
+    expect(f).toContain('Rules');
+    expect(f).toContain('Tag Rules');
     expect(f).toContain('Categories');
   });
 
@@ -1397,23 +1397,11 @@ describe('Rules', () => {
     });
   });
 
-  it('Tab cycles to Name Rules section', async () => {
-    const r = rules();
-    await waitFor(() => expect(frame(r)).toContain('Category Rules'));
-    r.stdin.write('\t');
-    await waitFor(() => {
-      // Name Rules section is now active — its label should be highlighted (non-dimmed)
-      // We can check we're in name rules by pressing Tab again to get to Categories
-      expect(frame(r)).toContain('Name Rules');
-    });
-  });
-
   it('Tab cycles to Categories section showing seeded categories', async () => {
     const r = rules();
-    await waitFor(() => expect(frame(r)).toContain('Category Rules'));
+    await waitFor(() => expect(frame(r)).toContain('Whole Foods'));
     r.stdin.write('\t');
-    r.stdin.write('\t');
-    r.stdin.write('\t'); // rules → names → tags → categories
+    r.stdin.write('\t'); // rules → tags → categories
     await waitFor(() => {
       const f = frame(r);
       expect(f).toContain('Grocery');
@@ -1423,9 +1411,8 @@ describe('Rules', () => {
 
   it('Tab cycles to Tag Rules section', async () => {
     const r = rules();
-    await waitFor(() => expect(frame(r)).toContain('Category Rules'));
-    r.stdin.write('\t');
-    r.stdin.write('\t'); // rules → names → tags
+    await waitFor(() => expect(frame(r)).toContain('Whole Foods'));
+    r.stdin.write('\t'); // rules → tags
     await waitFor(() => expect(frame(r)).toContain('No tag rules yet'));
     r.stdin.write('a');
     await waitFor(() => {
@@ -1436,30 +1423,117 @@ describe('Rules', () => {
     });
   });
 
-  it('[a] opens new category rule form', async () => {
+  it('[a] opens the new rule form with both a category and a display name field', async () => {
     const r = rules();
     await waitFor(() => expect(frame(r)).toContain('Whole Foods')); // rules loaded
     r.stdin.write('a');
     await waitFor(() => {
       const f = frame(r);
-      expect(f).toContain('New Category Rule');
+      expect(f).toContain('New Rule');
       expect(f).toContain('Pattern');
+      expect(f).toContain('Category');
+      expect(f).toContain('Display name');
     });
   });
 
-  it('typing pattern and Enter in rule-form saves the rule', async () => {
+  it('typing a pattern, Enter to Category, picking one, then Enter saves the rule', async () => {
+    // A new rule starts on "— none —", so the first Enter moves the cursor to
+    // Category instead of saving; the second one (with a category picked) saves.
     const r = rules();
     await waitFor(() => expect(frame(r)).toContain('Whole Foods'));
     r.stdin.write('a');
-    await waitFor(() => expect(frame(r)).toContain('New Category Rule'));
+    await waitFor(() => expect(frame(r)).toContain('New Rule'));
     for (const ch of 'Starbucks') r.stdin.write(ch);
     await waitFor(() => expect(frame(r)).toContain('Starbucks'));
     r.stdin.write('\r');
+    await waitFor(() => expect(frame(r)).toContain('New Rule')); // still open, nothing saved
+    await new Promise((res) => setTimeout(res, 10));
+    r.stdin.write('\x1b[C'); // → only moves the picker if the cursor landed on Category
+    await waitFor(() => expect(frame(r)).toContain('Bills & Utilities'));
+    await new Promise((res) => setTimeout(res, 10));
+    r.stdin.write('\r');
     await waitFor(() => {
       const f = frame(r);
-      expect(f).not.toContain('New Category Rule');
+      expect(f).not.toContain('New Rule');
       expect(f).toContain('Starbucks');
     });
+    const cats = await db.execute("SELECT category FROM category_rules WHERE pattern = 'Starbucks'");
+    expect(cats.rows).toHaveLength(1);
+    expect((cats.rows[0] as unknown as { category: string }).category).toBe('Bills & Utilities');
+  });
+
+  it('a new rule defaults to no category and Enter on it writes nothing', async () => {
+    const r = rules();
+    await waitFor(() => expect(frame(r)).toContain('Whole Foods'));
+    r.stdin.write('a');
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).toContain('New Rule');
+      expect(f).toContain('— none —');            // no category pre-selected
+      expect(f).not.toContain('Bills & Utilities'); // ...not the first-sorting one
+    });
+    for (const ch of 'Starbucks') r.stdin.write(ch);
+    await waitFor(() => expect(frame(r)).toContain('Starbucks'));
+    r.stdin.write('\r');
+    // Enter guided instead of saving: the form is still open and nothing was written.
+    await waitFor(() => expect(frame(r)).toContain('New Rule'));
+    const cats = await db.execute("SELECT id FROM category_rules WHERE pattern = 'Starbucks'");
+    const names = await db.execute("SELECT id FROM name_rules WHERE pattern = 'Starbucks'");
+    expect(cats.rows).toHaveLength(0);
+    expect(names.rows).toHaveLength(0);
+  });
+
+  it('Enter with an empty pattern leaves the cursor where it is', async () => {
+    // Nothing to guide toward, so Enter stays a no-op: ← must still do nothing,
+    // which it only does while the cursor sits on the Pattern field.
+    const r = rules();
+    await waitFor(() => expect(frame(r)).toContain('Whole Foods'));
+    r.stdin.write('a');
+    await waitFor(() => expect(frame(r)).toContain('New Rule'));
+    r.stdin.write('\r');
+    await new Promise((res) => setTimeout(res, 10));
+    r.stdin.write('\x1b[C'); // would advance the picker if Enter had jumped to Category
+    await new Promise((res) => setTimeout(res, 50));
+    const f = frame(r);
+    expect(f).toContain('New Rule');
+    expect(f).toContain('— none —');
+    expect(f).not.toContain('Bills & Utilities');
+  });
+
+  it('"— none —" says it removes the rule only when editing one that has a category', async () => {
+    const r = rules();
+    await waitFor(() => expect(frame(r)).toContain('Whole Foods'));
+    // New rule: nothing to remove, so the plain label.
+    r.stdin.write('a');
+    await waitFor(() => expect(frame(r)).toContain('New Rule'));
+    expect(frame(r)).not.toContain('removes rule');
+    r.stdin.write('\x1b'); // Esc back to the list
+    await waitFor(() => expect(frame(r)).not.toContain('New Rule'));
+
+    // Editing the seeded category rule: cursoring to "none" means deleting it.
+    await new Promise((res) => setTimeout(res, 10));
+    r.stdin.write('\r');
+    await waitFor(() => expect(frame(r)).toContain('Edit Rule'));
+    expect(frame(r)).toContain('Grocery');
+    expect(frame(r)).not.toContain('removes rule'); // a category is still selected
+    for (let i = 0; i < 4; i++) r.stdin.write('\x1b[B'); // → Category
+    await new Promise((res) => setTimeout(res, 10));
+    for (let i = 0; i < 3; i++) r.stdin.write('\x1b[D'); // ← past Dining, Bills & Utilities, to none
+    await waitFor(() => expect(frame(r)).toContain('— none (removes rule) —'));
+  });
+
+  it('a name-only rule shows the plain "— none —" label, with no removal warning', async () => {
+    await db.execute('DELETE FROM category_rules');
+    await db.execute(
+      "INSERT INTO name_rules (match_type, pattern, replacement) VALUES ('name', 'sq *', 'Square')",
+    );
+    const r = rules();
+    await waitFor(() => expect(frame(r)).toContain('Square'));
+    r.stdin.write('\r');
+    await waitFor(() => expect(frame(r)).toContain('Edit Rule'));
+    const f = frame(r);
+    expect(f).toContain('— none —');
+    expect(f).not.toContain('removes rule');
   });
 
   it('Enter on existing rule opens edit form pre-filled with its pattern', async () => {
@@ -1468,7 +1542,7 @@ describe('Rules', () => {
     r.stdin.write('\r');
     await waitFor(() => {
       const f = frame(r);
-      expect(f).toContain('Edit Category Rule');
+      expect(f).toContain('Edit Rule');
       expect(f).toContain('Whole Foods');
     });
   });
@@ -1528,30 +1602,51 @@ describe('Rules', () => {
     });
   });
 
-  it('[a] in Name Rules section opens new name rule form', async () => {
+  it('a category rule and a name rule with the same conditions render as one row', async () => {
+    // Seeded category rule: name/'Whole Foods' → Grocery. Same conditions, so
+    // the two collapse into a single row carrying both.
+    await db.execute(
+      "INSERT INTO name_rules (match_type, pattern, replacement) VALUES ('name', 'Whole Foods', 'WF Market')",
+    );
     const r = rules();
-    await waitFor(() => expect(frame(r)).toContain('Category Rules'));
-    r.stdin.write('\t'); // switch to Name Rules
-    await waitFor(() => expect(frame(r)).toContain('No name rules'));
-    r.stdin.write('a');
     await waitFor(() => {
-      const f = frame(r);
-      expect(f).toContain('New Name Rule');
-      expect(f).toContain('Pattern');
-      expect(f).toContain('Replace with');
+      const line = frame(r).split('\n').find((l) => l.includes('Whole Foods'));
+      expect(line).toBeDefined();
+      expect(line).toContain('Grocery');   // category cell
+      expect(line).toContain('WF Market'); // display-name cell
+    });
+    // One row, not two.
+    await waitFor(() => expect(frame(r)).toContain('1 rules'));
+  });
+
+  it('a name rule with no category rule shows as a row with an empty category', async () => {
+    await db.execute('DELETE FROM category_rules');
+    await db.execute(
+      "INSERT INTO name_rules (match_type, pattern, replacement) VALUES ('name', 'sq *', 'Square')",
+    );
+    const r = rules();
+    await waitFor(() => {
+      const line = frame(r).split('\n').find((l) => l.includes('sq *'));
+      expect(line).toBeDefined();
+      expect(line).toContain('Square');
     });
   });
 
-  it('typing pattern + replacement in name-rule-form and Enter saves the rule', async () => {
+  it('one save writes both a category rule and a name rule', async () => {
     const r = rules();
-    await waitFor(() => expect(frame(r)).toContain('Category Rules'));
-    r.stdin.write('\t');
-    await waitFor(() => expect(frame(r)).toContain('No name rules'));
+    await waitFor(() => expect(frame(r)).toContain('Whole Foods'));
     r.stdin.write('a');
-    await waitFor(() => expect(frame(r)).toContain('New Name Rule'));
+    await waitFor(() => expect(frame(r)).toContain('New Rule'));
     for (const ch of 'amazon') r.stdin.write(ch);
     await waitFor(() => expect(frame(r)).toContain('amazon'));
-    for (let i = 0; i < 4; i++) r.stdin.write('\x1b[B'); // navigate to replacement
+    for (let i = 0; i < 4; i++) r.stdin.write('\x1b[B'); // pattern → category
+    // Consecutive writes coalesce into one chunk, and a chunk mixing two
+    // different sequences is read as a single key — so the → gets its own.
+    await new Promise((res) => setTimeout(res, 10));
+    r.stdin.write('\x1b[C'); // → off "— none —" onto the first category
+    await waitFor(() => expect(frame(r)).toContain('Bills & Utilities'));
+    await new Promise((res) => setTimeout(res, 10));
+    r.stdin.write('\x1b[B'); // → display name
     // Wait for React to commit the field navigation before typing (avoids stale closure)
     await waitFor(() => expect(frame(r)).toContain('display name'));
     for (const ch of 'Amazon') r.stdin.write(ch);
@@ -1559,16 +1654,60 @@ describe('Rules', () => {
     r.stdin.write('\r');
     await waitFor(() => {
       const f = frame(r);
-      expect(f).not.toContain('New Name Rule');
+      expect(f).not.toContain('New Rule');
       expect(f).toContain('amazon');
       expect(f).toContain('Amazon');
     });
+    const cats = await db.execute("SELECT category FROM category_rules WHERE pattern = 'amazon'");
+    const names = await db.execute("SELECT replacement FROM name_rules WHERE pattern = 'amazon'");
+    expect(cats.rows).toHaveLength(1);
+    expect(names.rows).toHaveLength(1);
+    expect((names.rows[0] as unknown as { replacement: string }).replacement).toBe('Amazon');
+  });
+
+  it('leaving the category on "— none —" saves a name rule only', async () => {
+    const r = rules();
+    await waitFor(() => expect(frame(r)).toContain('Whole Foods'));
+    r.stdin.write('a');
+    await waitFor(() => expect(frame(r)).toContain('New Rule'));
+    for (const ch of 'amazon') r.stdin.write(ch);
+    await waitFor(() => expect(frame(r)).toContain('amazon'));
+    // The category is already on "— none —" (a new rule's default), so this
+    // walks straight past it to the display name.
+    await waitFor(() => expect(frame(r)).toContain('— none —'));
+    for (let i = 0; i < 5; i++) r.stdin.write('\x1b[B'); // pattern → display name
+    await waitFor(() => expect(frame(r)).toContain('display name'));
+    for (const ch of 'Amazon') r.stdin.write(ch);
+    await waitFor(() => expect(frame(r)).toContain('Amazon'));
+    r.stdin.write('\r');
+    await waitFor(() => expect(frame(r)).not.toContain('New Rule'));
+    const cats = await db.execute("SELECT category FROM category_rules WHERE pattern = 'amazon'");
+    const names = await db.execute("SELECT replacement FROM name_rules WHERE pattern = 'amazon'");
+    expect(cats.rows).toHaveLength(0);
+    expect(names.rows).toHaveLength(1);
+  });
+
+  it('[x] on a combined row deletes both underlying rules', async () => {
+    await db.execute(
+      "INSERT INTO name_rules (match_type, pattern, replacement) VALUES ('name', 'Whole Foods', 'WF Market')",
+    );
+    const r = rules();
+    await waitFor(() => expect(frame(r)).toContain('WF Market'));
+    r.stdin.write('x');
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).toContain('Rule deleted');
+      expect(f).toContain('No rules yet');
+    });
+    const cats = await db.execute("SELECT id FROM category_rules WHERE pattern = 'Whole Foods'");
+    const names = await db.execute("SELECT id FROM name_rules WHERE pattern = 'Whole Foods'");
+    expect(cats.rows).toHaveLength(0);
+    expect(names.rows).toHaveLength(0);
   });
 
   it('Enter in categories section opens the edit panel', async () => {
     const r = rules();
-    await waitFor(() => expect(frame(r)).toContain('Category Rules'));
-    r.stdin.write('\t');
+    await waitFor(() => expect(frame(r)).toContain('Whole Foods'));
     r.stdin.write('\t');
     r.stdin.write('\t'); // categories section
     await waitFor(() => expect(frame(r)).toContain('Bills & Utilities'));
@@ -1583,8 +1722,7 @@ describe('Rules', () => {
 
   it('Esc in categories edit panel closes without navigating away', async () => {
     const r = rules();
-    await waitFor(() => expect(frame(r)).toContain('Category Rules'));
-    r.stdin.write('\t');
+    await waitFor(() => expect(frame(r)).toContain('Whole Foods'));
     r.stdin.write('\t');
     r.stdin.write('\t');
     await waitFor(() => expect(frame(r)).toContain('Bills & Utilities'));
@@ -1603,7 +1741,7 @@ describe('Rules', () => {
     const r = render(
       <W><Rules onNavigate={onNavigate} showHints={false} /></W>,
     );
-    await waitFor(() => expect(frame(r)).toContain('Category Rules'));
+    await waitFor(() => expect(frame(r)).toContain('Whole Foods'));
     r.stdin.write('1');
     expect(onNavigate).toHaveBeenCalledWith('dashboard');
   });
@@ -2668,7 +2806,7 @@ describe('App', () => {
       ['4', ['Net Worth', 'Test Checking']],
       ['5', ['Tags', 'travel']],
       ['6', ['Financial Health', 'SNAPSHOT']],
-      ['7', ['Category Rules', 'Whole Foods']],
+      ['7', ['Tag Rules', 'Whole Foods']],  // Rules screen: its section tabs + the seeded rule
       ['8', ['Accounts', 'Test Checking']],
       ['9', ['Canvas']],
       ['0', ['Settings', 'HOUSEHOLD']],

--- a/tests/tui/snapshot.test.tsx
+++ b/tests/tui/snapshot.test.tsx
@@ -115,8 +115,13 @@ describe('snapshots', () => {
   });
 
   it('rules', async () => {
+    // A name rule sharing the seeded category rule's conditions, so the capture
+    // shows a merged row (category + display name) rather than an empty list.
+    await db.execute(
+      "INSERT INTO name_rules (match_type, pattern, replacement) VALUES ('name', 'Whole Foods', 'WF Market')",
+    );
     const r = render(<W><Rules onNavigate={noop} showHints isActive /></W>);
-    await waitFor(() => { if (!r.lastFrame()?.includes('rules')) throw new Error(); });
+    await waitFor(() => { if (!r.lastFrame()?.includes('WF Market')) throw new Error(); });
     dump('rules', frame(r));
   });
 

--- a/tui/Rules.tsx
+++ b/tui/Rules.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { Box, Text, useInput } from 'ink';
 import { getAllRules, getAllNameRules, getAllTagRules, getAllCategories, getCategoryDetails, getHiddenCategorySet, toggleHiddenCategory, getLinkedAccounts, type Rule, type NameRule, type TagRuleRow, type CategoryDetail, type LinkedAccount } from '../core/queries.js';
 import {
@@ -7,6 +7,7 @@ import {
   deleteCategory, renameCategory, createCategory,
 } from '../core/rules.js';
 import { getTagOptions, type TagOption } from '../core/tags.js';
+import { mergeRules, type MergedRule } from '../core/rules-merge.js';
 import { countTagRuleMatches, type TagMatchType } from '../core/tag-rules.js';
 import type { Screen, TxFilter } from './App.js';
 import { truncate, Divider } from './fmt.js';
@@ -18,24 +19,35 @@ import { ModalPanel, TextInput, SelectableRow, usePagination, useStatusMessage, 
 
 type Flexibility = 'fixed' | 'flexible' | 'discretionary' | null;
 const FLEX_CYCLE: Flexibility[] = [null, 'fixed', 'flexible', 'discretionary'];
-type Mode = 'list' | 'search' | 'rule-form' | 'name-rule-form' | 'tag-rule-form' | 'add-category-name' | 'edit-category';
+type Mode = 'list' | 'search' | 'rule-form' | 'tag-rule-form' | 'add-category-name' | 'edit-category';
 type CatEditField = 'name' | 'flexibility' | 'hidden';
-type RuleField = 'pattern' | 'type' | 'min' | 'max' | 'category' | 'account';
-type NameRuleField = 'pattern' | 'type' | 'min' | 'max' | 'replacement' | 'account';
+// One form covers both rule kinds: a row can carry a category, a display name, or both.
+type RuleField = 'pattern' | 'type' | 'min' | 'max' | 'category' | 'replacement' | 'account';
 type TagRuleField = 'type' | 'pattern' | 'min' | 'max' | 'tag' | 'account';
-const RULE_FIELDS: RuleField[] = ['pattern', 'type', 'min', 'max', 'category', 'account'];
-const NAME_RULE_FIELDS: NameRuleField[] = ['pattern', 'type', 'min', 'max', 'replacement', 'account'];
+const RULE_FIELDS: RuleField[] = ['pattern', 'type', 'min', 'max', 'category', 'replacement', 'account'];
 const TAG_MATCH_TYPES: TagMatchType[] = ['all', 'name', 'regex'];
-type Section = 'rules' | 'names' | 'tags' | 'categories';
+type Section = 'rules' | 'tags' | 'categories';
 
-const SECTIONS: Section[] = ['rules', 'names', 'tags', 'categories'];
+const SECTIONS: Section[] = ['rules', 'tags', 'categories'];
+
+/** Fixed-width list cell: truncated with an ellipsis, or padded to keep columns aligned. */
+function cell(text: string, width: number): string {
+  return text.length > width ? text.slice(0, width - 1) + '…' : text.padEnd(width);
+}
+
+/** "$50" / "$10-$50" / "≥$10" / "≤$50" / "" for a rule's amount bounds. */
+function amountLabel(min: number | null, max: number | null): string {
+  if (min !== null && max !== null) return min === max ? `$${min}` : `$${min}-$${max}`;
+  if (min !== null) return `≥$${min}`;
+  if (max !== null) return `≤$${max}`;
+  return '';
+}
 
 export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Screen, f?: TxFilter) => void; isActive?: boolean; showHints: boolean }) {
   const refreshKey = useRefreshKey();
   const [rules, setRules] = useState<Rule[]>([]);
   const [nameRules, setNameRules] = useState<NameRule[]>([]);
   const [cursor, setCursor] = useState(0);
-  const [nameCursor, setNameCursor] = useState(0);
   const [mode, setMode] = useState<Mode>('list');
   const [section, setSection] = useState<Section>('rules');
   const [uncategorized, setUncategorized] = useState(0);
@@ -47,19 +59,14 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
   const [renameCatInput, setRenameCatInput] = useState('');
   const [catDetails, setCatDetails] = useState<CategoryDetail[]>([]);
 
-  // New category rule state
+  // Unified rule form state. A save writes a category rule, a name rule, or
+  // both, from these same fields.
   const [newPattern, setNewPattern] = useState('');
   const [newType, setNewType] = useState<'name' | 'regex'>('name');
   const [newMinAmount, setNewMinAmount] = useState('');
   const [newMaxAmount, setNewMaxAmount] = useState('');
-  const [catCursor, setCatCursor] = useState(0);
-
-  // New name rule state
-  const [newNamePattern, setNewNamePattern] = useState('');
-  const [newNameType, setNewNameType] = useState<'name' | 'regex'>('name');
-  const [newNameMinAmount, setNewNameMinAmount] = useState('');
-  const [newNameMaxAmount, setNewNameMaxAmount] = useState('');
   const [newReplacement, setNewReplacement] = useState('');
+  const [catCursor, setCatCursor] = useState(0);
 
   // Tag rules
   const [tagRules, setTagRules] = useState<TagRuleRow[]>([]);
@@ -74,11 +81,12 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
   const [tagRuleField, setTagRuleField] = useState<TagRuleField>('type');
   const [tagMatchCount, setTagMatchCount] = useState(0);
 
-  // Account scoping (shared by both rule forms; only one is active at a time)
+  // Account scoping (shared by the rule and tag-rule forms; only one is open at a time)
   const [accounts, setAccounts] = useState<LinkedAccount[]>([]);
   const [accountCursor, setAccountCursor] = useState(0); // 0 = All accounts; i>0 → accounts[i-1]
 
-  // Editing
+  // Editing: a combined row edits both underlying records, so the form tracks
+  // one id per table (either may be null — that side doesn't exist yet).
   const [editingRuleId, setEditingRuleId] = useState<number | null>(null);
   const [editingNameRuleId, setEditingNameRuleId] = useState<number | null>(null);
 
@@ -87,25 +95,26 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
 
   // Unified rule form field cursor
   const [ruleField, setRuleField] = useState<RuleField>('pattern');
-  const [nameRuleField, setNameRuleField] = useState<NameRuleField>('pattern');
 
   // Search
   const [search, setSearch] = useState('');
 
   const setTyping = useSetTyping();
-  const TEXT_INPUT_MODES_RULES = new Set<Mode>(['search', 'rule-form', 'name-rule-form', 'tag-rule-form', 'add-category-name', 'edit-category']);
+  const TEXT_INPUT_MODES_RULES = new Set<Mode>(['search', 'rule-form', 'tag-rule-form', 'add-category-name', 'edit-category']);
   useEffect(() => { setTyping(TEXT_INPUT_MODES_RULES.has(mode)); }, [mode]);
 
   const termW = useTerminalWidth();
   const inner = Math.max(60, termW) - 4;
-  // Category rules: 6 children → 5 gaps of 2; fixed: sel(2)+type(5)+amt(10)+pri(3) = 20; total reserve = 20+10 = 30
-  const rulesFlex = Math.max(20, inner - 30);
-  const rulePatW = Math.max(12, Math.floor(rulesFlex * 0.5));
-  const ruleCatW = Math.max(10, rulesFlex - rulePatW);
-  // Name rules: 5 children → 4 gaps of 2; fixed: sel(2)+type(5)+amt(12) = 19; total reserve = 19+8 = 27
-  const namesFlex = Math.max(20, inner - 27);
-  const namePatW  = Math.max(12, Math.floor(namesFlex * 0.5));
-  const nameReplW = Math.max(10, namesFlex - namePatW);
+  // Rules: 6 children (type, pattern, amount, category, name, @account) → 5 gaps
+  // of 2; fixed: sel(2)+type(5)+amt(10) = 17; total reserve = 17+10 = 27
+  const rulesFlex = Math.max(30, inner - 27);
+  const rulePatW = Math.max(12, Math.floor(rulesFlex * 0.4));
+  const ruleCatW = Math.max(10, Math.floor(rulesFlex * 0.3));
+  const ruleNameW = Math.max(10, rulesFlex - rulePatW - ruleCatW);
+  // Tag rules: 5 children → 4 gaps of 2; fixed: sel(2)+type(5)+amt(10) = 17; total reserve = 17+8 = 25
+  const tagsFlex = Math.max(20, inner - 25);
+  const tagPatW = Math.max(12, Math.floor(tagsFlex * 0.5));
+  const tagNameW = Math.max(10, tagsFlex - tagPatW);
   // Categories: [sel=2] gap [name] gap [flex=14] gap [hidden=6]
   // reserve: 2+14+6 + 3gaps*2 = 28
   const catNameW = Math.max(12, inner - 28);
@@ -142,6 +151,14 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
     return () => { cancelled = true; };
   }, [mode, newTagType, newTagPattern, accountCursor, newTagMinAmount, newTagMaxAmount]);
 
+  // Category picker options: index 0 = "— none —" (no category rule, i.e. a
+  // name-only rule), then one per category.
+  const catOptions: (string | null)[] = [null, ...categories];
+  const catCursorFor = (category: string | null): number => {
+    const i = category === null ? 0 : catOptions.indexOf(category);
+    return i >= 0 ? i : 0;
+  };
+
   // Account picker options: index 0 = "All accounts" (global), then one per account.
   const accountOptions: (string | null)[] = [null, ...accounts.map((a) => a.id)];
   const accountLabel = (id: string | null): string => {
@@ -156,61 +173,77 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
 
   useEffect(() => { load(); }, [refreshKey]);
 
-  async function handleDeleteRule(id: number) {
-    const count = await deleteCategoryRule(id);
-    showStatus(`Rule deleted · recategorized ${count} transaction${count === 1 ? '' : 's'}`, 3000);
+  // Category and name rules that fire on the same condition are one row here;
+  // each row still writes through to its own table.
+  const mergedRules = useMemo(() => mergeRules(rules, nameRules), [rules, nameRules]);
+
+  const plural = (n: number, word: string) => `${n} ${word}${n === 1 ? '' : 's'}`;
+
+  /** Deletes both records behind a merged row — either side may be absent. */
+  async function handleDeleteRule(row: MergedRule) {
+    const bits: string[] = [];
+    if (row.categoryRuleId !== null) {
+      const count = await deleteCategoryRule(row.categoryRuleId);
+      bits.push(`recategorized ${plural(count, 'transaction')}`);
+    }
+    if (row.nameRuleId !== null) {
+      await deleteNameRule(row.nameRuleId);
+      bits.push('display name cleared');
+    }
+    showStatus(`Rule deleted${bits.length ? ' · ' + bits.join(' · ') : ''}`, 3000);
     load();
   }
 
-  function handleDeleteNameRule(id: number) {
-    deleteNameRule(id);
-    showStatus('Name rule deleted');
-    load();
+  function resetRuleForm() {
+    setNewPattern(''); setNewType('name'); setNewMinAmount(''); setNewMaxAmount(''); setNewReplacement('');
+    setEditingRuleId(null); setEditingNameRuleId(null);
   }
 
+  /** A rule needs a pattern and something to do: a category, a display name, or both. */
+  const ruleFormValid = newPattern.trim().length > 0
+    && (catOptions[catCursor] != null || newReplacement.trim().length > 0);
+
+  /**
+   * One save, up to two writes: the picked category and the typed display name
+   * each create/update their own record, and clearing either one on an existing
+   * rule deletes that record. The category write goes first, so a bad regex is
+   * rejected before anything is persisted.
+   */
   async function saveRule() {
-    const category = categories[catCursor];
+    const category = catOptions[catCursor] ?? null;
+    const replacement = newReplacement.trim();
     const minAmt = newMinAmount.trim() ? parseFloat(newMinAmount) : null;
     const maxAmt = newMaxAmount.trim() ? parseFloat(newMaxAmount) : null;
-    let count: number;
+    const accountId = accountOptions[accountCursor] ?? null;
+    const bits: string[] = [];
     try {
-      count = await saveCategoryRule({
-        pattern: newPattern, matchType: newType, category,
-        minAmount: minAmt, maxAmount: maxAmt,
-        accountId: accountOptions[accountCursor] ?? null,
-        editingId: editingRuleId,
-      });
+      if (category !== null) {
+        const count = await saveCategoryRule({
+          pattern: newPattern, matchType: newType, category,
+          minAmount: minAmt, maxAmount: maxAmt, accountId, editingId: editingRuleId,
+        });
+        bits.push(`recategorized ${plural(count, 'transaction')}`);
+      } else if (editingRuleId !== null) {
+        const count = await deleteCategoryRule(editingRuleId);
+        bits.push(`category cleared · recategorized ${plural(count, 'transaction')}`);
+      }
+      if (replacement) {
+        await saveNameRule({
+          pattern: newPattern, matchType: newType, replacement,
+          minAmount: minAmt, maxAmount: maxAmt, accountId, editingId: editingNameRuleId,
+        });
+        bits.push(`display name "${replacement}"`);
+      } else if (editingNameRuleId !== null) {
+        await deleteNameRule(editingNameRuleId);
+        bits.push('display name cleared');
+      }
     } catch (e) {
+      // Leave the form open so the user can fix the input.
       showStatus(e instanceof Error ? e.message : 'Failed to save rule', 4000);
       return;
     }
-    setEditingRuleId(null);
-    showStatus(`Rule saved · recategorized ${count} transaction${count === 1 ? '' : 's'}`, 3000);
-    setNewPattern('');
-    setMode('list');
-    load();
-  }
-
-  async function handleSaveNameRule() {
-    const minAmt = newNameMinAmount.trim() ? parseFloat(newNameMinAmount) : null;
-    const maxAmt = newNameMaxAmount.trim() ? parseFloat(newNameMaxAmount) : null;
-    try {
-      await saveNameRule({
-        pattern: newNamePattern, matchType: newNameType, replacement: newReplacement,
-        minAmount: minAmt, maxAmount: maxAmt,
-        accountId: accountOptions[accountCursor] ?? null,
-        editingId: editingNameRuleId,
-      });
-    } catch (e) {
-      showStatus(e instanceof Error ? e.message : 'Failed to save name rule', 4000);
-      return;
-    }
-    setEditingNameRuleId(null);
-    showStatus('Name rule saved', 3000);
-    setNewNamePattern('');
-    setNewReplacement('');
-    setNewNameMinAmount('');
-    setNewNameMaxAmount('');
+    showStatus(`Rule saved${bits.length ? ' · ' + bits.join(' · ') : ''}`, 3000);
+    resetRuleForm();
     setMode('list');
     load();
   }
@@ -247,18 +280,15 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
 
   // Clearing the search filter shifts which rule sits under a given numeric
   // cursor index, so re-anchor the cursor to the rule the user was looking at
-  // (by id) — otherwise Esc-then-'x' deletes the wrong rule.
+  // — otherwise Esc-then-'x' deletes the wrong rule. A merged row has two ids,
+  // so it anchors on its match-condition key plus both ids.
   function clearSearchPreservingCursor() {
     if (section === 'rules' && filteredRules[cursor]) {
-      const id = filteredRules[cursor].id;
-      const idx = rules.findIndex((r) => r.id === id);
+      const row = filteredRules[cursor];
+      const idx = mergedRules.findIndex((m) => m.key === row.key
+        && m.categoryRuleId === row.categoryRuleId && m.nameRuleId === row.nameRuleId);
       setSearch('');
       if (idx >= 0) setCursor(idx);
-    } else if (section === 'names' && filteredNameRules[nameCursor]) {
-      const id = filteredNameRules[nameCursor].id;
-      const idx = nameRules.findIndex((r) => r.id === id);
-      setSearch('');
-      if (idx >= 0) setNameCursor(idx);
     } else if (section === 'tags' && filteredTagRules[tagRuleCursor]) {
       const id = filteredTagRules[tagRuleCursor].id;
       const idx = tagRules.findIndex((r) => r.id === id);
@@ -292,7 +322,7 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
         return;
       }
 
-      if (section === 'rules' || section === 'names' || section === 'tags') {
+      if (section === 'rules' || section === 'tags') {
         if (input === '/') { setMode('search'); return; }
       }
 
@@ -301,39 +331,28 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
         if (key.upArrow) setCursor((c) => Math.max(0, c - 1));
         if (key.downArrow) setCursor((c) => Math.min(filteredRules.length - 1, c + 1));
         if (input === 'a') {
-          setEditingRuleId(null); setNewPattern(''); setNewType('name'); setNewMinAmount(''); setNewMaxAmount(''); setCatCursor(0); setAccountCursor(0);
+          resetRuleForm();
+          // A new rule opens on "— none —" rather than on whichever category
+          // happens to sort first: a pre-selected category would quietly
+          // recategorize every matching transaction for someone who only wanted
+          // a rename. Enter guides the cursor here instead (see 'rule-form').
+          setCatCursor(0);
+          setAccountCursor(0);
           setRuleField('pattern'); setMode('rule-form');
         }
-        if (input === 'x' && filteredRules[cursor]) { void handleDeleteRule(filteredRules[cursor].id); }
+        if (input === 'x' && filteredRules[cursor]) { void handleDeleteRule(filteredRules[cursor]); }
         if (key.return && filteredRules[cursor]) {
           const r = filteredRules[cursor];
-          setEditingRuleId(r.id);
+          setEditingRuleId(r.categoryRuleId);
+          setEditingNameRuleId(r.nameRuleId);
           setNewPattern(r.pattern);
-          setNewType(r.match_type as 'name' | 'regex');
-          setNewMinAmount(r.min_amount !== null ? String(r.min_amount) : '');
-          setNewMaxAmount(r.max_amount !== null ? String(r.max_amount) : '');
-          setCatCursor(Math.max(0, categories.indexOf(r.category)));
-          setAccountCursor(accountCursorFor(r.account_id));
+          setNewType(r.matchType as 'name' | 'regex');
+          setNewMinAmount(r.minAmount !== null ? String(r.minAmount) : '');
+          setNewMaxAmount(r.maxAmount !== null ? String(r.maxAmount) : '');
+          setNewReplacement(r.replacement ?? '');
+          setCatCursor(catCursorFor(r.category));
+          setAccountCursor(accountCursorFor(r.accountId));
           setRuleField('pattern'); setMode('rule-form');
-        }
-      } else if (section === 'names') {
-        if (key.upArrow) setNameCursor((c) => Math.max(0, c - 1));
-        if (key.downArrow) setNameCursor((c) => Math.min(filteredNameRules.length - 1, c + 1));
-        if (input === 'a') {
-          setEditingNameRuleId(null); setNewNamePattern(''); setNewNameType('name'); setNewNameMinAmount(''); setNewNameMaxAmount(''); setNewReplacement(''); setAccountCursor(0);
-          setNameRuleField('pattern'); setMode('name-rule-form');
-        }
-        if (input === 'x' && filteredNameRules[nameCursor]) { handleDeleteNameRule(filteredNameRules[nameCursor].id); }
-        if (key.return && filteredNameRules[nameCursor]) {
-          const r = filteredNameRules[nameCursor];
-          setEditingNameRuleId(r.id);
-          setNewNamePattern(r.pattern);
-          setNewNameType(r.match_type as 'name' | 'regex');
-          setNewNameMinAmount(r.min_amount !== null ? String(r.min_amount) : '');
-          setNewNameMaxAmount(r.max_amount !== null ? String(r.max_amount) : '');
-          setNewReplacement(r.replacement);
-          setAccountCursor(accountCursorFor(r.account_id));
-          setNameRuleField('pattern'); setMode('name-rule-form');
         }
       } else if (section === 'tags') {
         if (key.upArrow) setTagRuleCursor((c) => Math.max(0, c - 1));
@@ -432,8 +451,15 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
         return;
       }
     } else if (mode === 'rule-form') {
-      if (key.escape) { setEditingRuleId(null); setMode('list'); return; }
-      if (key.return) { if (newPattern.trim()) { void saveRule(); } return; }
+      if (key.escape) { resetRuleForm(); setMode('list'); return; }
+      if (key.return) {
+        if (ruleFormValid) { void saveRule(); }
+        // A pattern with nothing to do yet is a half-typed rule, not a mistake:
+        // send the cursor to Category so Enter always moves the user forward.
+        // An empty pattern has no field to guide toward, so it stays a no-op.
+        else if (newPattern.trim()) { setRuleField('category'); }
+        return;
+      }
       if (key.upArrow) { setRuleField((f) => RULE_FIELDS[Math.max(0, RULE_FIELDS.indexOf(f) - 1)]); return; }
       if (key.downArrow) { setRuleField((f) => RULE_FIELDS[Math.min(RULE_FIELDS.length - 1, RULE_FIELDS.indexOf(f) + 1)]); return; }
       if (ruleField === 'pattern') {
@@ -449,31 +475,11 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
         if (input && !key.ctrl && !key.meta) { setNewMaxAmount((p) => p + input); return; }
       } else if (ruleField === 'category') {
         if (key.leftArrow) { setCatCursor((c) => Math.max(0, c - 1)); return; }
-        if (key.rightArrow) { setCatCursor((c) => Math.min(categories.length - 1, c + 1)); return; }
-      } else if (ruleField === 'account') {
-        if (key.leftArrow) { setAccountCursor((c) => Math.max(0, c - 1)); return; }
-        if (key.rightArrow) { setAccountCursor((c) => Math.min(accountOptions.length - 1, c + 1)); return; }
-      }
-    } else if (mode === 'name-rule-form') {
-      if (key.escape) { setEditingNameRuleId(null); setMode('list'); return; }
-      if (key.return) { if (newNamePattern.trim() && newReplacement.trim()) { void handleSaveNameRule(); } return; }
-      if (key.upArrow) { setNameRuleField((f) => NAME_RULE_FIELDS[Math.max(0, NAME_RULE_FIELDS.indexOf(f) - 1)]); return; }
-      if (key.downArrow) { setNameRuleField((f) => NAME_RULE_FIELDS[Math.min(NAME_RULE_FIELDS.length - 1, NAME_RULE_FIELDS.indexOf(f) + 1)]); return; }
-      if (nameRuleField === 'pattern') {
-        if (key.backspace || key.delete) { setNewNamePattern((p) => p.slice(0, -1)); return; }
-        if (input && !key.ctrl && !key.meta) { setNewNamePattern((p) => p + input); return; }
-      } else if (nameRuleField === 'type') {
-        if (key.leftArrow || key.rightArrow) { setNewNameType((t) => t === 'name' ? 'regex' : 'name'); return; }
-      } else if (nameRuleField === 'min') {
-        if (key.backspace || key.delete) { setNewNameMinAmount((p) => p.slice(0, -1)); return; }
-        if (input && !key.ctrl && !key.meta) { setNewNameMinAmount((p) => p + input); return; }
-      } else if (nameRuleField === 'max') {
-        if (key.backspace || key.delete) { setNewNameMaxAmount((p) => p.slice(0, -1)); return; }
-        if (input && !key.ctrl && !key.meta) { setNewNameMaxAmount((p) => p + input); return; }
-      } else if (nameRuleField === 'replacement') {
+        if (key.rightArrow) { setCatCursor((c) => Math.min(catOptions.length - 1, c + 1)); return; }
+      } else if (ruleField === 'replacement') {
         if (key.backspace || key.delete) { setNewReplacement((p) => p.slice(0, -1)); return; }
         if (input && !key.ctrl && !key.meta) { setNewReplacement((p) => p + input); return; }
-      } else if (nameRuleField === 'account') {
+      } else if (ruleField === 'account') {
         if (key.leftArrow) { setAccountCursor((c) => Math.max(0, c - 1)); return; }
         if (key.rightArrow) { setAccountCursor((c) => Math.min(accountOptions.length - 1, c + 1)); return; }
       }
@@ -521,11 +527,10 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
 
   const q = search.toLowerCase();
   const filteredRules = q
-    ? rules.filter((r) => r.pattern.toLowerCase().includes(q) || r.category.toLowerCase().includes(q))
-    : rules;
-  const filteredNameRules = q
-    ? nameRules.filter((r) => r.pattern.toLowerCase().includes(q) || r.replacement.toLowerCase().includes(q))
-    : nameRules;
+    ? mergedRules.filter((r) => r.pattern.toLowerCase().includes(q)
+        || (r.category ?? '').toLowerCase().includes(q)
+        || (r.replacement ?? '').toLowerCase().includes(q))
+    : mergedRules;
   const filteredTagRules = q
     ? tagRules.filter((r) => r.pattern.toLowerCase().includes(q) || r.tag_name.toLowerCase().includes(q))
     : tagRules;
@@ -540,7 +545,7 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
         <Box gap={3}>
           {SECTIONS.map((s) => (
             <Text key={s} bold color={section === s ? C_ACCENT : undefined} dimColor={section !== s}>
-              {s === 'rules' ? 'Category Rules' : s === 'names' ? 'Name Rules' : s === 'tags' ? 'Tag Rules' : 'Categories'}
+              {s === 'rules' ? 'Rules' : s === 'tags' ? 'Tag Rules' : 'Categories'}
             </Text>
           ))}
         </Box>
@@ -568,73 +573,33 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
             { label: 'PATTERN', width: rulePatW },
             { label: 'AMOUNT', width: 10 },
             { label: 'CATEGORY', width: ruleCatW },
-            { label: 'PRI' },
+            { label: 'NAME', width: ruleNameW },
           ]} />
-          {visible.map((rule) => {
-            const isSelected = rule.id === filteredRules[cursor]?.id;
-            const amtLabel = rule.min_amount !== null && rule.max_amount !== null && rule.min_amount === rule.max_amount
-              ? `$${rule.min_amount}`
-              : rule.min_amount !== null && rule.max_amount !== null
-              ? `$${rule.min_amount}-$${rule.max_amount}`
-              : rule.min_amount !== null ? `≥$${rule.min_amount}`
-              : rule.max_amount !== null ? `≤$${rule.max_amount}`
-              : '';
-            return (
-              <SelectableRow key={rule.id} selected={isSelected}>
-                <Text color={C_WARNING} dimColor={!isSelected}>{rule.match_type.padEnd(5)}</Text>
-                <Text dimColor={!isSelected}>
-                  {rule.pattern.length > rulePatW ? rule.pattern.slice(0, rulePatW - 1) + '…' : rule.pattern.padEnd(rulePatW)}
-                </Text>
-                {amtLabel ? <Text color={C_MANUAL} dimColor={!isSelected}>{truncate(amtLabel, 10).padEnd(10)}</Text> : <Text>{' '.repeat(10)}</Text>}
-                <Text color={C_ACCENT} dimColor={!isSelected}>{rule.category.length > ruleCatW ? rule.category.slice(0, ruleCatW - 1) + '…' : rule.category.padEnd(ruleCatW)}</Text>
-                <Text dimColor>{rule.priority}</Text>
-                {rule.account_id && <Text color={C_MANUAL} dimColor={!isSelected}>@{accountLabel(rule.account_id)}</Text>}
-              </SelectableRow>
-            );
-          })}
-          <Divider />
-          <Box gap={4}>
-            <Text dimColor>{filteredRules.length}{search ? `/${rules.length}` : ''} rules</Text>
-            {uncategorized > 0 && <Text color={C_WARNING}>{uncategorized} uncategorized transactions</Text>}
-          </Box>
-        </>
-      )}
-
-      {section === 'names' && (
-        <>
-          <ColumnHeader hasCursor columns={[
-            { label: 'TYPE', width: 5 },
-            { label: 'PATTERN', width: namePatW },
-            { label: 'AMOUNT', width: 12 },
-            { label: 'REPLACEMENT' },
-          ]} />
-          {filteredNameRules.length === 0
-            ? <Box marginTop={1}><Text dimColor>{nameRules.length === 0 ? 'No name rules yet. [a] to add one.' : 'No matches.'}</Text></Box>
-            : filteredNameRules.map((rule, i) => {
-                const isSelected = nameCursor === i;
-                const amtLabel = rule.min_amount !== null && rule.max_amount !== null && rule.min_amount === rule.max_amount
-                  ? `$${rule.min_amount}`
-                  : rule.min_amount !== null && rule.max_amount !== null
-                  ? `$${rule.min_amount}-$${rule.max_amount}`
-                  : rule.min_amount !== null ? `≥$${rule.min_amount}`
-                  : rule.max_amount !== null ? `≤$${rule.max_amount}`
-                  : '';
+          {filteredRules.length === 0
+            ? <Box marginTop={1}><Text dimColor>{mergedRules.length === 0 ? 'No rules yet. [a] to add one.' : 'No matches.'}</Text></Box>
+            : visible.map((rule) => {
+                const isSelected = rule === filteredRules[cursor];
+                const amt = amountLabel(rule.minAmount, rule.maxAmount);
                 return (
-                  <SelectableRow key={rule.id} selected={isSelected}>
-                    <Text color={C_WARNING} dimColor={!isSelected}>{rule.match_type.padEnd(5)}</Text>
-                    <Text dimColor={!isSelected}>
-                      {rule.pattern.length > namePatW ? rule.pattern.slice(0, namePatW - 1) + '…' : rule.pattern.padEnd(namePatW)}
-                    </Text>
-                    {amtLabel
-                      ? <Text color={C_MANUAL} dimColor={!isSelected}>{truncate(amtLabel, 12).padEnd(12)}</Text>
-                      : <Text>{' '.repeat(12)}</Text>}
-                    <Text color={C_POSITIVE} dimColor={!isSelected}>{rule.replacement.length > nameReplW ? rule.replacement.slice(0, nameReplW - 1) + '…' : rule.replacement}</Text>
-                    {rule.account_id && <Text color={C_MANUAL} dimColor={!isSelected}>@{accountLabel(rule.account_id)}</Text>}
+                  <SelectableRow key={`${rule.categoryRuleId ?? '-'}:${rule.nameRuleId ?? '-'}`} selected={isSelected}>
+                    <Text color={C_WARNING} dimColor={!isSelected}>{rule.matchType.padEnd(5)}</Text>
+                    <Text dimColor={!isSelected}>{cell(rule.pattern, rulePatW)}</Text>
+                    {amt ? <Text color={C_MANUAL} dimColor={!isSelected}>{truncate(amt, 10).padEnd(10)}</Text> : <Text>{' '.repeat(10)}</Text>}
+                    {rule.category
+                      ? <Text color={C_ACCENT} dimColor={!isSelected}>{cell(rule.category, ruleCatW)}</Text>
+                      : <Text>{' '.repeat(ruleCatW)}</Text>}
+                    {rule.replacement
+                      ? <Text color={C_POSITIVE} dimColor={!isSelected}>{cell(rule.replacement, ruleNameW)}</Text>
+                      : <Text>{' '.repeat(ruleNameW)}</Text>}
+                    {rule.accountId && <Text color={C_MANUAL} dimColor={!isSelected}>@{accountLabel(rule.accountId)}</Text>}
                   </SelectableRow>
                 );
               })}
           <Divider />
-          <Text dimColor>{filteredNameRules.length}{search ? `/${nameRules.length}` : ''} name rule{nameRules.length !== 1 ? 's' : ''}</Text>
+          <Box gap={4}>
+            <Text dimColor>{filteredRules.length}{search ? `/${mergedRules.length}` : ''} rules</Text>
+            {uncategorized > 0 && <Text color={C_WARNING}>{uncategorized} uncategorized transactions</Text>}
+          </Box>
         </>
       )}
 
@@ -642,30 +607,24 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
         <>
           <ColumnHeader hasCursor columns={[
             { label: 'TYPE', width: 5 },
-            { label: 'PATTERN', width: rulePatW },
+            { label: 'PATTERN', width: tagPatW },
             { label: 'AMOUNT', width: 10 },
-            { label: 'TAG', width: ruleCatW },
+            { label: 'TAG', width: tagNameW },
           ]} />
           {filteredTagRules.length === 0
             ? <Box marginTop={1}><Text dimColor>{tagRules.length === 0 ? 'No tag rules yet. [a] to add one (type "all" + an account tags everything in it).' : 'No matches.'}</Text></Box>
             : filteredTagRules.map((rule, i) => {
                 const isSelected = tagRuleCursor === i;
-                const amtLabel = rule.min_amount !== null && rule.max_amount !== null && rule.min_amount === rule.max_amount
-                  ? `$${rule.min_amount}`
-                  : rule.min_amount !== null && rule.max_amount !== null
-                  ? `$${rule.min_amount}-$${rule.max_amount}`
-                  : rule.min_amount !== null ? `≥$${rule.min_amount}`
-                  : rule.max_amount !== null ? `≤$${rule.max_amount}`
-                  : '';
+                const amtLabel = amountLabel(rule.min_amount, rule.max_amount);
                 const patLabel = rule.match_type === 'all' ? '— all —' : rule.pattern;
                 return (
                   <SelectableRow key={rule.id} selected={isSelected}>
                     <Text color={C_WARNING} dimColor={!isSelected}>{rule.match_type.padEnd(5)}</Text>
                     <Text dimColor={rule.match_type === 'all' || !isSelected}>
-                      {patLabel.length > rulePatW ? patLabel.slice(0, rulePatW - 1) + '…' : patLabel.padEnd(rulePatW)}
+                      {cell(patLabel, tagPatW)}
                     </Text>
                     {amtLabel ? <Text color={C_MANUAL} dimColor={!isSelected}>{truncate(amtLabel, 10).padEnd(10)}</Text> : <Text>{' '.repeat(10)}</Text>}
-                    <Text color={C_ACCENT} dimColor={!isSelected}>{rule.tag_name.length > ruleCatW ? rule.tag_name.slice(0, ruleCatW - 1) + '…' : rule.tag_name.padEnd(ruleCatW)}</Text>
+                    <Text color={C_ACCENT} dimColor={!isSelected}>{cell(rule.tag_name, tagNameW)}</Text>
                     {rule.account_id && <Text color={C_MANUAL} dimColor={!isSelected}>@{accountLabel(rule.account_id)}</Text>}
                   </SelectableRow>
                 );
@@ -732,29 +691,34 @@ export function Rules({ onNavigate, isActive, showHints }: { onNavigate: (s: Scr
       })()}
 
       {mode === 'rule-form' && (
-        <ModalPanel title={`${editingRuleId !== null ? 'Edit' : 'New'} Category Rule`}>
+        <ModalPanel title={`${editingRuleId !== null || editingNameRuleId !== null ? 'Edit' : 'New'} Rule`}>
           <Box marginTop={1} flexDirection="column" gap={1}>
             <EditTextField label="Pattern" active={ruleField === 'pattern'} value={newPattern} color={C_WARNING} placeholder="keyword or /regex/" emptyText="empty" />
             <EditToggleField label="Match type" active={ruleField === 'type'} value={newType} />
             <EditTextField label="Min $" active={ruleField === 'min'} value={newMinAmount} color={C_WARNING} placeholder="optional" />
             <EditTextField label="Max $" active={ruleField === 'max'} value={newMaxAmount} color={C_WARNING} placeholder="optional" />
-            <EditToggleField label="Category" active={ruleField === 'category'} value={categories[catCursor] ?? '—'} />
+            <EditToggleField
+              label="Category"
+              active={ruleField === 'category'}
+              // On an existing category rule, "none" is a delete — name the
+              // consequence in the picker, where the choice gets made.
+              value={catOptions[catCursor] ?? (editingRuleId !== null ? '— none (removes rule) —' : '— none —')}
+              valueColor={catOptions[catCursor] ? undefined : (editingRuleId !== null ? C_WARNING : C_DIM)}
+            />
+            <EditTextField label="Display name" active={ruleField === 'replacement'} value={newReplacement} color={C_POSITIVE} placeholder="display name" emptyText="—" />
             <EditToggleField label="Account" active={ruleField === 'account'} value={accountLabel(accountOptions[accountCursor] ?? null)} />
           </Box>
-          <Box marginTop={1}><Text dimColor>↑↓ field  ·  ← → change  ·  Enter save  ·  Esc cancel</Text></Box>
-        </ModalPanel>
-      )}
-
-      {mode === 'name-rule-form' && (
-        <ModalPanel title={`${editingNameRuleId !== null ? 'Edit' : 'New'} Name Rule`} borderColor={C_POSITIVE}>
-          <Box marginTop={1} flexDirection="column" gap={1}>
-            <EditTextField label="Pattern" active={nameRuleField === 'pattern'} value={newNamePattern} color={C_WARNING} placeholder="keyword or /regex/" emptyText="empty" />
-            <EditToggleField label="Match type" active={nameRuleField === 'type'} value={newNameType} />
-            <EditTextField label="Min $" active={nameRuleField === 'min'} value={newNameMinAmount} color={C_WARNING} placeholder="optional" />
-            <EditTextField label="Max $" active={nameRuleField === 'max'} value={newNameMaxAmount} color={C_WARNING} placeholder="optional" />
-            <EditTextField label="Replace with" active={nameRuleField === 'replacement'} value={newReplacement} color={C_POSITIVE} placeholder="display name" emptyText="empty" />
-            <EditToggleField label="Account" active={nameRuleField === 'account'} value={accountLabel(accountOptions[accountCursor] ?? null)} />
-          </Box>
+          {!ruleFormValid && (
+            <Box marginTop={1}>
+              {/* Once a pattern is typed, the hint names the remaining step —
+                  same wording as the GUI's rule form. */}
+              <Text dimColor>
+                {newPattern.trim()
+                  ? 'Pick a category or enter a display name to save.'
+                  : 'Needs a pattern, and a category or a display name.'}
+              </Text>
+            </Box>
+          )}
           <Box marginTop={1}><Text dimColor>↑↓ field  ·  ← → change  ·  Enter save  ·  Esc cancel</Text></Box>
         </ModalPanel>
       )}


### PR DESCRIPTION
Closes #121.

Category rules and name rules shared nearly identical structure — pattern, match type, optional amount range — but lived in separate `Tab`-separated sections. Covering a new merchant meant two interactions in two places: one rule to categorize it, another to clean up its display name.

Both the TUI and the GUI now show them as one list, where a rule that sets both a category and a display name is a single row, and one save writes a category rule, a name rule, or both.

## How pairing works

The two tables stay separate at the data layer — this is purely a UX change. Since `category_rules` and `name_rules` have no foreign key between them, "one combined rule" is *inferred* from matching `match_type`, `pattern`, `account_id`, `min_amount` and `max_amount`.

That logic lives in `core/rules-merge.ts` so the two surfaces can't drift apart. Worth knowing: two rules differing only in amount bounds show as two rows, not one.

The renderer imports the module directly rather than through the GUI bridge, since it's pure and needs no IPC — hence the new `EXPECTED_UNBRIDGED` entry in `tests/gui-bridge-parity.test.ts`. **If anyone later bridges it through `gui/main/registry.ts`, that entry must come out or the sibling stale-entries test will fail.**

## Form behaviour

The category picker gains a `— none —` option, which is what makes a name-only rule expressible at all.

New rules open on `— none —` rather than pre-selecting the first category. The old default silently pre-selected whatever category sorted first, so someone adding a rename-only rule who never looked at the Category field would assign an arbitrary category to every matching transaction with no signal it happened — and the merged form makes that *more* likely, since name-only rules now live in a form that has a category picker.

Two changes keep that cheap rather than annoying:

- **Enter guides instead of dead-ending.** With a pattern typed and nothing else set, `Enter` moves the field cursor to Category rather than silently doing nothing. (The GUI has no Enter-to-submit, so there it's a quiet hint explaining the disabled Save button.)
- **`— none —` says what it does.** When editing a rule that currently has a category, it renders as `— none (removes rule) —` in warning colour — selecting it deletes the category rule and recategorizes every matching transaction, and previously the only warning arrived afterward in the status line. No confirmation dialog, since row delete doesn't have one either.

## Testing

991 of 992 tests pass; typecheck clean; Rules e2e rebuilt and re-run.

The one failure — the `digit-nav sweep` case in `tests/tui/screens.test.tsx`, at the **Canvas** step — is pre-existing and unrelated. I reproduced it on clean `dev` in a separate worktree. It's worth its own issue: the Canvas screen renders an empty frame under the seeded-data sweep.

New coverage: 15 unit tests for `mergeRules` (pairing, unpaired on both sides, `null` vs `0` bounds, duplicate keys, ordering, key uniqueness), plus TUI and GUI cases for combined-row rendering, one save writing both tables, `— none —` producing a name-only rule, the guiding Enter, and the conditional removal label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEgRjut1fGdsPLhQ2vDeuv