### PR TITLE
feat: surface transaction date reattribution in the TUI and GUI

### DIFF
--- a/core/queries.ts
+++ b/core/queries.ts
@@ -578,6 +578,10 @@ export const SORT_ORDER_BY: Record<SortMode, string> = {
 export type TxRow = {
   id: string; date: string; name: string; display_name: string | null; merchant_name: string | null;
   amount: number; category: string; manual_category: string | null; ignored: number; tag_names: string | null;
+  // The bank's posting date, retained by setTransactionDate when a transaction
+  // is reattributed to another period; NULL unless `date` has been overridden.
+  // UI uses it to show "reattributed from X" and offer restore-to-posting-date.
+  original_date: string | null;
 };
 
 export function buildSearchRe(search: string): RegExp {
@@ -605,7 +609,7 @@ export async function getTransactions(filters: {
 
   const where = conditions.length ? 'WHERE ' + conditions.join(' AND ') : '';
   const result = await db.execute({
-    sql: `SELECT t.id, t.date, t.name, t.display_name, t.merchant_name, t.amount, t.category, t.manual_category, t.ignored,
+    sql: `SELECT t.id, t.date, t.original_date, t.name, t.display_name, t.merchant_name, t.amount, t.category, t.manual_category, t.ignored,
             (SELECT GROUP_CONCAT(tg2.name, ', ') FROM transaction_tags tt2 JOIN tags tg2 ON tg2.id = tt2.tag_id WHERE tt2.transaction_id = t.id) as tag_names
           FROM transactions t ${where}
           ORDER BY ${SORT_ORDER_BY[sort]}

--- a/core/tools.ts
+++ b/core/tools.ts
@@ -20,7 +20,7 @@ import { getFinanceGuide, getFinanceTopicList, formatGuideSection, type GuideTop
 import { applyCategoriesToAll } from './categorize.js';
 import { deleteCategoryRule } from './rules.js';
 import { rebuildDisplayNames } from './rename.js';
-import { setTransactionCategory, clearTransactionOverride, setTransactionIgnored, setTransactionDate, clearTransactionDate } from './transactions.js';
+import { setTransactionCategory, clearTransactionOverride, setTransactionIgnored, setTransactionDate, clearTransactionDate, isValidIsoDate } from './transactions.js';
 import { addTagToTransaction, removeTagFromTransaction, getOrCreateTag } from './tags.js';
 import { fmt, fmtSigned, fmtSpan } from './fmt.js';
 import { syncAll } from './sync.js';
@@ -823,7 +823,9 @@ async function executeToolImpl(
       const date = str('date');
       // Reject anything SQLite's date functions would silently treat as NULL —
       // a bad date here would quietly drop the row out of every range query.
-      if (!/^\d{4}-\d{2}-\d{2}$/.test(date) || Number.isNaN(Date.parse(date))) {
+      // setTransactionDate enforces this too; the early return gives the agent
+      // a friendly message instead of a thrown error.
+      if (!isValidIsoDate(date)) {
         return `"${date}" is not a valid date. Use YYYY-MM-DD.`;
       }
       await setTransactionDate(str('id'), date);

--- a/core/transactions.ts
+++ b/core/transactions.ts
@@ -4,6 +4,20 @@ import { rebuildDisplayNames } from './rename.js';
 import { applyCategoriesToAll } from './categorize.js';
 import { validateRegex } from './rule-utils.js';
 
+/**
+ * True when `s` is a real calendar date in YYYY-MM-DD form. Used by both the
+ * `set_transaction_date` MCP wrapper and setTransactionDate itself.
+ *
+ * The round-trip check is deliberate: `Date.parse('2025-02-30')` does NOT
+ * return NaN — V8 rolls the day over to March 2 — so a plain parse would wave
+ * impossible days through. Re-serialising and comparing catches them.
+ */
+export function isValidIsoDate(s: string): boolean {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(s)) return false;
+  const d = new Date(`${s}T00:00:00Z`);
+  return !Number.isNaN(d.getTime()) && d.toISOString().slice(0, 10) === s;
+}
+
 // ── Single-transaction mutations ───────────────────────────────────────────────
 
 export async function setTransactionCategory(id: string, category: string): Promise<void> {
@@ -34,8 +48,16 @@ export async function clearTransactionOverride(id: string): Promise<void> {
  * Reattribute a transaction to the period it belongs to. Preserves the bank's
  * posting date in `original_date` on the first edit, so repeated edits never
  * lose it and `clearTransactionDate` can always get back to the truth.
+ *
+ * Rejects anything that isn't a real YYYY-MM-DD date: SQLite's date functions
+ * would silently treat a malformed value as NULL, quietly dropping the row out
+ * of every range query. Callers (MCP wrapper, GUI, TUI) guard too, but this is
+ * the last line before the write.
  */
 export async function setTransactionDate(id: string, date: string): Promise<void> {
+  if (!isValidIsoDate(date)) {
+    throw new Error(`Invalid transaction date "${date}": expected YYYY-MM-DD.`);
+  }
   await db.execute({
     sql: 'UPDATE transactions SET original_date = COALESCE(original_date, date), date = ? WHERE id = ?',
     args: [date, id],

--- a/gui/main/registry.ts
+++ b/gui/main/registry.ts
@@ -32,6 +32,8 @@ import {
 import {
   setTransactionCategory,
   clearTransactionOverride,
+  setTransactionDate,
+  clearTransactionDate,
   setTransactionIgnored,
   setTransactionDisplayName,
   deleteTransaction,
@@ -131,6 +133,8 @@ export const registry = {
   transactions: {
     setTransactionCategory,
     clearTransactionOverride,
+    setTransactionDate,
+    clearTransactionDate,
     setTransactionIgnored,
     setTransactionDisplayName,
     deleteTransaction,

--- a/gui/renderer/src/screens/Transactions.module.css
+++ b/gui/renderer/src/screens/Transactions.module.css
@@ -273,6 +273,27 @@
   font-size: 13px;
 }
 
+.dateHint {
+  margin: 12px 0 0;
+  font-size: 13px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.restoreBtn {
+  font-size: 11.5px;
+  color: var(--text-dim);
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  padding: 2px 8px;
+}
+
+.restoreBtn:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
 .modalActions {
   display: flex;
   justify-content: flex-end;

--- a/gui/renderer/src/screens/Transactions.tsx
+++ b/gui/renderer/src/screens/Transactions.tsx
@@ -466,6 +466,7 @@ function EditModal({
 }) {
   const [name, setName] = useState('');
   const [cat, setCat] = useState(tx.category);
+  const [date, setDate] = useState(tx.date);
   const [pattern, setPattern] = useState('');
   const [matchType, setMatchType] = useState<'name' | 'regex'>('name');
   const [matchCount, setMatchCount] = useState(0);
@@ -482,10 +483,20 @@ function EditModal({
     }
   }, [pattern, matchType]);
 
+  // Non-null only once the date has been reattributed away from the bank's
+  // posting date.
+  const originalDate = tx.original_date;
+
+  async function restoreDate() {
+    await api.transactions.clearTransactionDate(tx.id);
+    onSaved('Date restored to posting date');
+  }
+
   async function save() {
     const newDisplay = name.trim();
     const nameChanged = newDisplay.length > 0;
     const catChanged = cat !== tx.category;
+    const dateChanged = date !== tx.date && date.length > 0;
 
     if (pattern.trim()) {
       const saved: string[] = [];
@@ -506,7 +517,15 @@ function EditModal({
     } else {
       if (nameChanged) await api.transactions.setTransactionDisplayName(tx.id, newDisplay);
       if (catChanged) await api.transactions.setTransactionCategory(tx.id, cat);
-      onSaved(nameChanged || catChanged ? 'Transaction updated' : 'No changes');
+      if (dateChanged) {
+        try {
+          await api.transactions.setTransactionDate(tx.id, date);
+        } catch (e) {
+          setError(e instanceof Error ? e.message : 'Failed to set date');
+          return;
+        }
+      }
+      onSaved(nameChanged || catChanged || dateChanged ? 'Transaction updated' : 'No changes');
     }
   }
 
@@ -525,6 +544,8 @@ function EditModal({
             </option>
           ))}
         </select>
+        <label>Date</label>
+        <input type="date" value={date} onChange={(e) => setDate(e.target.value)} disabled={isRule} />
         <label>Pattern</label>
         <input
           value={pattern}
@@ -537,6 +558,14 @@ function EditModal({
           <option value="regex">regex</option>
         </select>
       </div>
+      {originalDate && !isRule && (
+        <p className={styles.dateHint}>
+          <span className="dim">Reattributed from {originalDate}</span>
+          <button className={styles.restoreBtn} onClick={() => void restoreDate()}>
+            restore posting date
+          </button>
+        </p>
+      )}
       {isRule && (
         <p className={styles.ruleHint}>
           <span className="warn">{matchCount} transactions match</span>

--- a/tests/gui/transactions.test.tsx
+++ b/tests/gui/transactions.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import React from 'react';
-import { cleanup, screen, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 vi.mock('../../core/db.js', async () => {
@@ -104,6 +104,43 @@ describe('GUI Transactions', () => {
       expect(row.textContent).toContain('◆');
       expect(row.textContent).toContain('Dining');
     });
+  });
+
+  it('edit modal reattributes a transaction date and preserves the posting date', async () => {
+    const { container } = renderScreen(<Transactions />);
+    await waitFor(() => expect(screen.getByText('Trader Joes')).toBeTruthy());
+    await userEvent.click(screen.getByText('Trader Joes'));
+    await waitFor(() => expect(screen.getByText(/^Edit/)).toBeTruthy());
+
+    const dateInput = container.querySelector('input[type="date"]') as HTMLInputElement;
+    expect(dateInput.value).toBe('2026-05-14');
+    fireEvent.change(dateInput, { target: { value: '2026-05-20' } });
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(screen.getByText('Transaction updated')).toBeTruthy());
+    await waitFor(() => {
+      const row = screen.getByText('Trader Joes').closest('tr')!;
+      expect(row.textContent).toContain('2026-05-20');
+    });
+
+    // First edit stashes the bank's posting date so it can always be restored.
+    const res = await db.execute("SELECT date, original_date FROM transactions WHERE id = 'tx-groc-2'");
+    expect(res.rows[0]).toMatchObject({ date: '2026-05-20', original_date: '2026-05-14' });
+  });
+
+  it('edit modal shows a reattributed-from note and restores the posting date', async () => {
+    await db.execute(
+      "UPDATE transactions SET date = '2026-05-20', original_date = '2026-05-14' WHERE id = 'tx-groc-2'",
+    );
+    renderScreen(<Transactions />);
+    await waitFor(() => expect(screen.getByText('Trader Joes')).toBeTruthy());
+    await userEvent.click(screen.getByText('Trader Joes'));
+    await waitFor(() => expect(screen.getByText('Reattributed from 2026-05-14')).toBeTruthy());
+    await userEvent.click(screen.getByRole('button', { name: 'restore posting date' }));
+    await waitFor(() => expect(screen.getByText('Date restored to posting date')).toBeTruthy());
+
+    const res = await db.execute("SELECT date, original_date FROM transactions WHERE id = 'tx-groc-2'");
+    expect(res.rows[0]).toMatchObject({ date: '2026-05-14', original_date: null });
   });
 
   it('edit modal with a pattern shows live match count and saves a rule', async () => {

--- a/tests/queries.test.ts
+++ b/tests/queries.test.ts
@@ -519,6 +519,23 @@ describe('getTransactions — flex filter', () => {
 });
 
 // ──────────────────────────────────────────────────────────────────────
+describe('getTransactions — original_date', () => {
+  it('is null for transactions that have not been reattributed', async () => {
+    await insertTx({ amount: 100 });
+    const [row] = await getTransactions({});
+    expect(row.original_date).toBeNull();
+  });
+
+  it('carries the preserved posting date once a transaction is reattributed', async () => {
+    await insertTx({ amount: 100, date: '2025-01-15' });
+    await db.execute("UPDATE transactions SET original_date = '2025-01-15', date = '2024-12-31'");
+    const [row] = await getTransactions({});
+    expect(row.date).toBe('2024-12-31');
+    expect(row.original_date).toBe('2025-01-15');
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────
 describe('hasAccounts', () => {
   it('returns false when no accounts linked', async () => {
     await db.execute('DELETE FROM plaid_items');

--- a/tests/transactions.test.ts
+++ b/tests/transactions.test.ts
@@ -257,4 +257,12 @@ describe('setTransactionDate', () => {
     expect(inDec.rows.map((r) => r.id)).toEqual([id]);
     expect(inJan.rows).toHaveLength(0);
   });
+
+  it('rejects a malformed date and leaves the row untouched', async () => {
+    const id = await insertTx({ name: 'Target' });
+    await expect(setTransactionDate(id, '12/31/2024')).rejects.toThrow(/YYYY-MM-DD/);
+    await expect(setTransactionDate(id, '2025-13-01')).rejects.toThrow(/Invalid transaction date/);
+    await expect(setTransactionDate(id, '2025-02-30')).rejects.toThrow(/Invalid transaction date/);
+    expect(await dateOf(id)).toEqual({ date: '2025-01-15', original_date: null });
+  });
 });

--- a/tests/tui/screens.test.tsx
+++ b/tests/tui/screens.test.tsx
@@ -770,7 +770,8 @@ describe('Transactions', () => {
     r.stdin.write('\r');
     await waitFor(() => expect(frame(r)).toContain('← Grocery')); // panel open
     r.stdin.write('\x1b[B'); // name → category
-    r.stdin.write('\x1b[B'); // category → pattern
+    r.stdin.write('\x1b[B'); // category → date
+    r.stdin.write('\x1b[B'); // date → pattern
     await waitFor(() => expect(frame(r)).toContain('optional')); // Pattern field active (placeholder)
     for (const ch of 'Trader') r.stdin.write(ch);
     await waitFor(() => expect(frame(r)).toContain('transactions match'));
@@ -782,7 +783,8 @@ describe('Transactions', () => {
     r.stdin.write('\r');
     await waitFor(() => expect(frame(r)).toContain('← Grocery')); // panel open
     r.stdin.write('\x1b[B'); // name → category
-    r.stdin.write('\x1b[B'); // category → pattern
+    r.stdin.write('\x1b[B'); // category → date
+    r.stdin.write('\x1b[B'); // date → pattern
     r.stdin.write('\x1b[B'); // pattern → type
     await waitFor(() => expect(frame(r)).toContain('(unchanged)')); // name inactive = type field reached
     r.stdin.write('\x1b[C'); // → toggle name → regex
@@ -798,8 +800,10 @@ describe('Transactions', () => {
     r.stdin.write('\x1b[B'); // name → category
     await waitFor(() => expect(frame(r)).toContain('(unchanged)'));
     r.stdin.write('\x1b[C'); // cycle Grocery → Income
+    await waitFor(() => expect(frame(r)).toContain('← Income  →'));
     // Navigate to Pattern and type a pattern
-    r.stdin.write('\x1b[B'); // category → pattern
+    r.stdin.write('\x1b[B'); // category → date
+    r.stdin.write('\x1b[B'); // date → pattern
     await waitFor(() => expect(frame(r)).toContain('optional'));
     for (const ch of 'Trader') r.stdin.write(ch);
     await waitFor(() => expect(frame(r)).toContain('transactions match'));
@@ -809,6 +813,77 @@ describe('Transactions', () => {
       expect(f).not.toContain('optional'); // panel closed
       expect(f).toContain('Saved:');
     });
+  });
+
+  it('edit panel shows a Date field prefilled with the transaction date', async () => {
+    const r = txns();
+    await waitFor(() => expect(frame(r)).toContain('Trader Joes'));
+    r.stdin.write('\r');
+    await waitFor(() => {
+      // Trader Joes' posting date, prefilled into the panel's Date field
+      expect(flat(r)).toContain('Date [ 2026-05-14 ]');
+    });
+  });
+
+  it('editing the Date field and Enter reattributes the transaction', async () => {
+    const r = txns();
+    await waitFor(() => expect(frame(r)).toContain('Trader Joes'));
+    r.stdin.write('\r');
+    await waitFor(() => expect(frame(r)).toContain('← Grocery')); // panel open
+    r.stdin.write('\x1b[B'); // name → category
+    r.stdin.write('\x1b[B'); // category → date
+    await waitFor(() => expect(frame(r)).toContain('(unchanged)')); // date field active
+    // Clear the prefilled date and type a new one in April
+    for (let i = 0; i < 10; i++) r.stdin.write('\x7f'); // backspace ×10
+    await waitFor(() => expect(frame(r)).toContain('YYYY-MM-DD')); // field emptied → placeholder
+    for (const ch of '2026-04-30') r.stdin.write(ch);
+    await waitFor(() => expect(frame(r)).toContain('2026-04-30'));
+    r.stdin.write('\r'); // save
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).toContain('Date set to 2026-04-30');
+      // Row now sorts/reads under the reattributed date and out of the May window
+      expect(f).not.toContain('Trader Joes');
+    });
+  });
+
+  it('a malformed date shows an error and does not crash', async () => {
+    const r = txns();
+    await waitFor(() => expect(frame(r)).toContain('Trader Joes'));
+    r.stdin.write('\r');
+    await waitFor(() => expect(frame(r)).toContain('← Grocery'));
+    r.stdin.write('\x1b[B'); // name → category
+    r.stdin.write('\x1b[B'); // category → date
+    await waitFor(() => expect(frame(r)).toContain('(unchanged)'));
+    for (let i = 0; i < 10; i++) r.stdin.write('\x7f');
+    await waitFor(() => expect(frame(r)).toContain('YYYY-MM-DD'));
+    for (const ch of '2026-13') r.stdin.write(ch); // wrong shape — rejected before core
+    await waitFor(() => expect(frame(r)).toContain('2026-13'));
+    r.stdin.write('\r');
+    await waitFor(() => {
+      const f = frame(r);
+      expect(f).toContain('Invalid date');
+      expect(f).toContain('Trader Joes'); // still there, panel stayed put, no crash
+    });
+  });
+
+  it('marks a reattributed row and restores its posting date with [d]', async () => {
+    // Reattribute a May row's date to April, keeping its posting date.
+    await db.execute({
+      sql: 'UPDATE transactions SET original_date = ?, date = ? WHERE id = ?',
+      args: ['2026-04-28', '2026-05-14', 'tx-groc-2'],
+    });
+    const r = txns();
+    await waitFor(() => expect(frame(r)).toContain('Trader Joes'));
+    // Row carries the reattribution marker (asterisk flush against the date)
+    await waitFor(() => expect(frame(r)).toContain('2026-05-14*'));
+    r.stdin.write('\r');
+    await waitFor(() => expect(frame(r)).toContain('posted 2026-04-28')); // edit panel context line
+    r.stdin.write('\x1b'); // Esc back to the list
+    await waitFor(() => expect(frame(r)).not.toContain('posted 2026-04-28'));
+    r.stdin.write('d'); // restore posting date
+    await waitFor(() => expect(frame(r)).toContain('Date restored to 2026-04-28'));
+    await waitFor(() => expect(frame(r)).not.toContain('2026-05-14*'));
   });
 
   // The tag panel titles itself with whatever row the cursor is on, so its

--- a/tui/Transactions.tsx
+++ b/tui/Transactions.tsx
@@ -3,6 +3,7 @@ import { Box, Text, useInput } from 'ink';
 import {
   setTransactionCategory, clearTransactionOverride, setTransactionIgnored,
   setTransactionDisplayName, deleteTransaction,
+  setTransactionDate, clearTransactionDate,
   upsertCategoryRule, upsertNameRule,
   setTransactionCategoryBulk, clearOverridesBulk, setIgnoredBulk,
 } from '../core/transactions.js';
@@ -27,11 +28,17 @@ import { ModalPanel, usePagination, TextInput, SelectableRow, useStatusMessage, 
 import { useRefreshKey } from './RefreshContext.js';
 import { useSetTyping } from './TypingContext.js';
 
+// TxRow.original_date (from core/queries.ts) is non-null only when a
+// transaction has been reattributed to another period; it holds the bank's
+// true posting date.
 type Tx = TxRow;
 
 
 type Mode = 'list' | 'search' | 'edit' | 'tag' | 'tag-all' | 'edit-all';
-type EditField = 'name' | 'category' | 'pattern' | 'type';
+type EditField = 'name' | 'category' | 'date' | 'pattern' | 'type';
+
+/** Reattributed dates are always stored as ISO YYYY-MM-DD; reject anything else before calling core. */
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 
 const SORT_CYCLE: SortMode[] = ['date-desc', 'date-asc', 'name-asc', 'name-desc', 'amount-desc', 'amount-asc', 'category-asc', 'category-desc'];
 
@@ -74,6 +81,7 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
   // Edit panel state
   const [editField, setEditField] = useState<EditField>('name');
   const [editName, setEditName] = useState('');
+  const [editDate, setEditDate] = useState('');
   const [editCatCursor, setEditCatCursor] = useState(0);
   const [editPattern, setEditPattern] = useState('');
   const [editMatchType, setEditMatchType] = useState<'name' | 'regex'>('name');
@@ -113,7 +121,7 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
   const setTyping = useSetTyping();
   useEffect(() => {
     const isTextInput = mode === 'search' || mode === 'tag' || mode === 'tag-all'
-      || (mode === 'edit' && (editField === 'name' || editField === 'pattern'));
+      || (mode === 'edit' && (editField === 'name' || editField === 'pattern' || editField === 'date'));
     setTyping(isTextInput);
   }, [mode, editField]);
 
@@ -128,6 +136,7 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
     void getAllCategories().then((cats) => {
       setCategories(cats);
       setEditName('');
+      setEditDate(selected.date);
       setEditPattern('');
       setEditMatchType('name');
       setEditCatCursor(Math.max(0, cats.indexOf(selected.category)));
@@ -187,12 +196,28 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
     });
   }
 
-  function saveToTransaction() {
+  async function saveToTransaction() {
     if (!selected) return;
     const newCat = categories[editCatCursor];
     const newDisplay = editName.trim();
+    const newDate = editDate.trim();
     const nameChanged = newDisplay.length > 0;
     const catChanged = newCat !== selected.category;
+    const dateChanged = newDate.length > 0 && newDate !== selected.date;
+
+    if (dateChanged) {
+      if (!ISO_DATE_RE.test(newDate)) {
+        showStatus('Invalid date — use YYYY-MM-DD', 4000);
+        return;
+      }
+      try {
+        // core also validates and rejects impossible dates (e.g. 2026-02-31).
+        await setTransactionDate(selected.id, newDate);
+      } catch (e) {
+        showStatus(e instanceof Error ? e.message : 'Invalid date', 4000);
+        return;
+      }
+    }
 
     if (nameChanged) {
       setTransactionDisplayName(selected.id, newDisplay);
@@ -201,7 +226,9 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
       setTransactionCategory(selected.id, newCat);
     }
 
-    if (nameChanged || catChanged) showStatus('Transaction updated');
+    if (nameChanged || catChanged || dateChanged) {
+      showStatus(dateChanged && !nameChanged && !catChanged ? `Date set to ${newDate}` : 'Transaction updated');
+    }
     setMode('list');
     load(search, true);
   }
@@ -246,6 +273,15 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
     clearTransactionOverride(selected.id);
     showStatus('Override cleared');
     load(search, true);
+  }
+
+  function clearDateOverride() {
+    if (!selected?.original_date) return;
+    const posted = selected.original_date;
+    void clearTransactionDate(selected.id).then(() => {
+      showStatus(`Date restored to ${posted}`);
+      load(search, true);
+    });
   }
 
   const filteredTags = tagInput
@@ -341,10 +377,10 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
     }
 
     if (mode === 'edit') {
-      const EDIT_FIELDS: EditField[] = ['name', 'category', 'pattern', 'type'];
+      const EDIT_FIELDS: EditField[] = ['name', 'category', 'date', 'pattern', 'type'];
       if (key.escape) { setMode('list'); return; }
       if (key.return) {
-        if (editPattern.trim()) { void saveAsRule(); } else { saveToTransaction(); }
+        if (editPattern.trim()) { void saveAsRule(); } else { void saveToTransaction(); }
         return;
       }
       if (key.upArrow) { setEditField((f) => EDIT_FIELDS[Math.max(0, EDIT_FIELDS.indexOf(f) - 1)]); return; }
@@ -355,6 +391,11 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
       } else if (editField === 'category') {
         if (key.leftArrow) { setEditCatCursor((c) => Math.max(0, c - 1)); return; }
         if (key.rightArrow) { setEditCatCursor((c) => Math.min(categories.length - 1, c + 1)); return; }
+      } else if (editField === 'date') {
+        if (key.backspace || key.delete) { setEditDate((d) => d.slice(0, -1)); return; }
+        // Only the characters an ISO date is made of, so the buffer can't drift
+        // into something core will just reject on save.
+        if (input && !key.ctrl && !key.meta && /^[0-9-]+$/.test(input)) { setEditDate((d) => d + input); return; }
       } else if (editField === 'pattern') {
         if (key.backspace || key.delete) { setEditPattern((p) => p.slice(0, -1)); return; }
         if (input && !key.ctrl && !key.meta) { setEditPattern((p) => p + input); return; }
@@ -428,6 +469,7 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
         return;
       }
       if (input === 'c' && selected?.manual_category) clearOverride();
+      if (input === 'd' && selected?.original_date) clearDateOverride();
       if (input === 'C' && txs.length > 0) {
         clearOverridesBulk(txs.map((t) => t.id));
         const count = txs.filter((t) => t.manual_category).length;
@@ -525,7 +567,7 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
       </Box>
       <Text dimColor>
         {showHints
-          ? `[/] search  ·  [f] filter  ·  ${from ? '← →  ·  ' : ''}[s] sort  ·  Enter edit  [g] tag  [i] ignore  [x] delete  ·  [S] sync`
+          ? `[/] search  ·  [f] filter  ·  ${from ? '← →  ·  ' : ''}[s] sort  ·  Enter edit  [g] tag  [i] ignore  ${selected?.original_date ? '[d] restore date  ' : ''}[x] delete  ·  [S] sync`
           : '[/] search'}
       </Text>
 
@@ -559,7 +601,7 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
           <Box key={tx.id} flexDirection="column">
             <SelectableRow selected={isSelected}>
               <Text color={isSelected ? C_ACCENT : undefined} dimColor={isIgnored && !isSelected}>
-                {tx.date}
+                {tx.date}{tx.original_date ? <Text color={C_MANUAL}>*</Text> : null}
               </Text>
               <Text dimColor={isIgnored}>{truncate(tx.display_name ?? tx.merchant_name ?? tx.name, descW).padEnd(descW)}</Text>
               <Text color={isIgnored ? undefined : tx.amount < 0 ? C_POSITIVE : undefined} dimColor={isIgnored}>
@@ -662,9 +704,16 @@ export function Transactions({ onNavigate, initialFilter, isActive, showHints }:
           <Box marginTop={1} flexDirection="column" gap={1}>
             <EditTextField label="Name" labelWidth={12} active={editField === 'name'} value={editName} color={C_WARNING} placeholder="type new name…" emptyText="(unchanged)" />
             <EditToggleField label="Category" labelWidth={12} active={editField === 'category'} value={categories[editCatCursor] ?? '—'} />
+            <EditTextField label="Date" labelWidth={12} active={editField === 'date'} value={editDate} color={C_WARNING} placeholder="YYYY-MM-DD" emptyText="—" />
             <EditTextField label="Pattern" labelWidth={12} active={editField === 'pattern'} value={editPattern} color={C_MANUAL} placeholder="optional — saves as rule" emptyText="—" />
             <EditToggleField label="Match type" labelWidth={12} active={editField === 'type'} value={editMatchType} />
           </Box>
+
+          {selected.original_date ? (
+            <Box marginTop={1}>
+              <Text dimColor>posted {selected.original_date} · [Esc] then [d] restores it</Text>
+            </Box>
+          ) : null}
 
           {editPattern.trim() ? (
             <Box marginTop={1} gap={2}>


### PR DESCRIPTION
## Why

PR #169 added `setTransactionDate` / `clearTransactionDate` to the finance engine and the MCP tools, but left both UIs with no way to reach them — the only way to reattribute a transaction's date was to ask an agent. This adds a date field to the transaction edit panel on each surface.

## Changes

**core**
- `getTransactions()` now selects `original_date` and `TxRow` carries it, so a row knows whether its date was reattributed.
- `setTransactionDate` validates `YYYY-MM-DD` before writing (a malformed date silently drops the row out of every range query). The check also now rejects impossible days like `2025-02-30`, which the old MCP-only regex + `Date.parse` let through.

**gui**
- Date input in the transaction edit modal, wired through `registry.ts` (the generic preload bridge picks it up automatically).
- "Restore posting date" action on reattributed rows, mirroring the existing category-override / "clear override" pattern.

**tui**
- Date field in the edit panel, ordered `name → category → date → pattern → type`.
- A dim `posted <original_date>` hint on reattributed rows and `d` in list mode to restore, mirroring `c` for category overrides.

## Tests

- `tsc --noEmit` clean; full suite **971 passed**.
- New tests in `tests/queries.test.ts`, `tests/transactions.test.ts`, `tests/gui/transactions.test.tsx`, `tests/tui/screens.test.tsx`.
- One pre-existing failure remains — `digit-nav sweep` / Canvas render timeout in `tests/tui/screens.test.tsx` — confirmed to fail identically on the clean branch (`git stash`). Unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)