### PR TITLE
docs: fix stale "delta mode" naming (it is the scorecard)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Personal finance, keyboard-first. Available as a **terminal UI** or a **desktop 
 - **Manual assets** — track a house, car, or other asset by name and value
 - **Category & name rules** — substring or regex rules that auto-categorize and rename transactions; survives re-syncs
 - **Spending flexibility** — tag categories as fixed / flexible / discretionary; see breakdown on Dashboard
-- **Delta mode** — per-category spending deltas vs prior period, same period last year, and 12-month rolling average; heat-map coloring
+- **Scorecard** — categories flagged over / under the typical month against a 12-month median baseline, with a net verdict and optional delta columns (prior period, same period last year, 12-month average); heat-map coloring
 - **Tags** — label transactions across accounts (trips, projects, events) and view summaries by tag
 - **Net worth** — balance history with asset/liability breakdown; by account or by type
 - **Financial health** — cash and liquid runway, FIRE number and progress, years to retirement with adjustable assumptions

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -38,18 +38,20 @@ Fields: **Your name**, **Birth year**, and optionally **Spouse name**, **Spouse 
 |-----|--------|
 | `r` | Cycle time range (Week → Month → Quarter → Year → All Time) |
 | `← →` | Previous / next period |
-| `Tab` | Cycle views: Categories → Flex → Account picker |
-| `↑ ↓` | Select category (Categories view) or account (Account view) |
-| `Enter` | Drill into transactions for selected category / account |
+| `Tab` | Cycle views: Categories → Flex → Account → Owner (Owner shown once an account has an owner) |
+| `↑ ↓` | Select row in the active view |
+| `Enter` | Drill into transactions for the selected row |
+| `m` | Top merchants for the selected category (Categories view, not in scorecard) |
 | `Space` | Toggle account filter (Account view) |
-| `c` | Clear account filter |
-| `d` | Toggle delta mode (spending vs prior period / same period last year / 12-month avg) |
+| `c` | Clear account filter (Account view) |
+| `s` | Toggle scorecard — categories over / under the typical month |
+| `x` | In scorecard: switch compact bars ↔ delta columns |
 | `f` | Open filter panel |
 | `/` | Search transactions by name (regex); filters category totals live |
 
-In **Categories** view, spending is broken down by category with bar charts. In **Flex** view, spending is grouped by flexibility tier (fixed / flexible / discretionary / untagged). In **Account** view, select an account to filter all dashboard data to that account.
+In **Categories** view, spending is broken down by category with bar charts. In **Flex** view, spending is grouped by flexibility tier (fixed / flexible / discretionary / untagged). In **Account** view, select an account to filter all dashboard data to that account. In **Owner** view, spending is split by the owner assigned to each account.
 
-In **delta mode**, the bar chart is replaced by three delta columns — vs prev period, vs same period last year, and vs 12-month rolling average — color-coded green / yellow / red by deviation. Not available for the All Time range. An active search carries through when switching to Transactions (`2`) or Trends (`3`).
+In **scorecard** mode (`s`), categories are bucketed into OVER / TYPICAL / UNDER against their 12-month median, with a net verdict at the bottom. `x` swaps the compact bars for delta columns against three baselines — prev period, same period last year, and 12-month average — color-coded green / yellow / red by deviation. Scorecard is not available for the All Time range. An active search carries through when switching to Transactions (`2`) or Trends (`3`).
 
 ## Transactions `[2]`
 


### PR DESCRIPTION
## What

The Dashboard comparison view is called **scorecard** and is bound to **`s`** (with `x` toggling the three-baseline delta columns). The docs still called it "delta mode" bound to `d`, which never existed in `tui/Dashboard.tsx`.

- `docs/keybindings.md` — corrected the Dashboard key table and the two prose paragraphs; while there, documented the **Owner** view and the `m` merchants drill, which were also missing
- `README.md` — renamed the "Delta mode" feature bullet to "Scorecard"

Verified against `tui/Dashboard.tsx` (`s` → `scorecardMode`, `x` → `detailMode`), `core/scorecard.ts`, and the `get_scorecard` MCP tool.

## Not included

`PLANS.md` is gitignored (`.gitignore:7`) and untracked, so it can't go in a PR. I still cleaned it up locally: removed the "Net Worth Tracking" and "FIRE Planning Screen" sections, since both ship today as the **Net Worth** (screen 4) and **Financial Health** (screen 6) screens in `tui/` and `gui/renderer/src/screens/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)