### PR TITLE
feat: count loan balances as liabilities in net worth

### DIFF
--- a/core/account-class.ts
+++ b/core/account-class.ts
@@ -6,4 +6,5 @@
 export const isAssetAccount = (a: { type: string; balance: number }): boolean =>
   a.type === 'depository' || a.type === 'investment' || (a.type === 'other' && a.balance > 0);
 
-export const isLiabilityAccount = (a: { type: string }): boolean => a.type === 'credit';
+export const isLiabilityAccount = (a: { type: string }): boolean =>
+  a.type === 'credit' || a.type === 'loan';

--- a/core/agent-context.ts
+++ b/core/agent-context.ts
@@ -87,7 +87,8 @@ export async function getBalances(): Promise<BalanceSummary> {
         WHEN 'investment'  THEN 1
         WHEN 'other'       THEN 2
         WHEN 'credit'      THEN 3
-        ELSE 4
+        WHEN 'loan'        THEN 4
+        ELSE 5
       END,
       bh.balance DESC
   `);
@@ -275,7 +276,7 @@ export const APP_CONTEXT = `
   \`date\`, so they reflect the reattribution. Survives re-syncs.
 - \`ignored\`: soft-hides a transaction from all totals (transfers, reimbursements, refunds, etc.).
 - \`hidden_categories\`: categories excluded from all totals and charts (e.g. "Transfer").
-- Accounts: type is one of depository, investment, credit, other.
+- Accounts: type is one of depository, investment, credit, loan, other.
 - Manual assets are stored as accounts with type='other', subtype='manual'.
 - Balances are stored in balance_history (account_id, date, balance). Most recent = current balance.
 
@@ -298,8 +299,10 @@ export const APP_CONTEXT = `
 
 ## Net Worth Calculation
 - Assets: depository + investment + other (if balance > 0)
-- Liabilities: credit accounts
+- Liabilities: credit + loan accounts (credit cards, plus mortgage / auto / student loans)
 - Net Worth = Assets − Liabilities
+- Loan balances are subtracted, so FIRE progress reflects mortgage debt. To net a
+  house out, add it as a manual asset or leave the mortgage unlinked.
 
 ## FIRE Calculation (Financial Health screen)
 - FIRE Number = (avg monthly expenses × 12) / withdrawal_rate

--- a/core/canvas-agent.ts
+++ b/core/canvas-agent.ts
@@ -117,7 +117,7 @@ export async function loadCanvasContext(): Promise<CanvasContext> {
     `Monthly surplus:   ${fmt(health.monthlySavings)} (savings rate: ${Math.round(health.savingsRate)}%)`,
     `Cash (checking/savings): ${fmtCompact(health.cash)}`,
     `Taxable investments (brokerage): ${fmtCompact(taxableBrokerage)}  ← no withdrawal restrictions`,
-    `Total accessible (cash + brokerage): ${fmtCompact(health.liquid)}`,
+    `Total liquid (cash + brokerage): ${fmtCompact(health.liquid)}`,
     `Retirement accounts (401k/IRA/Roth): ${fmtCompact(health.retirement)}  ← restricted until ~59½`,
     `Credit card debt:  ${fmtCompact(health.totalDebt)}`,
     health.loanDebt > 0 ? `Loan debt (mortgage/auto/student): ${fmtCompact(health.loanDebt)}` : null,

--- a/core/health.ts
+++ b/core/health.ts
@@ -69,7 +69,7 @@ export async function loadHealthData(): Promise<HealthData> {
     db.execute(`
       SELECT
         COALESCE(SUM(CASE WHEN a.type IN ('depository','investment') OR (a.type = 'other' AND bh.balance > 0) THEN bh.balance ELSE 0 END), 0) -
-        COALESCE(SUM(CASE WHEN a.type = 'credit' THEN bh.balance ELSE 0 END), 0) AS net_worth
+        COALESCE(SUM(CASE WHEN a.type IN ('credit','loan') THEN bh.balance ELSE 0 END), 0) AS net_worth
       FROM accounts a
       JOIN balance_history bh ON bh.account_id = a.id
       WHERE a.excluded = 0

--- a/core/queries.ts
+++ b/core/queries.ts
@@ -825,11 +825,11 @@ export async function getNetWorthHistory(granularity: NetWorthGranularity = 'mon
         WHEN a.type = 'other' AND pl.balance > 0 THEN pl.balance
         ELSE 0
       END) AS assets,
-      SUM(CASE WHEN a.type = 'credit' THEN pl.balance ELSE 0 END) AS liabilities,
+      SUM(CASE WHEN a.type IN ('credit', 'loan') THEN pl.balance ELSE 0 END) AS liabilities,
       SUM(CASE
         WHEN a.type IN ('depository', 'investment') THEN pl.balance
         WHEN a.type = 'other' AND pl.balance > 0 THEN pl.balance
-        WHEN a.type = 'credit' THEN -pl.balance
+        WHEN a.type IN ('credit', 'loan') THEN -pl.balance
         ELSE 0
       END) AS net_worth
     FROM period_last pl
@@ -860,7 +860,7 @@ export async function getAccountsWithBalances(): Promise<{ accounts: AccountBala
     db.execute(`
       SELECT bh.date,
         SUM(CASE WHEN a.type IN ('depository','investment') OR (a.type = 'other' AND bh.balance > 0) THEN bh.balance ELSE 0 END) as assets,
-        SUM(CASE WHEN a.type = 'credit' THEN bh.balance ELSE 0 END) as liabilities
+        SUM(CASE WHEN a.type IN ('credit','loan') THEN bh.balance ELSE 0 END) as liabilities
       FROM balance_history bh
       JOIN accounts a ON a.id = bh.account_id
       WHERE a.excluded = 0

--- a/core/tools.ts
+++ b/core/tools.ts
@@ -573,7 +573,7 @@ async function executeToolImpl(
         'Liabilities:',
         ...b.accounts.filter((a) => a.isLiability).map((a) => `  ${a.name}: ${fmt(a.balance)}`),
         `  Total liabilities: ${fmt(b.totalLiabilities)}`,
-        `Net worth: ${b.netWorth >= 0 ? '' : '-'}${fmt(b.netWorth)}`,
+        `Net worth: ${fmt(b.netWorth)}`,
         `Cash (checking/savings): ${fmt(b.cash)}`,
         `Liquid (incl. brokerage): ${fmt(b.liquid)}`,
         ...(b.excludedAccounts.length ? [
@@ -591,7 +591,7 @@ async function executeToolImpl(
       const fmtM = (n: number) => Number.isFinite(n) && n < 999 ? `${n.toFixed(1)} months` : '∞';
       const hasPretax = h.pretaxMonthly > 0;
       return [
-        `Net worth: ${h.netWorth >= 0 ? '' : '-'}${fmt(h.netWorth, 0)}`,
+        `Net worth: ${fmt(h.netWorth, 0)}`,
         `Cash runway: ${fmtM(h.cashRunwayMonths)} (${fmt(h.cash, 0)} in checking/savings)`,
         `Liquid runway: ${fmtM(h.liquidRunwayMonths)} (${fmt(h.liquid, 0)} incl. brokerage)`,
         `Avg monthly expenses (12 mo): ${fmt(h.avgMonthlyExpenses, 0)}`,

--- a/tests/health.test.ts
+++ b/tests/health.test.ts
@@ -1,5 +1,12 @@
-import { describe, it, expect } from 'vitest';
-import { yearsToFire, coastYears } from '../core/health.js';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('../core/db.js', async () => {
+  const { makeTestDb } = await import('./helpers/makeTestDb.js');
+  return { db: await makeTestDb() };
+});
+
+import { db } from '../core/db.js';
+import { yearsToFire, coastYears, loadHealthData } from '../core/health.js';
 
 describe('yearsToFire', () => {
   it('returns 0 when already at or above target', () => {
@@ -59,6 +66,56 @@ describe('coastYears', () => {
 
   it('returns null for extreme values (over 200 years)', () => {
     expect(coastYears(1, 1000000000, 1)).toBeNull();
+  });
+});
+
+describe('loadHealthData — loan accounts as liabilities', () => {
+  beforeEach(async () => {
+    await db.execute('DELETE FROM accounts');
+    await db.execute('DELETE FROM balance_history');
+    await db.execute('DELETE FROM transactions');
+
+    const acct = (id: string, type: string, subtype: string) =>
+      db.execute({
+        sql: "INSERT INTO accounts (id, name, type, subtype, excluded) VALUES (?, ?, ?, ?, 0)",
+        args: [id, id, type, subtype],
+      });
+    const bal = (id: string, balance: number) =>
+      db.execute({
+        sql: "INSERT INTO balance_history (account_id, balance, date) VALUES (?, ?, '2026-05-20')",
+        args: [id, balance],
+      });
+
+    await acct('chk', 'depository', 'checking');
+    await acct('brk', 'investment', 'brokerage');
+    await acct('401k', 'investment', '401k');
+    await acct('cc', 'credit', 'credit card');
+    await acct('mtg', 'loan', 'mortgage');
+
+    await bal('chk', 40000);    // cash + liquid
+    await bal('brk', 150000);   // liquid (taxable brokerage), not cash
+    await bal('401k', 500000);  // retirement, not liquid
+    await bal('cc', 3000);      // credit liability
+    await bal('mtg', 300000);   // loan liability
+  });
+
+  it('subtracts both credit and loan balances from net worth', async () => {
+    const h = await loadHealthData();
+    // assets 40000 + 150000 + 500000 = 690000; liabilities 3000 + 300000 = 303000
+    expect(h.netWorth).toBe(387000);
+  });
+
+  it('reports loanDebt separately from credit-card debt', async () => {
+    const h = await loadHealthData();
+    expect(h.totalDebt).toBe(3000);    // credit card only
+    expect(h.loanDebt).toBe(300000);   // mortgage, reported on its own
+  });
+
+  it('leaves cash and liquid untouched by the loan', async () => {
+    const h = await loadHealthData();
+    expect(h.cash).toBe(40000);              // depository only
+    expect(h.liquid).toBe(190000);           // checking + taxable brokerage
+    expect(h.retirement).toBe(500000);       // 401k
   });
 });
 

--- a/tests/queries.test.ts
+++ b/tests/queries.test.ts
@@ -686,6 +686,35 @@ describe('excluded accounts', () => {
 });
 
 // ──────────────────────────────────────────────────────────────────────
+describe('loan accounts count as liabilities in net worth', () => {
+  beforeEach(async () => {
+    await db.execute('DELETE FROM accounts');
+    await db.execute('DELETE FROM balance_history');
+    // Checking asset, a credit card, and a mortgage — all Plaid balances stored positive.
+    await db.execute({ sql: "INSERT INTO accounts (id, name, type, subtype, excluded) VALUES ('chk', 'Checking', 'depository', 'checking', 0)", args: [] });
+    await db.execute({ sql: "INSERT INTO accounts (id, name, type, subtype, excluded) VALUES ('cc', 'Visa', 'credit', 'credit card', 0)", args: [] });
+    await db.execute({ sql: "INSERT INTO accounts (id, name, type, subtype, excluded) VALUES ('mtg', 'Mortgage', 'loan', 'mortgage', 0)", args: [] });
+    await db.execute({ sql: "INSERT INTO balance_history (account_id, balance, date) VALUES ('chk', 50000, '2025-01-31')", args: [] });
+    await db.execute({ sql: "INSERT INTO balance_history (account_id, balance, date) VALUES ('cc', 2000, '2025-01-31')", args: [] });
+    await db.execute({ sql: "INSERT INTO balance_history (account_id, balance, date) VALUES ('mtg', 300000, '2025-01-31')", args: [] });
+  });
+
+  it('subtracts the loan balance in getNetWorthHistory', async () => {
+    const hist = await getNetWorthHistory('month');
+    expect(hist).toHaveLength(1);
+    expect(hist[0].assets).toBe(50000);
+    expect(hist[0].liabilities).toBe(302000);      // credit card + mortgage
+    expect(hist[0].net_worth).toBe(-252000);       // 50000 - 2000 - 300000
+  });
+
+  it('subtracts the loan balance in the getAccountsWithBalances history series', async () => {
+    const { history } = await getAccountsWithBalances();
+    expect(history.at(-1)!.liabilities).toBe(302000);
+    expect(history.at(-1)!.net).toBe(-252000);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────
 describe('getLinkedAccounts — awaiting-first-sync placeholders', () => {
   beforeEach(async () => {
     await db.execute('DELETE FROM plaid_items');

--- a/tests/tools-balances.test.ts
+++ b/tests/tools-balances.test.ts
@@ -29,6 +29,34 @@ describe('getBalances with an excluded account', () => {
   });
 });
 
+describe('getBalances with a loan account', () => {
+  beforeEach(async () => {
+    // Add a mortgage alongside the checking account seeded above.
+    await db.execute("INSERT INTO accounts (id, name, type, subtype, institution_name, mask, excluded) VALUES ('mtg', 'Home Mortgage', 'loan', 'mortgage', 'Test Bank', '7777', 0)");
+    await db.execute("INSERT INTO balance_history (account_id, balance, date) VALUES ('mtg', 300000.00, '2026-05-20')");
+  });
+
+  it('classifies the loan as a liability and subtracts it from net worth', async () => {
+    const b = await getBalances();
+    const mtg = [...b.accounts].find((a) => a.name === 'Home Mortgage')!;
+    expect(mtg.isLiability).toBe(true);
+    expect(mtg.isAsset).toBe(false);
+    expect(b.totalAssets).toBe(5000);
+    expect(b.totalLiabilities).toBe(300000);
+    expect(b.loanDebt).toBe(300000);          // still reported separately
+    expect(b.netWorth).toBe(-295000);
+  });
+
+  it('lists the mortgage under Liabilities in the get_balances tool output', async () => {
+    const out = await executeTool('get_balances', {});
+    expect(out).toContain('Home Mortgage: $300,000.00');
+    expect(out).toContain('Total liabilities: $300,000.00');
+    // Negative net worth once the mortgage is subtracted (fmt renders the sign;
+    // the tool prefixes another '-', a pre-existing double-sign quirk).
+    expect(out).toContain('$295,000.00');
+  });
+});
+
 describe('get_balances tool output', () => {
   it('shows a carved-out "Excluded" section and leaves net worth untouched', async () => {
     const out = await executeTool('get_balances', {});

--- a/tests/tools-balances.test.ts
+++ b/tests/tools-balances.test.ts
@@ -51,9 +51,10 @@ describe('getBalances with a loan account', () => {
     const out = await executeTool('get_balances', {});
     expect(out).toContain('Home Mortgage: $300,000.00');
     expect(out).toContain('Total liabilities: $300,000.00');
-    // Negative net worth once the mortgage is subtracted (fmt renders the sign;
-    // the tool prefixes another '-', a pre-existing double-sign quirk).
-    expect(out).toContain('$295,000.00');
+    // Net worth goes negative once the mortgage is subtracted; fmt() owns the
+    // single leading sign (no double '-').
+    expect(out).toContain('Net worth: -$295,000.00');
+    expect(out).not.toContain('--$');
   });
 });
 


### PR DESCRIPTION
## What

Loan balances (`type='loan'` — mortgage, auto, student) now count as liabilities in net worth. Previously only `type='credit'` accounts were subtracted, so net worth was overstated and FIRE progress (`netWorth / fireNumber`) ignored mortgage debt.

Decision: loans DO count. To net a home out, add it as a manual asset or leave the mortgage unlinked — that's a choice, not the default.

## Net worth math, before → after

Every net-worth surface now treats `credit` + `loan` as liabilities:

| Site | Change |
|---|---|
| `core/account-class.ts` `isLiabilityAccount` | `'credit'` → `'credit' \|\| 'loan'`. Feeds `getBalances` `totalLiabilities` / `netWorth` and the agent `isLiability` flag automatically. |
| `core/health.ts` `loadHealthData` net-worth SQL | subtracts `type IN ('credit','loan')`. `loanDebt` still queried and reported separately for the breakdown; `totalDebt` stays credit-only. |
| `core/queries.ts` `getNetWorthHistory` | `liabilities` and `net_worth` CASE arms include `loan`. |
| `core/queries.ts` `getAccountsWithBalances` history series | `liabilities` sum includes `loan`. |
| `core/agent-context.ts` `getBalances` | no logic change (uses `isLiabilityAccount`); `ORDER BY` now sorts `loan` right after `credit`. |

## Sign convention

Plaid stores `balances.current` for loan accounts as a **positive** number (amount owed), same as credit cards (confirmed in `core/sync.ts` — the value is inserted verbatim). So loans are subtracted directly, identical to the existing credit handling. No negation needed.

## Also in this PR

- **Double-sign fix.** `get_balances` and `get_financial_health` output prepended a literal `'-'` while `fmt()` already renders its own sign, so a negative net worth printed as `--$295,000.00`. Dropped the manual prefix in both formatters (`core/tools.ts`); `fmt()` now owns the sign. Loan accounts make negative net worth common, so this matters now.
- `core/agent-context.ts` `APP_CONTEXT`: account-types list now includes `loan`; the Net Worth Calculation section documents loan as a liability and the manual-asset workaround.
- `core/canvas-agent.ts`: `"Total accessible (cash + brokerage)"` → `"Total liquid (cash + brokerage)"` for consistent terminology.

## Tests

- `tests/health.test.ts`: new DB-backed `loadHealthData` case — depository + taxable brokerage + 401k + credit card + mortgage; asserts `netWorth` subtracts both credit and loan, `totalDebt` stays credit-only, `loanDebt` is reported separately, `cash` / `liquid` / `retirement` unaffected.
- `tests/queries.test.ts`: a mortgage plus a credit card, asserting `getNetWorthHistory` and the `getAccountsWithBalances` history series subtract both.
- `tests/tools-balances.test.ts`: `getBalances` classifies a mortgage as a liability, keeps `loanDebt` separate, drives `netWorth` negative; output asserts no `--$` double sign.
- Full non-UI suite: 610 passing, `tsc --noEmit` clean.

## Follow-ups (separate PRs)

- #176 — GUI Health screen: Credit cards / Loans / Total breakdown.
- #177 — TUI Health screen: same.
- Net Worth screens (gui + tui) already render loan accounts correctly — they classify through `isLiabilityAccount` and plot the core history series verbatim. Verified, no change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
