### PR TITLE
feat(gui): break Health debt into credit cards + loans

### DIFF
--- a/gui/renderer/src/screens/Health.tsx
+++ b/gui/renderer/src/screens/Health.tsx
@@ -68,6 +68,8 @@ export function Health() {
   const netCash = data.cash - data.totalDebt;
   const remainingDebt = Math.max(0, data.totalDebt - data.cash);
   const debtMonths = savings > 0 ? remainingDebt / savings : null;
+  const combinedDebt = data.totalDebt + data.loanDebt;
+  const hasLoanDebt = data.loanDebt > 0;
 
   return (
     <div className={styles.screen}>
@@ -141,7 +143,7 @@ export function Health() {
             <span className={`num ${runwayClass(liquidMonths, 12, 6)} ${styles.metricValue}`}>{fmtMonths(liquidMonths)}</span>
             <span className={`dim ${styles.metricHint}`}>{fmtCompact(data.liquid)} incl. brokerage</span>
           </div>
-          {data.totalDebt > 0 && (
+          {combinedDebt > 0 && !hasLoanDebt && (
             <div className={styles.metric}>
               <span className={styles.metricLabel}>Debt</span>
               <span className={`num neg ${styles.metricValue}`}>
@@ -153,6 +155,37 @@ export function Health() {
                   : `${fmtCompact(Math.abs(netCash))} more than cash`}
               </span>
             </div>
+          )}
+          {hasLoanDebt && (
+            <>
+              <div className={styles.metric}>
+                <span className={styles.metricLabel}>Credit cards</span>
+                <span className={`num ${data.totalDebt > 0 ? 'neg' : 'dim'} ${styles.metricValue}`}>
+                  {fmtCompact(data.totalDebt)}
+                </span>
+                <span className={`dim ${styles.metricHint}`}>
+                  {data.totalDebt === 0
+                    ? 'no card balance'
+                    : netCash >= 0
+                      ? `covered · ${fmtCompact(netCash)} net cash`
+                      : `${fmtCompact(Math.abs(netCash))} more than cash`}
+                </span>
+              </div>
+              <div className={styles.metric}>
+                <span className={styles.metricLabel}>Loans</span>
+                <span className={`num neg ${styles.metricValue}`}>
+                  {fmtCompact(data.loanDebt)}
+                </span>
+                <span className={`dim ${styles.metricHint}`}>mortgage / auto / student</span>
+              </div>
+              <div className={styles.metric}>
+                <span className={styles.metricLabel}>Total</span>
+                <span className={`num neg ${styles.metricValue}`}>
+                  {fmtCompact(combinedDebt)}
+                </span>
+                <span className={`dim ${styles.metricHint}`}>subtracted from net worth</span>
+              </div>
+            </>
           )}
           {data.totalDebt > 0 && netCash < 0 && (
             <div className={styles.metric}>

--- a/tests/gui/health.test.tsx
+++ b/tests/gui/health.test.tsx
@@ -42,6 +42,27 @@ describe('GUI Health', () => {
     expect(screen.getByText('Years to FIRE')).toBeTruthy();
   });
 
+  it('breaks debt into credit cards, loans and a combined total when a loan account exists', async () => {
+    await db.execute("UPDATE balance_history SET balance = 450.00 WHERE account_id = 'test-credit'");
+    await db.execute("INSERT INTO accounts (id, name, type, subtype, institution_name, mask) VALUES ('test-mortgage', 'Home Loan', 'loan', 'mortgage', 'Test Bank', '0003')");
+    await db.execute("INSERT INTO balance_history (account_id, balance, date) VALUES ('test-mortgage', 300000.00, '2026-05-20')");
+    renderScreen(<Health />);
+    await waitFor(() => expect(screen.getByText('Credit cards')).toBeTruthy());
+    expect(screen.getByText('Loans')).toBeTruthy();
+    // Combined-total row
+    const totalRow = screen.getByText('Total').closest('div')!;
+    expect(totalRow.textContent).toContain('subtracted from net worth');
+    // The single generic "Debt" row is not rendered once the breakdown shows
+    expect(screen.queryByText('Debt')).toBeNull();
+  });
+
+  it('shows a single Debt row when there is no loan debt', async () => {
+    await db.execute("UPDATE balance_history SET balance = 450.00 WHERE account_id = 'test-credit'");
+    renderScreen(<Health />);
+    await waitFor(() => expect(screen.getByText('Debt')).toBeTruthy());
+    expect(screen.queryByText('Loans')).toBeNull();
+  });
+
   it('renders the four assumption dials', async () => {
     renderScreen(<Health />);
     await waitFor(() => expect(screen.getByText('Monthly spending')).toBeTruthy());


### PR DESCRIPTION
Follow-up to core PR #175 (loan accounts count as liabilities in net worth). Merges after #175.

## Problem
The GUI Health screen's Cash Flow section showed a single **Debt** figure sourced from `HealthData.totalDebt`, which is credit-card-only. Once #175 lands, net worth drops for anyone with a mortgage / auto / student loan, with nothing on this screen accounting for it.

## Change
`HealthData.loanDebt` already exists (separate from `totalDebt`, which stays credit-only). When a loan account is present, the single **Debt** row now expands into three lines:

- **Credit cards** — `totalDebt`
- **Loans** — `loanDebt` (rendered only when `loanDebt > 0`)
- **Total** — combined, hinted "subtracted from net worth"

No visual change for users without a loan account (still the single **Debt** row). Payoff math (`netCash`, "Debt-free in") stays credit-only — a 30-year mortgage isn't a cash-runway payoff target.

Labels/layout match the parallel `tui/Health.tsx` change ("Credit cards" / "Loans" / "Total").

## Tests
`tests/gui/health.test.tsx`: added coverage for the three-line breakdown with a loan account, and for the single-row fallback without one. Full GUI suite green (134 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)