### PR TITLE
feat(tui): break out loan debt in the Health DEBT section

### DIFF
--- a/tests/tui/health-debt.test.tsx
+++ b/tests/tui/health-debt.test.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from 'ink-testing-library';
+import type { HealthData } from '../../core/health.js';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+// The DEBT section splits credit-card debt (HealthData.totalDebt) from loan debt
+// (HealthData.loanDebt, added when loan accounts started counting as liabilities).
+
+const BASE: HealthData = {
+  avgMonthlyExpenses: 4000,
+  monthlyIncome: 8000,
+  monthlySavings: 2000,
+  savingsRate: 25,
+  cash: 30000,
+  liquid: 50000,
+  retirement: 100000,
+  totalDebt: 0,
+  loanDebt: 0,
+  netWorth: 150000,
+};
+
+let health: HealthData = { ...BASE };
+
+vi.mock('../../core/health.js', async (importActual) => {
+  const actual = await importActual<typeof import('../../core/health.js')>();
+  return { ...actual, loadHealthData: async () => health };
+});
+
+vi.mock('../../core/settings.js', () => ({
+  PRETAX_MONTHLY_KEY: 'pretax_monthly',
+  getSetting: async () => null,
+  setSetting: async () => {},
+}));
+
+vi.mock('../../core/profile.js', () => ({
+  loadProfile: async () => null,
+  householdMembers: () => [],
+}));
+
+const { Health } = await import('../../tui/Health.js');
+
+const noop = () => {};
+const frame = (r: ReturnType<typeof render>) => r.lastFrame() ?? '';
+async function waitFor(fn: () => void) {
+  for (let i = 0; i < 50; i++) {
+    try { fn(); return; } catch { await new Promise((res) => setTimeout(res, 10)); }
+  }
+  fn();
+}
+
+beforeEach(() => { health = { ...BASE }; });
+
+describe('Health — DEBT section with loan debt', () => {
+  it('hides the DEBT section when there is neither card nor loan debt', async () => {
+    const r = render(<Health onNavigate={noop} showHints={false} isActive />);
+    await waitFor(() => expect(frame(r)).toContain('RETIREMENT'));
+    expect(frame(r)).not.toContain('DEBT');
+  });
+
+  it('shows only the credit-card view when there is no loan debt', async () => {
+    health = { ...BASE, totalDebt: 5000, cash: 30000 };
+    const r = render(<Health onNavigate={noop} showHints={false} isActive />);
+    await waitFor(() => expect(frame(r)).toContain('DEBT'));
+    const f = frame(r);
+    expect(f).toContain('Net cash');
+    expect(f).not.toContain('Loans');
+    expect(f).not.toMatch(/\bTotal\b/);
+  });
+
+  it('breaks out Credit cards / Loans / Total when there is loan debt', async () => {
+    health = { ...BASE, totalDebt: 4000, loanDebt: 296000, cash: 30000, netWorth: -150000 };
+    const r = render(<Health onNavigate={noop} showHints={false} isActive />);
+    await waitFor(() => expect(frame(r)).toContain('DEBT'));
+    const f = frame(r);
+    expect(f).toContain('Credit cards');
+    expect(f).toContain('$4,000');
+    expect(f).toContain('Loans');
+    expect(f).toContain('$296,000');
+    expect(f).toContain('mortgage / auto / student');
+    expect(f).toContain('Total');
+    expect(f).toContain('$300,000');
+  });
+
+  it('shows the section for a loan-only borrower and omits the card payoff rows', async () => {
+    health = { ...BASE, totalDebt: 0, loanDebt: 300000, netWorth: -150000 };
+    const r = render(<Health onNavigate={noop} showHints={false} isActive />);
+    await waitFor(() => expect(frame(r)).toContain('DEBT'));
+    const f = frame(r);
+    expect(f).toContain('Loans');
+    expect(f).toContain('Total');
+    expect(f).not.toContain('Net cash');
+    expect(f).not.toContain('Debt-free in');
+  });
+});

--- a/tui/Health.tsx
+++ b/tui/Health.tsx
@@ -255,34 +255,55 @@ export function Health({ onNavigate, isActive, showHints }: { onNavigate: (s: Sc
       </Box>
 
       {/* ── Debt (only shown if there is debt) ─────────────────────────────── */}
-      {data.totalDebt > 0 && (
+      {(data.totalDebt > 0 || data.loanDebt > 0) && (
         <Box flexDirection="column" marginTop={1}>
           <SectionHeader>DEBT</SectionHeader>
-          <Box gap={3} marginTop={1}>
-            <Text dimColor>{'Net cash'.padEnd(L)}</Text>
-            <Text bold color={netCash >= 0 ? C_POSITIVE : C_NEGATIVE}>
-              {fmtSigned(netCash).padStart(V)}
-            </Text>
-            <Text dimColor>
-              {netCash >= 0
-                ? 'could pay off now'
-                : `${fmtCompact(data.cash)} cash · ${fmtCompact(data.totalDebt)} debt`}
-            </Text>
-          </Box>
-          {netCash < 0 && (
-            <Box gap={3}>
-              <Text dimColor>{'Debt-free in'.padEnd(L)}</Text>
-              {debtMonths === null ? (
-                <Text color={C_NEGATIVE}>{'no surplus'.padStart(V)}</Text>
-              ) : (
-                <Text bold color={debtMonths <= 6 ? C_POSITIVE : debtMonths <= 24 ? C_WARNING : C_NEUTRAL}>
-                  {fmtMonths(debtMonths).padStart(V)}
+          {data.loanDebt > 0 && (
+            <>
+              <Box gap={3} marginTop={1}>
+                <Text dimColor>{'Credit cards'.padEnd(L)}</Text>
+                <Text bold color={C_NEGATIVE}>{fmt(data.totalDebt).padStart(V)}</Text>
+              </Box>
+              <Box gap={3}>
+                <Text dimColor>{'Loans'.padEnd(L)}</Text>
+                <Text bold color={C_NEGATIVE}>{fmt(data.loanDebt).padStart(V)}</Text>
+                <Text dimColor>mortgage / auto / student</Text>
+              </Box>
+              <Box gap={3}>
+                <Text dimColor>{'Total'.padEnd(L)}</Text>
+                <Text bold color={C_NEGATIVE}>{fmt(data.totalDebt + data.loanDebt).padStart(V)}</Text>
+              </Box>
+            </>
+          )}
+          {data.totalDebt > 0 && (
+            <>
+              <Box gap={3} marginTop={1}>
+                <Text dimColor>{'Net cash'.padEnd(L)}</Text>
+                <Text bold color={netCash >= 0 ? C_POSITIVE : C_NEGATIVE}>
+                  {fmtSigned(netCash).padStart(V)}
                 </Text>
+                <Text dimColor>
+                  {netCash >= 0
+                    ? 'could pay off now'
+                    : `${fmtCompact(data.cash)} cash · ${fmtCompact(data.totalDebt)} debt`}
+                </Text>
+              </Box>
+              {netCash < 0 && (
+                <Box gap={3}>
+                  <Text dimColor>{'Debt-free in'.padEnd(L)}</Text>
+                  {debtMonths === null ? (
+                    <Text color={C_NEGATIVE}>{'no surplus'.padStart(V)}</Text>
+                  ) : (
+                    <Text bold color={debtMonths <= 6 ? C_POSITIVE : debtMonths <= 24 ? C_WARNING : C_NEUTRAL}>
+                      {fmtMonths(debtMonths).padStart(V)}
+                    </Text>
+                  )}
+                  <Text dimColor>
+                    {debtMonths !== null ? `${fmtCompact(remainingDebt)} remaining after cash` : 'increase savings to pay off debt'}
+                  </Text>
+                </Box>
               )}
-              <Text dimColor>
-                {debtMonths !== null ? `${fmtCompact(remainingDebt)} remaining after cash` : 'increase savings to pay off debt'}
-              </Text>
-            </Box>
+            </>
           )}
         </Box>
       )}


### PR DESCRIPTION
Follow-up to core #175 (loan accounts — mortgage/auto/student — now count as liabilities in net worth everywhere).

## Problem
Once #175 lands, the Health screen's **Net worth** drops for anyone with a mortgage, but the **DEBT** section only ever rendered `HealthData.totalDebt` (credit cards) and wouldn't explain the drop. `HealthData.loanDebt` already exists in core, separate from `totalDebt`.

## Change (`tui/Health.tsx`)
- DEBT section now renders when there is card debt **or** loan debt (was: card debt only).
- When `loanDebt > 0`, a terse breakdown is shown:
  ```
  DEBT
  Credit cards            $4,000
  Loans                 $296,000   mortgage / auto / student
  Total                 $300,000

  Net cash               -$8,000   ...
  ```
- The loan line + breakdown only render when `loanDebt > 0`, so the section is byte-for-byte unchanged for people with no loans.
- The `Net cash` / `Debt-free in` payoff rows stay credit-card-scoped (their math already uses `totalDebt`) and now only render when `totalDebt > 0` — a loan-only borrower doesn't get a misleading "could pay off now".

## Wording
Labels: `Credit cards` / `Loans` / `Total`. Loan hint: `mortgage / auto / student`. #176 matches this on the GUI Health screen.

## Tests
New `tests/tui/health-debt.test.tsx` — 4 cases: no debt (section hidden), card-only (no breakdown), card + loan (breakdown + total), loan-only (breakdown, no payoff rows).

Merges after #175.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
